### PR TITLE
Context resetting when entering safe areas

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ContextGetSetContextHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ContextGetSetContextHandler.cs
@@ -28,15 +28,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
             ntc.Unk0.Add(ntcData);
             client.Send(ntc);
 
-            S2CContextSetContextBaseNotice baseNtc = new S2CContextSetContextBaseNotice();
+            // We believe it may be telling the client to load a persistent context.
+            // If it's not sent, it will load a new context.
+            // Sending S2CInstance_13_42_16_Ntc resets it (Like its done in StageAreaChangeHandler)
+            S2CContextSetContextBaseNtc baseNtc = new S2CContextSetContextBaseNtc();
             baseNtc.ContextId = packet.Structure.ContextId;
             baseNtc.UniqueId = packet.Structure.UniqueId;
             baseNtc.StageNo = packet.Structure.StageNo;
             baseNtc.EncountArea = packet.Structure.EncountArea;
             baseNtc.MasterIndex = packet.Structure.MasterIndex;
             baseNtc.Unk0 = packet.Structure.Unk0;
-            //client.Send(baseNtc); // Uncommenting this makes enemies not respawn ever, even if you go back to town
-            // We believe it may be telling the client to load a persistent context. If it's not sent, it will load a new context.
+            client.Send(baseNtc);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Logging;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -13,6 +14,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(StageAreaChangeHandler));
 
+        // List of "safe" areas, where the context reset NTC will be sent.
+        // TODO: Complete with all the safe areas. Maybe move it to DB or config?
+        private static readonly HashSet<uint> SafeStageIds = new HashSet<uint>(){
+            2 // White Dragon Temple
+        };
 
         public StageAreaChangeHandler(DdonGameServer server) : base(server)
         {
@@ -29,6 +35,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             
             Logger.Info($"StageNo:{client.StageNo} StageId{packet.Structure.StageId}");
             
+            // TODO: Only send it when the party leader moves to a safe stage
+            if(SafeStageIds.Contains(packet.Structure.StageId))
+            {
+                client.Send(new S2CInstance_13_42_16_Ntc());
+            }
+
             client.Send(res);
         }
 

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -237,12 +237,13 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CContext_35_3_16_Ntc.Serializer());
             Create(new S2CContextGetLobbyPlayerContextNtc.Serializer());
             Create(new S2CContextGetSetContextRes.Serializer());
-            Create(new S2CContextSetContextBaseNotice.Serializer());
+            Create(new S2CContextSetContextBaseNtc.Serializer());
             Create(new S2CGpGetValidChatComGroupRes.Serializer());
             Create(new S2CInnGetStayPriceRes.Serializer());
             Create(new S2CInnStayInnRes.Serializer());
             Create(new S2CInstance_13_20_16_Ntc.Serializer());
             Create(new S2CInstance_13_23_16_Ntc.Serializer());
