### PR TITLE
Feature/add utf8 encoded byte dump to packet command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
       - name: Test
-        run: dotnet test --no-restore --no-build
+        run: dotnet test --configuration Release --no-restore --no-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,10 +4,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.200
-      - name: Build Project
+          dotnet-version: 6.x
+      - name: Build
         run: dotnet build --configuration Release
+      - name: Test
+        run: dotnet test --no-restore --no-build

--- a/Arrowgene.Ddon.Cli/Command/Packet/PcapPacket.cs
+++ b/Arrowgene.Ddon.Cli/Command/Packet/PcapPacket.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Cli.Command.Packet;
+
+public class PcapPacket
+{
+    public ServerType ServerType { get; set; }
+    public PacketSource Source { get; set; }
+    public string TimeStamp { get; set; }
+    public uint Index { get; set; }
+    public uint Packet { get; set; }
+    public byte[] Data { get; set; }
+    public List<IPacket> ResolvedPackets { get; set; }
+}

--- a/Arrowgene.Ddon.Cli/Command/Packet/YamlFile.cs
+++ b/Arrowgene.Ddon.Cli/Command/Packet/YamlFile.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Cli.Command.Packet;
+
+public class YamlFile
+{
+    public List<YamlPeer> peers;
+    public List<YamlPacket> packets;
+}

--- a/Arrowgene.Ddon.Cli/Command/Packet/YamlPacket.cs
+++ b/Arrowgene.Ddon.Cli/Command/Packet/YamlPacket.cs
@@ -1,0 +1,10 @@
+namespace Arrowgene.Ddon.Cli.Command.Packet;
+
+public class YamlPacket
+{
+    public uint packet;
+    public uint peer;
+    public uint index;
+    public string timestamp;
+    public string data;
+}

--- a/Arrowgene.Ddon.Cli/Command/Packet/YamlPeer.cs
+++ b/Arrowgene.Ddon.Cli/Command/Packet/YamlPeer.cs
@@ -1,0 +1,8 @@
+namespace Arrowgene.Ddon.Cli.Command.Packet;
+
+public class YamlPeer
+{
+    public uint peer;
+    public string host;
+    public ushort port;
+}

--- a/Arrowgene.Ddon.Cli/Command/PacketCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/PacketCommand.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Linq;
+using System.Text;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Network;
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.Cli.Command
             string yamlPath = parameter.Arguments[0];
             string camelliaKey = parameter.Arguments[1];
             byte[] camelliaKeyBytes = Encoding.UTF8.GetBytes(camelliaKey);
-
+            bool addUtf8EncodedByteDump = parameter.Switches.Contains("--utf8-dump");
 
             string yamlPcap = File.ReadAllText(yamlPath);
             List<PcapPacket> pcapPackets = ReadYamlPcap(yamlPcap);
@@ -88,6 +88,12 @@ namespace Arrowgene.Ddon.Cli.Command
                         annotated.Append(Environment.NewLine);
                         annotated.Append(readPacket.PrintData());
                         annotated.Append(string.Join(", ", readPacket.Data.Select(dataByte => String.Format("0x{0:X}", dataByte))));
+                        if (addUtf8EncodedByteDump)
+                        {
+                            annotated.Append(Environment.NewLine);
+                            annotated.Append(string.Concat(Encoding.UTF8.GetString(readPacket.Data, 0, readPacket.Data.Length - 1).Select(c =>
+                                char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsSeparator(c) || char.IsSymbol(c) ? c : '·')));
+                        }
                         annotated.Append(Environment.NewLine);
                         annotated.Append(Environment.NewLine);
                     }

--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -26,7 +26,6 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Arrowgene.Ddon.Cli.Command;
-using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
@@ -110,7 +109,7 @@ namespace Arrowgene.Ddon.Cli
             ShowCopyright();
             CommandParameter parameter = ParseParameter(arguments);
             CommandResultType result = ProcessArguments(parameter);
