### PR TITLE
feat: Add empty handler for craft skill analyze option

### DIFF
--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -216,6 +216,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new CraftGetCraftSettingHandler(this));
             AddHandler(new CraftRecipeGetCraftRecipeHandler(this));
             AddHandler(new CraftStartCraftHandler(this));
+            AddHandler(new CraftSkillAnalyzeHandler(this));
 
             AddHandler(new DailyMissionListGetHandler(this));
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftSkillAnalyzeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftSkillAnalyzeHandler.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Logging;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class CraftSkillAnalyzeHandler : GameStructurePacketHandler<C2SCraftSkillAnalyzeReq>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(CraftSkillAnalyzeHandler));
+
+
+        public CraftSkillAnalyzeHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override void Handle(GameClient client, StructurePacket<C2SCraftSkillAnalyzeReq> packet)
+        {
+            S2CCraftSkillAnalyzeRes resp = new S2CCraftSkillAnalyzeRes()
+            {
+                Result = 0
+            };
+
+            client.Send(resp);
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -77,6 +77,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataCraftSkillRate.Serializer());
             Create(new CDataCraftSupportPawnID.Serializer());
             Create(new CDataCraftTimeSaveCost.Serializer());
+            Create(new CDataCraftSkillAnalyzeResult.Serializer());
             Create(new CDataDeliveredItem.Serializer());
             Create(new CDataDeliveredItemRecord.Serializer());
             Create(new CDataDeliveryItem.Serializer());
@@ -277,6 +278,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SCraftGetCraftSettingReq.Serializer());
             Create(new C2SCraftRecipeGetCraftRecipeReq.Serializer());
             Create(new C2SCraftStartCraftReq.Serializer());
+            Create(new C2SCraftSkillAnalyzeReq.Serializer());
 
             Create(new C2SEquipChangeCharacterEquipJobItemReq.Serializer());
             Create(new C2SEquipChangeCharacterEquipReq.Serializer());
@@ -494,6 +496,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CCraftGetCraftSettingRes.Serializer());
             Create(new S2CCraftRecipeGetCraftRecipeRes.Serializer());
             Create(new S2CCraftStartCraftRes.Serializer());
+            Create(new S2CCraftSkillAnalyzeRes.Serializer());
 
             Create(new S2CEquipChangeCharacterEquipJobItemNtc.Serializer());
             Create(new S2CEquipChangeCharacterEquipJobItemRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SCraftSkillAnalyzeReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SCraftSkillAnalyzeReq.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SCraftSkillAnalyzeReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CRAFT_CRAFT_SKILL_ANALYZE_REQ;
+
+        public C2SCraftSkillAnalyzeReq()
+        {
+            AssistPawnIds = new List<CDataCommonU32>();
+        }
+
+        public byte CraftType { get; set; }
+        public UInt32 RecipeId { get; set; }
+        public UInt32 ItemId { get; set; }
+        public UInt32 PawnId { get; set; }
+        public List<CDataCommonU32> AssistPawnIds { get; set; }
+        public UInt32 CreateCount { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SCraftSkillAnalyzeReq>
+        {
+            public override void Write(IBuffer buffer, C2SCraftSkillAnalyzeReq obj)
+            {
+                WriteByte(buffer, obj.CraftType);
+                WriteUInt32(buffer, obj.RecipeId);
+                WriteUInt32(buffer, obj.ItemId);
+                WriteEntityList<CDataCommonU32>(buffer, obj.AssistPawnIds);
+                WriteUInt32(buffer, obj.CreateCount);
+            }
+
+            public override C2SCraftSkillAnalyzeReq Read(IBuffer buffer)
+            {
+                C2SCraftSkillAnalyzeReq obj = new C2SCraftSkillAnalyzeReq();
+                obj.CraftType = ReadByte(buffer);
+                obj.RecipeId = ReadUInt32(buffer);
+                obj.ItemId = ReadUInt32(buffer);
+                obj.AssistPawnIds = ReadEntityList<CDataCommonU32>(buffer);
+                obj.CreateCount = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CCraftSkillAnalyzeRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CCraftSkillAnalyzeRes.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CCraftSkillAnalyzeRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CRAFT_CRAFT_SKILL_ANALYZE_RES;
+
+        public S2CCraftSkillAnalyzeRes()
+        {
+            AnalyzeResultList = new List<CDataCraftSkillAnalyzeResult>();
+        }
+
+        public Int32 ReqResult {  get; set; } // renamed from result due to name conflict
+        public List<CDataCraftSkillAnalyzeResult> AnalyzeResultList {  get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CCraftSkillAnalyzeRes>
+        {
+            public override void Write(IBuffer buffer, S2CCraftSkillAnalyzeRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteInt32(buffer, obj.ReqResult);
+                WriteEntityList<CDataCraftSkillAnalyzeResult>(buffer, obj.AnalyzeResultList);
+            }
+
+            public override S2CCraftSkillAnalyzeRes Read(IBuffer buffer)
+            {
+                S2CCraftSkillAnalyzeRes obj = new S2CCraftSkillAnalyzeRes();
+                ReadServerResponse(buffer, obj);
+                obj.ReqResult = ReadInt32(buffer);
+                obj.AnalyzeResultList = ReadEntityList<CDataCraftSkillAnalyzeResult>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataCraftSkillAnalyzeResult.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataCraftSkillAnalyzeResult.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+        
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataCraftSkillAnalyzeResult
+    {
+        public CDataCraftSkillAnalyzeResult()
+        {
+        }
+
+        public byte SkillType { get; set; }
+        public byte Rate {  get; set; }
+        public UInt32 Value0 { get; set; }
+        public UInt32 Value1 { get; set; }
+
+        public class Serializer : EntitySerializer<CDataCraftSkillAnalyzeResult>
+        {
+            public override void Write(IBuffer buffer, CDataCraftSkillAnalyzeResult obj)
+            {
+                WriteByte(buffer, obj.SkillType);
+                WriteByte(buffer, obj.Rate);
+                WriteUInt32(buffer, obj.Value0);
+                WriteUInt32(buffer, obj.Value1);
+            }
+
+            public override CDataCraftSkillAnalyzeResult Read(IBuffer buffer)
+            {
+                CDataCraftSkillAnalyzeResult obj = new CDataCraftSkillAnalyzeResult();
+                obj.SkillType = ReadByte(buffer);
+                obj.Rate = ReadByte(buffer);
+                obj.Value0 = ReadUInt32(buffer);
+                obj.Value1 = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a handler for crafting performance analysis to stop common hangs in the crafting menu. The server will simply reply back with a list of no results, resolving the client timeout issue.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
