### PR TITLE
Lv 1 EX skills in SkillGetLearnedSkillListHandler

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedSkillListHandler.cs
@@ -23,9 +23,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     .Select(skill => new CDataLearnedSetAcquirementParam() {
                         Job = skill.Job,
                         AcquirementNo = skill.SkillNo,
-                        AcquirementLv = 10
+                        AcquirementLv = (byte) (IsSkillEX(skill.SkillNo) ? 1 : 10) // EX skills must be Lv 1 to work, otherwise use Lv 10 (Max level)
                     }).ToList()
             });
+        }
+
+        private bool IsSkillEX(uint skillNo)
+        {
+            return skillNo >= 100;
         }
     }
 }


### PR DESCRIPTION
EX skills must be Lv 1 otherwise they do 0 dmg

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
