### PR TITLE
Workaround for the party ID pool exhausting over time.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
@@ -89,6 +89,7 @@ public class PartyManager
         }
 
         _idPool.Push(party.Id);
+        LogPartyIdCount();
         return true;
     }
 
@@ -107,6 +108,13 @@ public class PartyManager
             return null;
         }
 
+        LogPartyIdCount();
+        
         return party;
+    }
+
+    private void LogPartyIdCount()
+    {
+        Logger.Info($"Free party IDs: {_idPool.Count}/{MaxNumParties}");
     }
 }


### PR DESCRIPTION
When the ID pool is exhauested and a new party is created, a function is run that checks all the connected client's parties and rebuilds the party ID pool with that information. Far from ideal but seems to do the job for the time being.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
