### PR TITLE
feat: Add support for saving HP values on logout/disconnect

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -32,8 +32,7 @@ CREATE TABLE IF NOT EXISTS ddon_character_common
     "character_common_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "job"                 SMALLINT                          NOT NULL,
     "hide_equip_head"     BOOLEAN                           NOT NULL,
-    "hide_equip_lantern"  BOOLEAN                           NOT NULL,
-    "jewelry_slot_num"    SMALLINT                          NOT NULL
+    "hide_equip_lantern"  BOOLEAN                           NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS ddon_character
@@ -148,17 +147,8 @@ CREATE TABLE IF NOT EXISTS ddon_status_info
 (
     "character_common_id" INTEGER PRIMARY KEY NOT NULL,
     "hp"                  INTEGER             NOT NULL,
-    "stamina"             INTEGER             NOT NULL,
     "revive_point"        SMALLINT            NOT NULL,
-    "max_hp"              INTEGER             NOT NULL,
-    "max_stamina"         INTEGER             NOT NULL,
     "white_hp"            INTEGER             NOT NULL,
-    "gain_hp"             INTEGER             NOT NULL,
-    "gain_stamina"        INTEGER             NOT NULL,
-    "gain_attack"         INTEGER             NOT NULL,
-    "gain_defense"        INTEGER             NOT NULL,
-    "gain_magic_attack"   INTEGER             NOT NULL,
-    "gain_magic_defense"  INTEGER             NOT NULL,
     CONSTRAINT fk_status_info_character_common_id FOREIGN KEY ("character_common_id") REFERENCES ddon_character_common ("character_common_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -15,7 +15,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     {
         private static readonly string[] CharacterCommonFields = new string[]
         {
-            "job", "hide_equip_head", "hide_equip_lantern", "jewelry_slot_num"
+            "job", "hide_equip_head", "hide_equip_lantern"
         };
 
         private static readonly string[] CDataEditInfoFields = new string[]
@@ -36,8 +36,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         // Im not convinced most of these fields have to be stored in DB
         private static readonly string[] CDataStatusInfoFields = new string[]
         {
-            "character_common_id", "hp", "stamina", "revive_point", "max_hp", "max_stamina", "white_hp", "gain_hp", "gain_stamina",
-            "gain_attack", "gain_defense", "gain_magic_attack", "gain_magic_defense"
+            "character_common_id", "hp", "revive_point", "white_hp"
         };
 
 
@@ -291,9 +290,9 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         {
             common.CommonId = GetUInt32(reader, "character_common_id");
             common.Job = (JobId) GetByte(reader, "job");
-            common.JewelrySlotNum = GetByte(reader, "jewelry_slot_num");
             common.HideEquipHead = GetBoolean(reader, "hide_equip_head");
             common.HideEquipLantern = GetBoolean(reader, "hide_equip_lantern");
+            common.JewelrySlotNum = 0;
 
             common.EditInfo.Sex = GetByte(reader, "sex");
             common.EditInfo.Voice = GetByte(reader, "voice");
@@ -368,17 +367,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             common.EditInfo.MotionFilter = GetUInt16(reader, "motion_filter");
 
             common.StatusInfo.HP = GetUInt32(reader, "hp");
-            common.StatusInfo.Stamina = GetUInt32(reader, "stamina");
             common.StatusInfo.RevivePoint = GetByte(reader, "revive_point");
-            common.StatusInfo.MaxHP = GetUInt32(reader, "max_hp");
-            common.StatusInfo.MaxStamina = GetUInt32(reader, "max_stamina");
             common.StatusInfo.WhiteHP = GetUInt32(reader, "white_hp");
-            common.StatusInfo.GainHP = GetUInt32(reader, "gain_hp");
-            common.StatusInfo.GainStamina = GetUInt32(reader, "gain_stamina");
-            common.StatusInfo.GainAttack = GetUInt32(reader, "gain_attack");
-            common.StatusInfo.GainDefense = GetUInt32(reader, "gain_defense");
-            common.StatusInfo.GainMagicAttack = GetUInt32(reader, "gain_magic_attack");
-            common.StatusInfo.GainMagicDefense = GetUInt32(reader, "gain_magic_defense");
         }
 
         private void AddParameter(TCom command, CharacterCommon common)
@@ -386,7 +376,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             // CharacterCommonFields
             AddParameter(command, "@character_common_id", common.CommonId);
             AddParameter(command, "@job", (byte) common.Job);
-            AddParameter(command, "@jewelry_slot_num", common.JewelrySlotNum);
             AddParameter(command, "@hide_equip_head", common.HideEquipHead);
             AddParameter(command, "@hide_equip_lantern", common.HideEquipLantern);
             // CDataEditInfoFields
@@ -462,18 +451,9 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             AddParameter(command, "@muscle", common.EditInfo.Muscle);
             AddParameter(command, "@motion_filter", common.EditInfo.MotionFilter);
             // CDataStatusInfoFields
-            AddParameter(command, "@hp", common.StatusInfo.HP);
-            AddParameter(command, "@stamina", common.StatusInfo.Stamina);
+            AddParameter(command, "@hp", common.GreenHp);
             AddParameter(command, "@revive_point", common.StatusInfo.RevivePoint);
-            AddParameter(command, "@max_hp", common.StatusInfo.MaxHP);
-            AddParameter(command, "@max_stamina", common.StatusInfo.MaxStamina);
-            AddParameter(command, "@white_hp", common.StatusInfo.WhiteHP);
-            AddParameter(command, "@gain_hp", common.StatusInfo.GainHP);
-            AddParameter(command, "@gain_stamina", common.StatusInfo.GainStamina);
-            AddParameter(command, "@gain_attack", common.StatusInfo.GainAttack);
-            AddParameter(command, "@gain_defense", common.StatusInfo.GainDefense);
-            AddParameter(command, "@gain_magic_attack", common.StatusInfo.GainMagicAttack);
-            AddParameter(command, "@gain_magic_defense", common.StatusInfo.GainMagicDefense);
+            AddParameter(command, "@white_hp", common.WhiteHp);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -20,7 +20,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(CharacterManager));
 
         public static readonly uint BASE_HEALTH = 760U;
-        public static readonly uint BASE_STAMINA = 750U;
+        public static readonly uint BASE_STAMINA = 450U;
         public static readonly uint DEFAULT_RING_COUNT = 1;
         public static readonly uint BASE_ABILITY_COST_AMOUNT = 15;
 
@@ -78,12 +78,20 @@ namespace Arrowgene.Ddon.GameServer.Characters
             character.StatusInfo.GainStamina = ExtendedParams.StaminaMax;
             character.StatusInfo.GainHP = ExtendedParams.HpMax;
 
-            // These values reflect in the UI what the health bar displays
-            // TODO: Remove this when C2SLobbyLobbyDataMsgReq parsing is supported
-            // TODO: Server alone is not able to account for HP added by gear
-            // TODO: So we need to "trust" the value sent to the server is correct
-            character.StatusInfo.HP = CharacterManager.BASE_HEALTH + ExtendedParams.HpMax;
-            character.StatusInfo.WhiteHP = CharacterManager.BASE_HEALTH + ExtendedParams.HpMax;
+            /**
+             * Seems the game wants MaxHP to always be 760 and MaxStamina to be 450.
+             * Then it takes the values from the GainHp and GainStamina and add them 
+             * to the Max values. Finally it seems to take the status from the armor
+             * and add them to the running total for each stat, resulting the status
+             * you see in game.
+             */
+            character.StatusInfo.MaxStamina = CharacterManager.BASE_STAMINA;
+            character.StatusInfo.MaxHP = CharacterManager.BASE_HEALTH;
+        }
+
+        public void UpdateDatabaseOnExit(Character character)
+        {
+            _Database.UpdateStatusInfo(character);
         }
 
         public void UpdateCharacterExtendedParamsNtc(GameClient client, Character character)

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -11,13 +12,16 @@ namespace Arrowgene.Ddon.GameServer.Handler
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(LobbyLobbyLeaveHandler));
 
