### PR TITLE
Fixed equipped skills/augs being removed after upgrading them

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -74,14 +74,16 @@ namespace Arrowgene.Ddon.Database
         bool DeleteEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId);
 
         // CustomSkills
-        bool ReplaceLearnedCustomSkill(uint commonId, CustomSkill skill);
+        bool InsertLearnedCustomSkill(uint commonId, CustomSkill skill);
+        bool UpdateLearnedCustomSkill(uint commonId, CustomSkill updatedSkill);
         bool InsertEquippedCustomSkill(uint commonId, byte slotNo, CustomSkill skill);
         bool ReplaceEquippedCustomSkill(uint commonId, byte slotNo, CustomSkill skill);
         bool UpdateEquippedCustomSkill(uint commonId, JobId oldJob, byte oldSlotNo, byte slotNo, CustomSkill skill);
         bool DeleteEquippedCustomSkill(uint commonId, JobId job, byte slotNo);
 
         // Abilities
-        bool ReplaceLearnedAbility(uint commonId, Ability ability);
+        bool InsertLearnedAbility(uint commonId, Ability ability);
+        bool UpdateLearnedAbility(uint commonId, Ability ability);
         bool InsertEquippedAbility(uint commonId, JobId equipptedToJob, byte slotNo, Ability ability);
         bool ReplaceEquippedAbility(uint commonId, JobId equipptedToJob, byte slotNo, Ability ability);
         bool ReplaceEquippedAbilities(uint commonId, JobId equippedToJob, List<Ability> abilities);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -249,7 +249,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
 
             foreach(CustomSkill learnedSkills in common.LearnedCustomSkills)
             {
-                ExecuteNonQuery(conn, SqlReplaceLearnedCustomSkill, command => 
+                ExecuteNonQuery(conn, SqlInsertLearnedCustomSkill, command => 
                 {
                     AddParameter(command, common.CommonId, learnedSkills);
                 });
@@ -273,7 +273,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
 
             foreach(Ability ability in common.LearnedAbilities)
             {
-                ExecuteNonQuery(conn, SqlReplaceLearnedAbility, command =>
+                ExecuteNonQuery(conn, SqlInsertLearnedAbility, command =>
                 {
                     AddParameter(command, common.CommonId, ability);
                 });

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbLearnedAbility.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbLearnedAbility.cs
@@ -14,12 +14,22 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             "character_common_id", "job", "ability_id", "ability_lv"
         };
 
-        private readonly string SqlReplaceLearnedAbility = $"INSERT OR REPLACE INTO `ddon_learned_ability` ({BuildQueryField(LearnedAbilityFields)}) VALUES ({BuildQueryInsert(LearnedAbilityFields)});";
+        private readonly string SqlInsertLearnedAbility = $"INSERT INTO `ddon_learned_ability` ({BuildQueryField(LearnedAbilityFields)}) VALUES ({BuildQueryInsert(LearnedAbilityFields)});";
+        private readonly string SqlUpdateLearnedAbility = $"UPDATE `ddon_learned_ability` SET {BuildQueryUpdate(LearnedAbilityFields)} WHERE `character_common_id`=@character_common_id AND `job`=@job AND `ability_id`=@ability_id;";
         private static readonly string SqlSelectLearnedAbilities = $"SELECT {BuildQueryField(LearnedAbilityFields)} FROM `ddon_learned_ability` WHERE `character_common_id`=@character_common_id;";
         
-        public bool ReplaceLearnedAbility(uint commonId, Ability ability)
+        public bool InsertLearnedAbility(uint commonId, Ability ability)
         {
-            ExecuteNonQuery(SqlReplaceLearnedAbility, command =>
+            ExecuteNonQuery(SqlInsertLearnedAbility, command =>
+            {
+                AddParameter(command, commonId, ability);
+            });
+            return true;
+        }
+
+        public bool UpdateLearnedAbility(uint commonId, Ability ability)
+        {
+            ExecuteNonQuery(SqlUpdateLearnedAbility, command =>
             {
                 AddParameter(command, commonId, ability);
             });

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbLearnedCustomSkill.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbLearnedCustomSkill.cs
@@ -12,14 +12,24 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             "character_common_id", "job", "skill_id", "skill_lv"
         };
 
-        private readonly string SqlReplaceLearnedCustomSkill = $"INSERT OR REPLACE INTO `ddon_learned_custom_skill` ({BuildQueryField(LearnedCustomSkillFields)}) VALUES ({BuildQueryInsert(LearnedCustomSkillFields)});";
+        private readonly string SqlInsertLearnedCustomSkill = $"INSERT INTO `ddon_learned_custom_skill` ({BuildQueryField(LearnedCustomSkillFields)}) VALUES ({BuildQueryInsert(LearnedCustomSkillFields)});";
+        private readonly string SqlUpdateLearnedCustomSkill = $"UPDATE `ddon_learned_custom_skill` SET {BuildQueryUpdate(LearnedCustomSkillFields)} WHERE `character_common_id`=@character_common_id AND `job`=@job AND `skill_id`=@skill_id;";
         private static readonly string SqlSelectLearnedCustomSkills = $"SELECT {BuildQueryField(LearnedCustomSkillFields)} FROM `ddon_learned_custom_skill` WHERE `character_common_id`=@character_common_id;";
 
-        public bool ReplaceLearnedCustomSkill(uint commonId, CustomSkill skill)
+        public bool InsertLearnedCustomSkill(uint commonId, CustomSkill skill)
         {
-            ExecuteNonQuery(SqlReplaceLearnedCustomSkill, command =>
+            ExecuteNonQuery(SqlInsertLearnedCustomSkill, command =>
             {
                 AddParameter(command, commonId, skill);
+            });
+            return true;
+        }
+
+        public bool UpdateLearnedCustomSkill(uint commonId, CustomSkill updatedSkill)
+        {
+            ExecuteNonQuery(SqlUpdateLearnedCustomSkill, command =>
+            {
+                AddParameter(command, commonId, updatedSkill);
             });
             return true;
         }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillLearnSkillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillLearnSkillHandler.cs
@@ -1,10 +1,6 @@
-using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Entity.Structure;
-using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 


### PR DESCRIPTION
The problem was caused by INSERT OR REPLACE in the learned skill/augs tables triggering the ON DELETE CASCADE in the equipped skills/augs tables

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