-            
+
             if (result != CommandResultType.Exit)
             {
                 Logger.Info("Press `e'-key to exit.");
@@ -125,7 +124,7 @@ namespace Arrowgene.Ddon.Cli
             {
                 _lastCommand.Shutdown();
             }
-            
+
             // Wait for logs to be flushed to console
             Thread.Sleep(1000);
             LogProvider.Stop();
@@ -269,15 +268,16 @@ namespace Arrowgene.Ddon.Cli
         {
             Log log = e.Log;
             LogLevel logLevel = log.LogLevel;
-            
-            
+
+
             if (logLevel == LogLevel.Debug || logLevel == LogLevel.Info)
             {
-                if(log.LoggerIdentity.StartsWith("Arrowgene.WebServer.Server.Kestrel"))
+                if (log.LoggerIdentity.StartsWith("Arrowgene.WebServer.Server.Kestrel"))
                 {
                     // ignore internal web server logs
-                    return; 
+                    return;
                 }
+
                 if (log.LoggerIdentity.StartsWith("Arrowgene.WebServer.Route.WebRouter"))
                 {
                     // ignore web route logs
@@ -346,7 +346,7 @@ namespace Arrowgene.Ddon.Cli
                         consoleColor = ConsoleColor.DarkRed;
                         break;
                 }
-                
+
                 if (logLevel == LogLevel.Error)
                 {
                     consoleColor = ConsoleColor.Red;
@@ -374,7 +374,7 @@ namespace Arrowgene.Ddon.Cli
                 Console.ForegroundColor = consoleColor;
                 Console.WriteLine(text);
                 Console.ResetColor();
-                
+
                 // TODO perhaps some buffering and only flush after X logs
                 string filePath = Path.Combine(_logDir.FullName, $"{log.DateTime:yyyy-MM-dd}.log.txt");
                 using StreamWriter sw = new StreamWriter(filePath, append: true);

--- a/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
+++ b/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
@@ -26,6 +26,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Client\Arrowgene.Ddon.Client.csproj" />
+        <ProjectReference Include="..\Arrowgene.Ddon.Cli\Arrowgene.Ddon.Cli.csproj" />
         <ProjectReference Include="..\Arrowgene.Ddon.Server\Arrowgene.Ddon.Server.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/Arrowgene.Ddon.Test/Cli/Command/PacketCommandTest.cs
+++ b/Arrowgene.Ddon.Test/Cli/Command/PacketCommandTest.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Arrowgene.Ddon.Cli.Command;
+using Arrowgene.Ddon.Cli.Command.Packet;
+using Xunit;
+
+namespace Arrowgene.Ddon.Test.Cli.Command;
+
+public class PacketCommandTest
+{
+    [Fact]
+    public void TestUtf8Dump()
+    {
+        PacketCommand packetCommand = new PacketCommand();
+
+        string testYaml = TestUtils.GetTestFileAsString("pcapng1-tcp-stream-33_reduced_test.yaml");
+        List<PcapPacket> encryptedPackets = packetCommand.ReadYamlPcap(testYaml);
+        List<PcapPacket> decryptedPackets = packetCommand.DecryptPackets(encryptedPackets, Encoding.ASCII.GetBytes("3jc6R11q__MGmP9YIn7fyiNVQgSUoiBc"));
+        string annotatedPacketDump = packetCommand.GetAnnotatedPacketDump(decryptedPackets, true);
+
+        Assert.Contains("通信エラーが発生しました", annotatedPacketDump);
+    }
+}

--- a/Arrowgene.Ddon.Test/TestFiles/pcapng1-tcp-stream-33_reduced_test.yaml
+++ b/Arrowgene.Ddon.Test/TestFiles/pcapng1-tcp-stream-33_reduced_test.yaml
@@ -1,0 +1,200 @@
+peers:
+  - peer: 0
+    host: 10.62.10.6
+    port: 52580
+  - peer: 1
+    host: 106.185.74.104
+    port: 52100
+packets:
+  - packet: 11756
+    peer: 1
+    timestamp: 1562436321.517077923
+    data: !!binary |
+      ATDruZxUDPpEIcEDYnYxt6fNg0S3u/H5DJtPnnUQ/bzG3yc4J/A2bWc82srDeMyUHYCbRKyyRIFQ
+      gGFyiyc57Ch42Q01JROBgkQtjNMFBpBDCI0a9Ex4sn1z/WxNmOPvt/MGvWPcADd8Db96kaC55sTK
+      GwJPT+cNRQKDb1N/3CafwHl5vNxmsC9wmWwcczQv2q2efgNTyd+YZPIXW78XDWZPwOLQFWtJN0po
+      NID3uRQj3688uyrk+lPZbEamP9cYkIoamaADG5/PNw++w1wEDHTqmZSwXfLyyusGlIIr31EhMDV7
+      2nTAxKdKSJgvvNQDpYmyiBzLV3KgEo5q9cpOFxlzmbf49IL5bePv2bUiHaYecPMGWR+CnQJlR9BG
+      yASxb2SDhbDXjxgSUoL1CqXUt4wt
+  - packet: 11758
+    peer: 0
+    timestamp: 1562436321.610646963
+    data: !!binary |
+      AVAifLRyPZ/bowbOmdYgrnMjx/4fZ3BqgHE9qOPI3Goh+YCjVo9y/Z+7ywMXO1r3D33Ujh4vKxfU
+      89Mvt5e/oEWrCJJ916zfMQDQP1nOaMi1BlpXZaAHDu2k0XyrPY5mX3PwzTSYLN68Ur5LYmHcqMis
+      PG4FWe651RUPQg7CmYissSAXxp8bTAJdDV6e+ZS1x05n9UY7TnD57t+JnBaexQf7WYj5+vPH9edV
+      TvbKIcO6XA+1SRDZm2XV51sOyDVU1cmLsv4r9WGH+kE2nJ82Cgh227GXZXaRvoYGNXImdpNYZCoT
+      pboKELccFaqMRmuJVdg5YBkfeBBlOo+rlPi2/aZVs4x0wEY5WppI5IEH+aDwq9h6g2QIYlL1Y9Am
+      A0dRfxV177oL5uMz5vXAQ9BC0tmJ5KaRbEoqaqB5GBEmohHoB6hZSs2hqYzQ6E1d32k180w=
+  - packet: 11759
+    peer: 1
+    timestamp: 1562436321.724416971
+    data: !!binary |
+      AGA7aj8pGwCuYVtbwBMagHw7FvRUKzyEiXD2OIInEJkIeYynWzzsHON1kM3h/7y496ErmNdvMtKz
+      uq3iPf63sGaovjO8R87e3bpJGtBs6kP3rZ6uzc5LhOTzYaZ0OAHRtKo=
+  - packet: 11761
+    peer: 0
+    timestamp: 1562436321.798801899
+    data: !!binary |
+      ACAbDDON2hdVk1pLG6/caIy9gLiMYCKE0DIf0P4xG1a/rA==
+  - packet: 11762
+    peer: 1
+    timestamp: 1562436321.937855005
+    data: !!binary |
+      AECJ6/P+R5bdkmAmSvbIkuL9dCE1azpd+isbmGxKw/gSKbq5a4ol6Fj+hChGs2Hc5zCtYIcsZUL1
+      ZWs3VXfh7IHp
+  - packet: 11764
+    peer: 0
+    timestamp: 1562436321.998929024
+    data: !!binary |
+      ABApq2Cc9TsdZ0Gd3JCL9Gh0
+  - packet: 11765
+    peer: 1
+    timestamp: 1562436322.110450029
+    data: !!binary |
+      ACDBNhi2OPoSVV5eIV6LTl4SHYUEMH8cRkoFhMa4H8P0oQ==
+  - packet: 11766
+    peer: 0
+    timestamp: 1562436322.132018089
+    data: !!binary |
+      ABC3Sq04s2fRAsrmbWkeEunk
+  - packet: 11767
+    peer: 1
+    timestamp: 1562436322.243618011
+    data: !!binary |
+      GCA9Q1uHKhsBikZRsRu8tOG19auzrUW898Lh8qA5u/teIBpp11Zdejz40qtmXAiuUXuKvr9lIJ8l
+      qGhc1zkz9XQFCZaZnL43AF0F2a9plJNIB60nt0hj1vHGtCtn72fz3/x4pnnRQ+fk+ATaR4iIrTLm
+      WTAlPv0NCOVWE5XFp5GuE3FPH3MEz5aOXBO8NV2j7cUqVpf7mqC/bbiMk9fa4HDrN9D/56h+NabO
+      3CGfFiZnR7jKsxD7AZpsnYP7nFL2SBw9ucwyViS0E6BUOPkpmE5OgjYkUI6armm2GkHKXG6yX81y
+      DQEmKx0A6aKe87oQLwQ2azPyBkh+dOsSYb5cItLWXedAz/SPLPaDG4m++3oisp6vECtuKazFk+H3
+      zFQ0+sqA/bWtrnZws3jF92CgK7XsMQj4vuXN0pddkfUKtKot3UMJAKbFlJauwI3dFeog858q6cSn
+      pmuSbdMQsAYMfjCwvUeUKvm+GdwhRdcqoVOlCLGBUB8+NDdrqciutUg1BbTOQa3kqMqmajJyYYCT
+      ozc11BUiO+/6XL1vhg6iwpGJKKG0wun1w0w8xF/TyRgBQIs9CJzHZaG2tQ/P3K6OWzaOPPGK9TwT
+      diLcMyj7/IB8XXouGYny3safvpiGOpA8SAd2+7p1/WI/x90V7okOBzmQUt/6i+RA3R8HXUud14Io
+      y3rUCz+y0AyT2G0GpmSyaEyl2XItMOfJ/PsuDZIeMkbybWcBNC2M7O/JTD3jJE2NZi7OWMHdJ6RB
+      WtoHB+AHLcQM/9dIpqBldRkVS+qmOij24GQbyMTd1+9ZD+QHN47BzCo9JW7RCMiYWZg/mQc2B+/B
+      V9sQm7KwFvVC0wYhtsNdxQ6KSjUF6xo1b6Nxr5R+u56uFiNaI4gobxNZaouBgM54Yo0xypZclbPA
+      hjC/NKqrcXB1DQ6/127sHLZg+OZwhK9+7BkzQQt27oXCvX5AHYXX3e40IyNzfpVyBg6IdVQ7pcGY
+      2PM+4SXDr0hTcmNpUMsvNnDJd2383ZWv/Sody6WS4/hGpA8LgUN5R2QDYDAVysto9BMKt2+uKMiz
+      17NCI5lVC3Y3j05DC/1JUctxMdjrLs5biKk3YYIJpdlbjpmDWvVySmL0wVkCBW5aLqM+3vyzoqAI
+      iqpZ/Ffh0gHsOSOCJyee4GQA3lr19K9sRZHCxQ/Dzf3vx7dWEAci6amDfra1dnT6puVjionXjmx0
+      a7F8atzKArJFSBMjk40zznJIKngVTfQz0ZxmF16gNCZu+M48Gr1tXAOU8OnKGDn4e1CWiJEVAakK
+      I3CfWe/vA6/H30Dc/NlwUqcl22R0yBkjM+jSAcuii0CdQSaR44F2NJIDbUS3AVSpL4u8KlK6aOEO
+      7Zcb7yIrLhdF8d8x/Y/USeltXkaDRB2dZxgmQ4ZYgWHKMjEC7UzSOR9b+V0y/50LQJYN9iTQZy6i
+      n31xeEfjWW6qCRhhzAQGAWmX0EmxzswT3z+yXnp2gRsfYCcStmnnq/1BCYtgEgxRehz8UVRe0vXk
+      lukb//+HfG2unWaQ9ewbHV9GH3ZJfL3qYm00NGRENcS/QQ2+7kUZMup/V78YLEIjVNOBLCQ/gb3M
+      rJING7rqX3bsvJz7aFv0UZIHCCiYWroyspoZeF9kq/jmb0/4E2w5/YY4J9jSwRKxdR/QR32WoLJ1
+      6KWCnHYSYkoEmRE9ubm6pvBdePSogfuWSu0eNdJY7UjN4ErqAcA6FfvDzvOr5dTN1iDKSXGgfDLf
+      f0ZfpSWR9eyydJ+Gj5JjSCzfo+fTPg6nAWY/RNEXfxKPxRnh5ru/2sw=
+  - packet: 11768
+    peer: 1
+    timestamp: 1562436322.243745089
+    data: !!binary |
+      /onPdKKJxwMEyjD68BMaGQhbEVgoUeChCpoQ4Eo2Vg7FRdxniewTVsYh0rwiZMi/tmK3U3bObtdl
+      klwYz8DEb4ZmecYiI5Un9QmK3K7BA8Ixq9NSQatMyWyxxKw+KfI+sKOH+6kRIwHTvn9yhDuWFxeb
+      0dx9IJVnF3pQW5EHWMeiZWT3lqBdLsTzC/EDoqoLUSyHfeG8tmPvL9TJ5eBWXNqmQS1A0UKH7wVH
+      p3OxfGLwlmqNamhakJsYYQUuCLCPbz3eDi+Uc96eiJHgmXgmmCGi1Y4MaaiMhtZJA1Acn7roPB7P
+      LoDdjcCC1MpMftjrEUIAHaAG2DNomq0JId2X6QX2slzoCXGZjLTZf3DbaNi3Nc914f7lC1PHYqWi
+      u3Xu0hZ+E+s2DLU+vD7c+sn1+bDppnuOOWgqZQWiZaaSnCm9bF10mtyAW8myFa3nYip0M59xaKpG
+      ITuoBTbtXnGz7rl9nKIkHh2zRcBMKbZeBBNMgAheFNnJ7xZ4qBqpZUC1PTZ3uYWQXFWmUhBaDIfr
+      5Z62IvkzHEZEmaIY1/dU4Rf5cJz+mPAyX6UE0oNKcCEHKHFADHPq82mhpfm84Lqk5okRamYqJrX6
+      khUvULdYUvd7n7+BkKpO8Vy3LlbxI4c4V5ZVHXGyaT0frbU3LQXMTdoTVY9dVkKK8NjVK16PxyJI
+      WZR7HX+Ukp8L7Mi37F6aidB0oxhjXQu3uu1clXyLfTeK766KQV3VTYjfnw+UTW8Y1IdgXzzXVNQV
+      4nlFPAhc7aXOKOB3pPG2ud2NstcgZbRZ0Zbyt9jdnl4mA6h2KESSSGjUeYpxdo9Z5iboUJyv9ua5
+      eoAFKSTluT+hOsClWm4SJxl4aTGUey05G1PAXzv48jFXetIWf0Hxk72fVHP3/aFZr6busQLeqO3A
+      H7EJOTtYLkiCEM8IGTkgu0PmkBr9bloJwJV/hBRtPvIjq0lJ1zYafWFHNLO3AV5vt+NtDAS1vlHi
+      EUh/GL1rgcG9iPv6XhoH9YCE411maVDk5ItDqPTcpFiJnOZ7Nl2cRB4t2YZUa2/CvyO4nsXUPJ4o
+      gX/+EXB314qUp2g9tcLjJCQufkkGpQm585ydpWo+dkVFYCZFoYCwr0utnVOSBxHEvofEToMjjSGi
+      lLIY+qTRUHfXCD+M/b/McJYAoZZe6FtaQJ5i2S2icETznV425eeNdvIvYAwdSOW1QzBStzRF61O9
+      Er2SczzKaiuieLsz4hCfFsEQNM0AReMJ2OXd7rJLGiIWzuZaKdUV5nepXiAAAy0+Xp1LY5opNf7x
+      KXFzAkWgSCjhDvIkzPuDdJBYHtZL62BrD7cPTe1ZjnebHU2dUqguPbCg50D4qa4568hzQArkYzxo
+      apxQHaXAf15scD/xe8reipRfLktgo3nb2jjfsmds5cNw2k3wXoTIzPrIWGQ1kSiVyz7zZG5w1daI
+      tPeYXPwFSrK8WeNKLenLnv54on0GEToYGRWMawBu6ka8M3EQg9LCOj6EyYinufL6qdSSlOm2vqjz
+      Smb6nIPdkFMnKjlgdswzxI4q8uJyCXTYGLPNX+mvVQsWhZcYHfD1NlPbo/bMwhYZqq1O+hr7tA9R
+      YfgrdMepAtkt557Ho1bgFsxhQEsbLdy8sUZN0ixsFuAaWjbrThFSIXN4rkiqNOcNVt7hLmTuhDjD
+      hlgyoI0hH9fq2j3JpiMdrAEd2aSXo48zuHb7CEsPq7v5pnLOYDk7saBE1FOkcnDSy7etGgbHaoeR
+      J7fHr5tBjSOW5gLqUrimWYJmuhjwgw/e4MxCIxMwpqz4PRQS2zkuXBA=
+  - packet: 11770
+    peer: 1
+    timestamp: 1562436322.354834080
+    data: !!binary |
+      wrt/RttHB9Qu45eTC3xLJ8KBhVMt5ZE+ZQJdnjoV8SKufjan1rHHUJuHoHPe+C3HraQdOrgLtlcY
+      VFggOGw8yeYAeH4EQGhpr1qwZ1SK0uXGh5e+C1nAJWwLBFZrxCUHChUGf2qD2+zDef9y7K3G3A/i
+      M4khz1wlrCGqDqpUgOV7DNrpHqaMPK10IHinuZ605CbXs2lA9RPJO89rwNMrcgCPl6UhWCyR8uof
+      fQyWaDnUzJuCuONSdm9GHTL1c59giqXIGeyk79LS7QGIN08QBFY5Aaf81WBnAMgYm3ZW5PIk24gt
+      fqkhT/6C1QFJl0ejYF9TjEmazs/ToB5vhKTsM3RrkAXl5PkHjTvYIVJcEXtRjrHUiYMPQRuRgAI9
+      mp8s0xR19gKxWbTYC0SSbFCpCKRPSxnL4fbwhIY2XOTfg7C7bxUzo+UxFJd+TRpXmsP705MOj3mN
+      jyf6HPOX0UAOjWdJdQCvyvj8RHscNBVAdGC4RH6J5CUXsBMAu1Y0X7NFhEvoxNhT1wWm0Urqzb+k
+      iLXTfdZc+Dtsrgf3oK3b8C8hGCjmbK0MWVSLGTux+cPIiT4VHOYAVBRrZFZl1591YlfDznFi0Ac9
+      sJWbVdxrzUs7KpzF2Ms3COIWvZMdLxb8FAnrh4RA+6Qic3ib+NQGRwIZWaEJEd5GvRt5Yx85n5+g
+      wIL4EJBGinHl9gF5Xnv//hw8RwfwgI0ZNWAVLsZ0Qensn9FmIj1F2IR2f+qFuDyBWwHPEj9pQs3d
+      OTL4SV4/sKTiGWJoqVtKdurnzilb59fKxmViwf8kGaSUDISOA4RwXIXRR4Oj9mu4oJrCbuhfWq7j
+      tnODW0LEsXGzQL9y9pIYnAQTpYpSmObYwqIC7Z764FoXt3gphgHMYOn/OGNe4qh2JhvHw+yNNwkC
+      XX+leOS2+u4BHtX2FCOuUEyPu3YnfVocMTWEIO3wsTzYKfE2PVr3t0ysNjx4Z6Pb9+w96POgXqvS
+      7pSWKw2j8onXAiU7hkNhiRhbQEvSaF0k5JX9PtC0RHNKnby1ooSK1OzmsXARURJBK/DgGXw2U3nQ
+      CD541i0VB+HRG98Y1uNDyrDNRA9T7r/xVqbtiPstU1p3ptd19y+2xv8yKgY+aGgH0OSi2DYbfiKz
+      iSAjNFrAYLR7U6y/Re6L46ihrlI07vXvzD0FRXropcgoCMSRYCx1VMBWiR083Ov9P/D1TGI4QKtI
+      aKchZ8fiULSKJYpkSrZlzB0ZLwXT8IUGNMrHoDxRrJKHvzUPjFdi49R02l+5DCPtCXw33qfc78Ht
+      JAGP4trGrpl3ngNeiXZSa1HyKYdw1suNJCptlPnwMISFgnOVG9YUi2nAtf6OZBeyu7s0SgMh5qc5
+      3iqKBY8Soaneycso4qVjb63/C93nv/VshjDYkmNCxcUwlAqL2hPaBMhSd6+ecR1mlSZhUHh8B2Ob
+      iA95U3u3YYcHMnoUvfFthuDPXiQBSGzQbGjLvWUK8Hb033evACKm7Mpui+io/cA70KkD7R3vMqbh
+      zEYcgLRvmaT0IzA6sKR+Q0GtOuo5TrTQCh7Afd/GZh9a257beVNQwUBBDk2Dh/Ew/oxzOr0GyF6P
+      GLHOkWdMsqhmSNZ0Q/Ddb+BIT1CA9nL0h7Yq8+pzKY1gbmzDJt99DFMpnk0gTTpjbMCUu9h0YGYo
+      oEanKBHQ5QPPyq1i9VsgzEAPgbkLx5cDzcK6ZX+LZh8yo0WJu7wIqzdOdluYuC3hrd5srjPNTnup
+      NSj67lrZm9bcuN7IZ6XaF/wi2EPbiWE3T698An3MntLGaVa+ivrcD+8=
+  - packet: 11771
+    peer: 1
+    timestamp: 1562436322.354969025
+    data: !!binary |
+      Y5NjCR4YrtCScd2sNrDxuHimkTqfvhVp/ohnrc7bGZQZP8CVN9ssdUAYS5vEV/lo/Kw6HqaGo0Y0
+      oHhG55gvbbGgOdieXH65H70yKPUEwlBh/bDjJJYHGf5vY55itTtg4JD6ncUr+8BX6vzmrOEU0jkL
+      wx7qRmzipCl5aFGM5GjsijUli8WYl+ClIAAc5Kp1wghzJf5ybTl4L0t2EMZDSQrhzx+0nXXPb0MB
+      L37m21L72QO3gi4hD5fottmQEUmXXu/7q6O2GMRH64wAkN3/zdGkzNx1RPLioiWDTz8iPZBZpCR2
+      DBeVHV520Q4jIQoWHzRO25H2xPDEAAhYzEQzVcMCfcOz3Ul16DN+pB5fakLNeGHDWi1cxBeLWw9k
+      5Q20kJKNibau+NQytiKU0KX+9aRBNoEu9eO4DIyiVacciYqp+xmffE+tK+G3lqDze56kBZEUlXGl
+      D3q05OGKQUE5Tdx2lO2j3YHQ7NERfnhcUkdaDScp3VdRSRc13FWosqWds+vtKYQr+bUvmOIi+uSw
+      ERRWxJL+78el7FpDlO+94lIWbbW11khzbKa0rGX4vSQ8lPt9v7R8iRmrs8+0t+XOwHNfaaYKfKe2
+      TEH5iKPQqQ+zhC7ymPsvrQBUVm/OiVYUlM1kNrLAKsnMgvg/Tq0rEuLqQ7XQVTe3RfgMGTVSgXJZ
+      FcRrNUHf3sjMHKbE2YSUx64OMKsg57lSzPtXQBAG0XWOlpjdM6ZHgtK/4zUEgEsH98rFWklkEzaE
+      ZyI+cSIA7JW473D1W5imSSf1vT4s8GrjBqJCJiBDxR4jn4r+ygd/2arJiRB0DV643RQoHgONxKPk
+      QC9ZsPDuUDw7QIOBZYtBJxw3Fe01XTOhbIOrGEYRb7vTUBovWpxhbsve2gJAsfqUG+yDiThfe5lR
+      XdIm7IgknokQ1X0tOd/8VJnnnSumaG1duVq0s62DMOUuTACipAGvF4pgh/Vv9fN1qSimBtrPA66d
+      RGFezvX/iht3Fj5ij2g5ikl/MZIHiruNjsSVYrUOvGa9Xct11GEjG4o9NfRE8RGcqghNS0jYV5qI
+      MUyFFZf+PajS2TfrzTyHJAApfa8AZXg7TssLu76xn0Tz29iV8W0/xPWjQfsGl7vuoI4He6kEOlkY
+      bArG/udd6IjzCnxaJmi45e9rpBraCWZ5lrI53lCR0Ts/5PXT8DwfvOy++gt/TCnuchWlGVi5dDJo
+      XKu9NdBQrnUfYAWIgYJb+/1//l4kI2kFrA6Lsr6X4wBbbuvm5A3up05LD1RL2gWwEMMcKVb5cnTc
+      RM89/YkbCLo7f10581jKEv2ssYNQHZuaVpBfMoWf0lD3Y5HctTc8HMnWVZyfi6WTcCj5CLS+cw8F
+      OiYPShHaiysaQMiEe9ytFLTDx/IS30+KiC7p/VRwL3AvcmBL5PFnd+ZSJnGE2fU494lKpz81Ylij
+      nhgozZWpsd0uBtVaKJJyS0Ntovi6H/xFfDzTZQfj8zlBIVmHIlI3YpsHaysEEGsIvGZIQWtMWMR5
+      zcjZIIqoSFeHeZMrlT370xGKBJs0JvII8y/MDmOsoDzFseimurw2IeEyZnvpy8yRhAtojKV4IpNB
+      kVwdqyx6vuOMCOzxRIZOwsQBkKcHMJdFeAXnV4C/mG5SnrBnI1x7rilxbzpQXScmMekmyxjXRv4N
+      C3VhXtKVcM2zQCt+4wNDrl3TUhyP4+Z+nTOGQsNXHAtpOwyKYGXSuxXUAtdw/I7GEjq9syIP5jV/
+      51GuPe73EeHZdliAUCYnqozHMbjOOcjLVS2DikhprH7QAlsDwPlQtr8=
+  - packet: 11773
+    peer: 1
+    timestamp: 1562436322.355088949
+    data: !!binary |
+      hjmdN0BzyoViOW9NfF41rviDHDlSQ0QSozkt44ZlUxIFesauVIZ3hJFwO3D7fOJKGEfHl6YZn4dh
+      JFBkELyqbGFea3V4UX5zhyrwz0VSFMXJ/nUNWVajWdVJD2zIeF7OoR25g6oP89YbTVjPB0734IKt
+      u3Hnjs5iwsv46zcQ5T4y1xETDl6eUnwQBO7Na1HpnwoNzCnwtaoHc2N/3MoqwsuGD5syndloaKaA
+      A+ilrAW454IoLtRX6Wid9MjqIJG2noh5W7lWwotVzeYpxhrOdNmPgxavAlj4Apb34NUfskO/Wkkj
+      nkEC42xJqLwZfkd/Ki1xZCTp3QdiDM8hbZMsNPXBVJBO0LyQ339z3Vhw7nHRwCkkr0sQBBoevoXK
+      AANZSpM7Ohfjzbbbpuuw8LvzYfOJa/KyEY408X8CI8PS+SOxEnQS5WMqG/MHeX7kCppwbHCZtXpb
+      wLl8R3sW0tPspdY6tciMxqjuQ5QOd3VfttVZPpB4lghp43M7RJcSeuWJ+qbXBgtgKOipPw6JmF3x
+      h9Oao/FwFCXdKwLxoywYkIYvomW8/3Xb5zz4gggdA2IuW+UHZSRrDVGNzt6rbw/3hcStZmmsQDuE
+      Dic33q2ZM1S+D7HVZxgZ8d0FHA7Scd5cV1p5eZrHYiWOjqaboQButVNroPtVccOaMMj2gkeSonwq
+      ho41rKvkhVFfUb9Y6nrElcLNlZjlCWUQnvLv4bLCcjw4oBRjoNoUpTNpf6ppTePj6zuLRZ57/pWL
+      FK/6XSMcbWPfcp1v/vX+pBiknx2YZAMoiYyK7UWQc2pA5S1PAHGpzwxC0hJ+jxT0QkaXuQJU46tw
+      lRv3gdLVHRJuVKSUiyPdYsuyDqlBX5+sUj84SZHHglWUSnBcFYQZ9X0+M4v69Iiqu9jDbxm4QeSj
+      7T23eTqAcyDq5R/ohRzzCEnACLelvCj4eWqN4psNQOlBvLyRMKfXa/cYwpvtLVgDxUl9MFXcm6Ji
+      3ZpdCmcvlXpGhPO4mCH8OrumnbCSCGZuZcvTW78VsM+KsGoCa0z0zfFmnLyQXd0RZcYlVb+PlQiu
+      gbSe0cjA7iEy0EozSohyY1iDMQ6+vDS28uUEsN1pteJ9gLeVkwT75FVlT1h0P44noFIBeg/gakOX
+      KQeHZrnyzdKqV3/y4xtZPt/fEVFnIGvN4hpdXl0D5cuhWJBP4+I929yTI5pBOobu/NkguSwBt3T2
+      mTl5+gxSAhBBDwEn0ZBZourXrARUqj4kiyF0R6IdqPFb61b9SkaaYBI4EJP0i7HS0kLHkfD+xkQo
+      5HCU0SSmt2eT2a2wP7oYI5rNaNamAhjl1f3sX1rmEr59wmiB70b6A/fi+fhcoM8zYvQ3iutfhlau
+      RucDfmFfJDmBByto2iGWxJurdGDuY3fLrqnDpqSkNLzfnadV6AYk+P00RaD6f7tuUJbeffcLPnDg
+      qMAcI89z+l+8LqqESGXeRkU17AlpNjcaI45rnnU604scs6aq6LqiWx+MgxGX8V9O8M0Fu42yOFqq
+      Vto3TVJSib0YgPuHrJBadQVirhmuyrZSk3QDu4h3Q/GATyvAS921Y9KfWvoaPceFtJ1RP0T2UD1w
+      2dLynYKDHy4naMDD65hTII3j1N6zLQ/Mdt2bQnktGUIlzlRPaS9QsmjiU/1Zdmftc0f6lMtqcR7v
+      wEUnpPQXhPLkPAkvupR5bcPLB5Avu1JxYhWx99bM25vP/sBoj0SbDfq8GvhFjBfxuvc8B1KBIdCA
+      DDyhO3onVDbR2QsjZgol7GhJ7yblG774uryyzhwkmHB/MmJOGpBxr08=

--- a/Arrowgene.Ddon.Test/TestUtils.cs
+++ b/Arrowgene.Ddon.Test/TestUtils.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using Arrowgene.Logging;
-using Xunit.Abstractions;
 
 namespace Arrowgene.Ddon.Test
 {
@@ -14,6 +12,11 @@ namespace Arrowgene.Ddon.Test
             var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
             var dirPath = Path.GetDirectoryName(codeBasePath);
             return Path.Combine(dirPath, "TestFiles", relativePath);
+        }
+
+        public static string GetTestFileAsString(string relativePath)
+        {
+            return File.ReadAllText(GetTestPath(relativePath));
         }
     }
 }


### PR DESCRIPTION
- Add new optional UTF8 dump switch to the packet command.
- If the switch is present, the full byte data of a decrypted packet will be treated as UTF8 and appended to the already existing byte dump.
- Non-legible characters (not a letter, digit etc.) will be substituted with a placeholder to keep everything readable.
- Restructure packet command to make it testable and add utf8 dump unit test.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch