### PR TITLE
Fixed pawns not showing up

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyMypawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyMypawnHandler.cs
@@ -727,7 +727,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                                     ItemId = myPawnCsvData.VOverWear,
                                     Unk3 = 0,
                                     Color = 0,
-                                }
+                                },
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
                             }
                         }
                     }


### PR DESCRIPTION
Empty slots still had to be sent when serializing as CDataContextEquipData

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
