### PR TITLE
Feature/improve server error response logic to not break on decrypted dumps

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ServerGetServerListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ServerGetServerListHandler.cs
@@ -28,7 +28,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             S2CServerGetServerListRes response = new S2CServerGetServerListRes();
             response.GameServerListInfo = new List<CDataGameServerListInfo>(_assets.ServerList);
-            response.IsReceived = true;
             client.Send(response);
         }
     }

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -1101,7 +1101,7 @@ namespace Arrowgene.Ddon.Shared.Entity
         protected void ReadServerResponse(IBuffer buffer, ServerResponse value)
         {
             value.Error = buffer.ReadUInt32(Endianness.Big);
-            value.Result = buffer.ReadUInt32(Endianness.Big);
+            value.Result = value.Error != 0 ? buffer.ReadUInt16(Endianness.Big) : buffer.ReadUInt32(Endianness.Big);
         }
 
         protected void WriteEntity<TEntity>(IBuffer buffer, TEntity entity) where TEntity : class, new()

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstanceEnemyKillRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstanceEnemyKillRes.cs
@@ -28,8 +28,12 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             public override S2CInstanceEnemyKillRes Read(IBuffer buffer)
             {
                 S2CInstanceEnemyKillRes obj = new S2CInstanceEnemyKillRes();
-                obj.EnemyId = ReadUInt32(buffer);
-                obj.KillNum = ReadUInt32(buffer);
+                ReadServerResponse(buffer, obj);
+                if (obj.Error == 0)
+                {
+                    obj.EnemyId = ReadUInt32(buffer);
+                    obj.KillNum = ReadUInt32(buffer);
+                }
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CServerGetServerListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CServerGetServerListRes.cs
@@ -12,11 +12,9 @@ public class S2CServerGetServerListRes : ServerResponse
     public S2CServerGetServerListRes()
     {
         GameServerListInfo = new List<CDataGameServerListInfo>();
-        IsReceived = false;
     }
 
     public List<CDataGameServerListInfo> GameServerListInfo { get; set; }
-    public bool IsReceived { get; set; }
 
 
     public class Serializer : PacketEntitySerializer<S2CServerGetServerListRes>
@@ -25,7 +23,6 @@ public class S2CServerGetServerListRes : ServerResponse
         {
             WriteServerResponse(buffer, obj);
             WriteEntityList<CDataGameServerListInfo>(buffer, obj.GameServerListInfo);
-            WriteBool(buffer, obj.IsReceived);
         }
 
         public override S2CServerGetServerListRes Read(IBuffer buffer)
@@ -33,7 +30,6 @@ public class S2CServerGetServerListRes : ServerResponse
             S2CServerGetServerListRes obj = new S2CServerGetServerListRes();
             ReadServerResponse(buffer, obj);
             obj.GameServerListInfo = ReadEntityList<CDataGameServerListInfo>(buffer);
-            obj.IsReceived = ReadBool(buffer);
             return obj;
         }
     }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetAcquirableAbilityListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetAcquirableAbilityListRes.cs
@@ -28,7 +28,10 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             {
                 S2CSkillGetAcquirableAbilityListRes obj = new S2CSkillGetAcquirableAbilityListRes();
                 ReadServerResponse(buffer, obj);
-                obj.AbilityParamList = ReadEntityList<CDataAbilityParam>(buffer);
+                if (obj.Error == 0)
+                {
+                    obj.AbilityParamList = ReadEntityList<CDataAbilityParam>(buffer);
+                }
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetAcquirableSkillListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetAcquirableSkillListRes.cs
@@ -28,7 +28,10 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             {
                 S2CSkillGetAcquirableSkillListRes obj = new S2CSkillGetAcquirableSkillListRes();
                 ReadServerResponse(buffer, obj);
-                obj.SkillParamList = ReadEntityList<CDataSkillParam>(buffer);
+                if (obj.Error == 0)
+                {
+                    obj.SkillParamList = ReadEntityList<CDataSkillParam>(buffer);
+                }
                 return obj;
             }
         }


### PR DESCRIPTION
This has a dependency on PR #285.

While dumping the decrypted packets along with their parsed structures I've found a few issues related to error handling. Unsure if result should actually still be read at all or skipped entirely in error cases.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
