### PR TITLE
Add more customization options for packet command.

### DIFF
--- a/Arrowgene.Ddon.Shared/Network/StructurePacket.cs
+++ b/Arrowgene.Ddon.Shared/Network/StructurePacket.cs
@@ -48,11 +48,17 @@ namespace Arrowgene.Ddon.Shared.Network
 
     public abstract class StructurePacket : Packet, IStructurePacket
     {
-        private static readonly ISerializer Serializer = new SerializerBuilder()
+        public static ISerializer YamlSerializer { get; } = new SerializerBuilder()
             .WithTypeInspector(inspector => new MyTypeInspector(inspector))
             .WithTypeConverter(new ByteArrayConverter())
             .Build();
-        
+
+        public static ISerializer JsonSerializer { get; } = new SerializerBuilder()
+            .WithTypeInspector(inspector => new MyTypeInspector(inspector))
+            .WithTypeConverter(new ByteArrayConverter())
+            .JsonCompatible()
+            .Build();
+
         protected StructurePacket(IPacket packet) : base(packet.Id, packet.Data, packet.Source, packet.Count)
         {
         }
@@ -66,7 +72,7 @@ namespace Arrowgene.Ddon.Shared.Network
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.Append(PrintHeader());
             stringBuilder.Append(Environment.NewLine);
-            Serializer.Serialize(new IndentedTextWriter(new StringWriter(stringBuilder)), this);
+            YamlSerializer.Serialize(new IndentedTextWriter(new StringWriter(stringBuilder)), this);
             return stringBuilder.ToString();
         }
 

--- a/Arrowgene.Ddon.Test/Cli/Command/PacketCommandTest.cs
+++ b/Arrowgene.Ddon.Test/Cli/Command/PacketCommandTest.cs
@@ -17,7 +17,7 @@ public class PacketCommandTest
         string testYaml = TestUtils.GetTestFileAsString("pcapng1-tcp-stream-33_reduced_test.yaml");
         List<PcapPacket> encryptedPackets = packetCommand.ReadYamlPcap(testYaml);
         List<PcapPacket> decryptedPackets = packetCommand.DecryptPackets(encryptedPackets, Encoding.ASCII.GetBytes("3jc6R11q__MGmP9YIn7fyiNVQgSUoiBc"));
-        string annotatedPacketDump = packetCommand.GetAnnotatedPacketDump(decryptedPackets, true);
+        string annotatedPacketDump = packetCommand.GetAnnotatedPacketDump(decryptedPackets, false, true, false);
 
         Assert.Contains("通信エラーが発生しました", annotatedPacketDump);
     }
@@ -35,12 +35,12 @@ public class PacketCommandTest
         Assert.Equal(762, encryptedPackets.Count);
         Assert.Equal(688, count);
     }
-    
+
     [Fact]
     public void TestDecryptPcap85SplitPacket()
     {
         string testYaml = TestUtils.GetTestFileAsString("stream85-marked.pcapng_tcp-stream-11_edge_case.yaml");
-      
+
         PacketCommand packetCommand = new PacketCommand();
         List<PcapPacket> encryptedPackets = packetCommand.ReadYamlPcap(testYaml);
         List<PcapPacket> decryptedPackets = packetCommand.DecryptPackets(encryptedPackets, Encoding.ASCII.GetBytes("hkNnBgyXz40de6kX3vkmAWGvatldB-Pp"));


### PR DESCRIPTION
Add support for structure dumps.
Add support for customizing byte dump separator and prefix.

This also deactivates all customizations by default and expects the user to provide the switches.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
