### PR TITLE
Add new optional UTF8 dump switch to the packet command.

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/PacketCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/PacketCommand.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Linq;
+using System.Text;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Network;
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.Cli.Command
             string yamlPath = parameter.Arguments[0];
             string camelliaKey = parameter.Arguments[1];
             byte[] camelliaKeyBytes = Encoding.UTF8.GetBytes(camelliaKey);
-
+            bool addUtf8EncodedByteDump = parameter.Switches.Contains("--utf8-dump");
 
             string yamlPcap = File.ReadAllText(yamlPath);
             List<PcapPacket> pcapPackets = ReadYamlPcap(yamlPcap);
@@ -88,6 +88,12 @@ namespace Arrowgene.Ddon.Cli.Command
                         annotated.Append(Environment.NewLine);
                         annotated.Append(readPacket.PrintData());
                         annotated.Append(string.Join(", ", readPacket.Data.Select(dataByte => String.Format("0x{0:X}", dataByte))));
+                        if (addUtf8EncodedByteDump)
+                        {
+                            annotated.Append(Environment.NewLine);
+                            annotated.Append(string.Concat(Encoding.UTF8.GetString(readPacket.Data, 0, readPacket.Data.Length - 1).Select(c =>
+                                char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsSeparator(c) || char.IsSymbol(c) ? c : '·')));
+                        }
                         annotated.Append(Environment.NewLine);
                         annotated.Append(Environment.NewLine);
                     }


### PR DESCRIPTION
 If the switch is present, the full byte data of a decrypted packet will be treated as UTF8 and appended to the already existing byte dump.
 Non-legible characters (not a letter, digit etc.) will be substituted with a placeholder to keep everything readable.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
