### PR TITLE
refactor: Remove unused jewelry_slot_num field

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -32,8 +32,7 @@ CREATE TABLE IF NOT EXISTS ddon_character_common
     "character_common_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "job"                 SMALLINT                          NOT NULL,
     "hide_equip_head"     BOOLEAN                           NOT NULL,
-    "hide_equip_lantern"  BOOLEAN                           NOT NULL,
-    "jewelry_slot_num"    SMALLINT                          NOT NULL
+    "hide_equip_lantern"  BOOLEAN                           NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS ddon_character

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -15,7 +15,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     {
         private static readonly string[] CharacterCommonFields = new string[]
         {
-            "job", "hide_equip_head", "hide_equip_lantern", "jewelry_slot_num"
+            "job", "hide_equip_head", "hide_equip_lantern"
         };
 
         private static readonly string[] CDataEditInfoFields = new string[]
@@ -291,7 +291,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         {
             common.CommonId = GetUInt32(reader, "character_common_id");
             common.Job = (JobId) GetByte(reader, "job");
-            common.JewelrySlotNum = GetByte(reader, "jewelry_slot_num");
             common.HideEquipHead = GetBoolean(reader, "hide_equip_head");
             common.HideEquipLantern = GetBoolean(reader, "hide_equip_lantern");
 
@@ -386,7 +385,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             // CharacterCommonFields
             AddParameter(command, "@character_common_id", common.CommonId);
             AddParameter(command, "@job", (byte) common.Job);
-            AddParameter(command, "@jewelry_slot_num", common.JewelrySlotNum);
             AddParameter(command, "@hide_equip_head", common.HideEquipHead);
             AddParameter(command, "@hide_equip_lantern", common.HideEquipLantern);
             // CDataEditInfoFields

--- a/deploy/mariadb/schema_mariadb.sql
+++ b/deploy/mariadb/schema_mariadb.sql
@@ -32,8 +32,7 @@ CREATE TABLE IF NOT EXISTS ddon_character_common
     "character_common_id" INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
     "job"                 SMALLINT                           NOT NULL,
     "hide_equip_head"     BOOLEAN                            NOT NULL,
-    "hide_equip_lantern"  BOOLEAN                            NOT NULL,
-    "jewelry_slot_num"    SMALLINT                           NOT NULL
+    "hide_equip_lantern"  BOOLEAN                            NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS ddon_character

--- a/deploy/postgresql/schema_postgres.sql
+++ b/deploy/postgresql/schema_postgres.sql
@@ -32,8 +32,7 @@ CREATE TABLE IF NOT EXISTS ddon_character_common
     "character_common_id" SERIAL PRIMARY KEY NOT NULL,
     "job"                 SMALLINT           NOT NULL,
     "hide_equip_head"     BOOLEAN            NOT NULL,
-    "hide_equip_lantern"  BOOLEAN            NOT NULL,
-    "jewelry_slot_num"    SMALLINT           NOT NULL
+    "hide_equip_lantern"  BOOLEAN            NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS ddon_character


### PR DESCRIPTION
Since the dragon force augment mechanic was implemented, the jewelry_slot_num field in the DB is no longer used, so remove it.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