+        private CharacterManager _CharacterManager;
 
         public LobbyLobbyLeaveHandler(DdonGameServer server) : base(server)
         {
             server.ClientConnectionChangeEvent += OnClientConnectionChangeEvent;
+            _CharacterManager = server.CharacterManager;
         }
 
         // I have no idea on when this gets called, not when exiting the game, thats for sure
+        // - Return to title makes this happen
         public override void Handle(GameClient client, StructurePacket<C2SLobbyLeaveReq> packet)
         {
             client.Send(new S2CLobbyLeaveRes());
@@ -45,6 +49,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         otherClient.Send(ntc);
                     }
                 }
+
+                _CharacterManager.UpdateDatabaseOnExit(client.Character);
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/RpcHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/RpcHandler.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.RpcPacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class RpcHandler
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(RpcHandler));
+
+        public static void Handle(GameClient client, byte packetType, byte[] rpcData)
+        {
+            IBuffer buffer = new StreamBuffer(rpcData);
+            buffer.SetPositionStart();
+
+            RpcPacketHeader Header = new RpcPacketHeader().Read(buffer);
+            if (gRpcPacketHandlers.ContainsKey(Header.MsgIdFull))
+            {
+                gRpcPacketHandlers[Header.MsgIdFull].Handle(client.Character, buffer);
+            }
+        }
+
+        public static readonly Dictionary<RpcMessageId, IRpcPacket> gRpcPacketHandlers = new Dictionary<RpcMessageId, IRpcPacket>()
+        {
+            {RpcMessageId.HeartBeat1, new RpcHeartbeatPacket()},
+        };
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/IRpcPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/IRpcPacket.cs
@@ -1,0 +1,11 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
+{
+    public interface IRpcPacket
+    {
+        public void Handle(Character character, IBuffer buffer);
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcHeartbeatPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcHeartbeatPacket.cs
@@ -1,0 +1,67 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
+{
+    public class RpcHeartbeatPacket : RpcPacketBase
+    {
+        public RpcHeartbeatPacket()
+        {
+        }
+
+        public UInt64 Unk0 { get; set; }
+        public bool IsEnemy { get; set; }
+        public bool IsCharacter {  get; set; }
+        public bool IsHuman { get; set; }
+        public bool IsEnemyLarge {  get; set; }
+
+        public double PosX { get; set; }
+        public float PosY { get; set; }
+        public double PosZ { get; set; }
+
+        public UInt32 Unk1 { get; set; }
+        public UInt32 Unk2 { get; set; }
+        public UInt32 Unk3 { get; set; }
+
+        public UInt16 GreenHP { get; set; }
+        public UInt16 WhiteHP {  get; set; }
+        public UInt16 Unk4 { get; set; }
+        public UInt16 Stamina { get; set; }
+
+        public override void Handle(Character character, IBuffer buffer)
+        {
+            RpcHeartbeatPacket obj = Read(buffer);
+
+            if (obj.IsCharacter)
+            {
+                character.X = obj.PosX;
+                character.Y = obj.PosY;
+                character.Z = obj.PosZ;
+                character.GreenHp = obj.GreenHP;
+                character.WhiteHp = obj.WhiteHP;
+            }
+        }
+
+        private RpcHeartbeatPacket Read(IBuffer buffer)
+        {
+            RpcHeartbeatPacket obj = new RpcHeartbeatPacket();
+            obj.Unk0 = ReadUInt64(buffer); // nNetMsgData::CtrlBase::stMsgCtrlBaseData.mUniqueId ?
+            obj.IsEnemy = ReadBool(buffer);
+            obj.IsCharacter = ReadBool(buffer);
+            obj.IsHuman = ReadBool(buffer);
+            obj.IsEnemyLarge = ReadBool(buffer);
+            obj.PosX = ReadDouble(buffer);
+            obj.PosY = ReadFloat(buffer);
+            obj.PosZ = ReadDouble(buffer);
+            obj.Unk1 = ReadUInt32(buffer);
+            obj.Unk2 = ReadUInt32(buffer);
+            obj.Unk3 = ReadUInt32(buffer);
+            obj.GreenHP = ReadUInt16(buffer);
+            obj.WhiteHP = ReadUInt16(buffer);
+            obj.Unk4 = ReadUInt16(buffer);
+            obj.Stamina = ReadUInt16(buffer);
+            return obj;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcLoginPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcLoginPacket.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
+{
+    public class RpcLoginPacket : RpcPacketBase
+    {
+        public RpcLoginPacket()
+        {
+            Unk0 = new byte[6];
+        }
+
+        public byte[] Unk0 { get; set; }
+        public UInt16 StageNo { get; set; }
+
+        public override void Handle(Character character, IBuffer buffer)
+        {
+            RpcLoginPacket obj = Read(buffer);
+        }
+        private RpcLoginPacket Read(IBuffer buffer)
+        {
+            RpcLoginPacket obj = new RpcLoginPacket();
+            obj.Unk0 = ReadBytes(buffer, Unk0.Length);
+            obj.StageNo = ReadUInt16(buffer);
+            return obj;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketBase.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketBase.cs
@@ -1,0 +1,54 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
+{
+    public abstract class RpcPacketBase : IRpcPacket
+    {
+        public RpcPacketBase()
+        {
+        }
+
+        public abstract void Handle(Character character, IBuffer buffer);
+
+        public byte[] ReadBytes(IBuffer buffer, int length)
+        {
+            return buffer.ReadBytes(length);
+        }
+
+        public byte ReadByte(IBuffer buffer)
+        {
+            return buffer.ReadByte();
+        }
+
+        public UInt16 ReadUInt16(IBuffer buffer)
+        {
+            return buffer.ReadUInt16(Endianness.Big);
+        }
+
+        public UInt32 ReadUInt32(IBuffer buffer)
+        {
+            return buffer.ReadUInt32(Endianness.Big);
+        }
+
+        public UInt64 ReadUInt64(IBuffer buffer)
+        {
+            return buffer.ReadUInt64(Endianness.Big);
+        }
+
+        public bool ReadBool(IBuffer buffer) 
+        {
+            return buffer.ReadBool();
+        }
+
+        public double ReadDouble(IBuffer buffer) 
+        {
+            return buffer.ReadDouble(Endianness.Big);
+        }
+        public float ReadFloat(IBuffer buffer)
+        {
+            return buffer.ReadFloat(Endianness.Big);
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketHeader.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketHeader.cs
@@ -1,0 +1,38 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
+{
+    public class RpcPacketHeader : RpcPacketBase
+    {
+        public RpcPacketHeader()
+        {
+        }
+
+        public UInt32 SessionId { get; set; }
+        public UInt64 RpcId { get; set; }
+        public RpcMessageId MsgIdFull { get; set; }
+        public UInt32 SearchId { get; set; }
+
+        public override void Handle(Character character, IBuffer buffer)
+        {
+            /* special case nothing to do */
+        }
+
+        public RpcPacketHeader Read(IBuffer buffer)
+        {
+            RpcPacketHeader obj = new RpcPacketHeader();
+            obj.SessionId = ReadUInt32(buffer);    // NetMsgData.Head.SessionId
+            obj.RpcId = ReadUInt64(buffer); // NetMsgData.Head.RpcId
+            obj.MsgIdFull = (RpcMessageId) ReadUInt32(buffer);    // NetMsgData.Head.MsgIdFull
+            obj.SearchId = ReadUInt32(buffer);     // NetMsgData.Head.SearchId, seems to either a PawnId or 0
+            return obj;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
+++ b/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
@@ -58,5 +58,8 @@ namespace Arrowgene.Ddon.Shared.Model
         public double X { get; set; }
         public float Y { get; set; }
         public double Z { get; set; }
+
+        public uint GreenHp {  get; set; }
+        public uint WhiteHp { get; set; }
     }
 }

--- a/Arrowgene.Ddon.Shared/Model/RpcMessageId.cs
+++ b/Arrowgene.Ddon.Shared/Model/RpcMessageId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum RpcMessageId : UInt32
+    {
+        Login = 0x41000001,
+        HeartBeat0 = 0x40010002,
+        HeartBeat1 = 0x40010015,
+        HeartBeat2 = 0x4001001A,
+        Combat1    = 0x40010037,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/RpcPacketType.cs
+++ b/Arrowgene.Ddon.Shared/Model/RpcPacketType.cs
@@ -1,0 +1,8 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum RpcPacketType : byte
+    {
+        Ping = 2,   // See this while in town and out in the field
+        Combat = 4, // See this when fighting monsters
+    }
+}


### PR DESCRIPTION
Added additional parsing to the RPC packets to extract the HP values. When the disconnect notification is raised, the current value of green and white HP is stored in the DB and used when the character is logged into next time. Removed unused fields related to stats and jewelry.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
