### PR TITLE
Commented Game Token Overwritting Login Token

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ConnectionLoginHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ConnectionLoginHandler.cs
@@ -109,7 +109,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             Logger.Info(client, "Logged Into GameServer");
 
             // update login token for client
-            client.Account.LoginToken = GameToken.GenerateLoginToken();
+            // client.Account.LoginToken = GameToken.GenerateLoginToken();
             client.Account.LoginTokenCreated = now;
             if (!Database.UpdateAccount(client.Account))
             {

--- a/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
@@ -91,7 +91,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                 }
 
                 TimeSpan loginTokenAge = account.LoginTokenCreated.Value - now;
-                if (loginTokenAge > TimeSpan.FromDays(1)) // TODO convert to setting
+                if (loginTokenAge > TimeSpan.FromDays(7)) // TODO convert to setting
                 {
                     Logger.Error(client, $"OneTimeToken Created at: {account.LoginTokenCreated} expired.");
                     res.Error = 1;


### PR DESCRIPTION
This fixes the "Return to Title" issue since the token was different it would either throw an error or generate a new account (in both required or not account from the config).
Login token is only regenerated and updated on each logging in through the launcher.
Also increased the login token lifespan so it can be used for longer (a week if the person doesn't log out).

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
