### PR TITLE
Exception handling when reloading enemy set CSV

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "fudge.auto-using",
         "jeff-hykin.better-cpp-syntax",
         "ms-dotnettools.csharp",
-        "jchannon.csharpextensions"
+        "jchannon.csharpextensions",
+        "notblank00.hexeditor"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/Arrowgene.Ddon.Cli/bin/Debug/net6.0/Arrowgene.Ddon.Cli.dll",
-            "args": ["client"],
+            "args": ["client", "J:\\Juegos\\Dragon's Dogma Online\\nativePC\\rom"],
             "cwd": "${workspaceFolder}/Arrowgene.Ddon.Cli",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "integratedTerminal",


### PR DESCRIPTION
Added a retry loop in order to prevent the server from crashing when the enemy set CSV to reload is still locked by some other process