+            Create(new S2CInstance_13_42_16_Ntc.Serializer());
             Create(new S2CInstanceEnemyKillRes.Serializer());
             Create(new S2CInstanceEnemyRepopNtc.Serializer());
             Create(new S2CInstanceExchangeOmInstantKeyValueRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CContextSetContextBaseNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CContextSetContextBaseNtc.cs
@@ -3,11 +3,11 @@ using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 {
-    public class S2CContextSetContextBaseNotice : IPacketStructure
+    public class S2CContextSetContextBaseNtc : IPacketStructure
     {
-        public PacketId Id => PacketId.S2C_CONTEXT_35_11_16_NTC;
+        public PacketId Id => PacketId.S2C_CONTEXT_SET_CONTEXT_BASE_NTC;
 
-        public S2CContextSetContextBaseNotice()
+        public S2CContextSetContextBaseNtc()
         {
             ContextId=0;
             UniqueId=0;
@@ -24,9 +24,9 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
         public int MasterIndex { get; set; }
         public uint Unk0 { get; set; }
 
-        public class Serializer : PacketEntitySerializer<S2CContextSetContextBaseNotice>
+        public class Serializer : PacketEntitySerializer<S2CContextSetContextBaseNtc>
         {
-            public override void Write(IBuffer buffer, S2CContextSetContextBaseNotice obj)
+            public override void Write(IBuffer buffer, S2CContextSetContextBaseNtc obj)
             {
                 WriteUInt32(buffer, obj.ContextId);
                 WriteUInt64(buffer, obj.UniqueId);
@@ -36,9 +36,9 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 WriteUInt32(buffer, obj.Unk0);
             }
 
-            public override S2CContextSetContextBaseNotice Read(IBuffer buffer)
+            public override S2CContextSetContextBaseNtc Read(IBuffer buffer)
             {
-                S2CContextSetContextBaseNotice obj = new S2CContextSetContextBaseNotice();
+                S2CContextSetContextBaseNtc obj = new S2CContextSetContextBaseNtc();
                 obj.ContextId = ReadUInt32(buffer);
                 obj.UniqueId = ReadUInt64(buffer);
                 obj.StageNo = ReadInt32(buffer);

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstance_13_42_16_Ntc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstance_13_42_16_Ntc.cs
@@ -1,0 +1,22 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CInstance_13_42_16_Ntc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_INSTANCE_13_42_16_NTC;
+
+        public class Serializer : PacketEntitySerializer<S2CInstance_13_42_16_Ntc>
+        {
+            public override void Write(IBuffer buffer, S2CInstance_13_42_16_Ntc obj)
+            {
+            }
+
+            public override S2CInstance_13_42_16_Ntc Read(IBuffer buffer)
+            {
+                return new S2CInstance_13_42_16_Ntc();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -1590,7 +1590,7 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId C2S_CONTEXT_MASTER_THROW_REQ = new PacketId(35, 10, 1, "C2S_CONTEXT_MASTER_THROW_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_CONTEXT_MASTER_THROW_RES = new PacketId(35, 10, 2, "S2C_CONTEXT_MASTER_THROW_RES", ServerType.Game, PacketSource.Server); // マスター移譲に
         public static readonly PacketId S2C_CONTEXT_35_10_16_NTC = new PacketId(35, 10, 16, "S2C_CONTEXT_35_10_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_CONTEXT_35_11_16_NTC = new PacketId(35, 11, 16, "S2C_CONTEXT_35_11_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_CONTEXT_SET_CONTEXT_BASE_NTC = new PacketId(35, 11, 16, "S2C_CONTEXT_SET_CONTEXT_BASE_NTC", ServerType.Game, PacketSource.Server, "S2C_CONTEXT_35_11_16_NTC");
         public static readonly PacketId S2C_CONTEXT_35_12_16_NTC = new PacketId(35, 12, 16, "S2C_CONTEXT_35_12_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_CONTEXT_35_13_16_NTC = new PacketId(35, 13, 16, "S2C_CONTEXT_35_13_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_CONTEXT_35_14_16_NTC = new PacketId(35, 14, 16, "S2C_CONTEXT_35_14_16_NTC", ServerType.Game, PacketSource.Server);
@@ -3491,7 +3491,7 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, C2S_CONTEXT_MASTER_THROW_REQ);
             AddPacketIdEntry(packetIds, S2C_CONTEXT_MASTER_THROW_RES);
             AddPacketIdEntry(packetIds, S2C_CONTEXT_35_10_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_CONTEXT_35_11_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_CONTEXT_SET_CONTEXT_BASE_NTC);
             AddPacketIdEntry(packetIds, S2C_CONTEXT_35_12_16_NTC);
             AddPacketIdEntry(packetIds, S2C_CONTEXT_35_13_16_NTC);
             AddPacketIdEntry(packetIds, S2C_CONTEXT_35_14_16_NTC);


### PR DESCRIPTION
In order to avoid enemies not spawning, the delivery of
S2CContextSetContextBaseNtc was commented out.
However this had the side effect of human enemies not spawning at all.
To have the best of both worlds, we send S2CInstance_13_42_16_Ntc, as
it's been noticed on the pcaps, when entering a safe area (White Dragon
Temple) so the context gets reset and enemies in the field respawn.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
