### PR TITLE
fix: Add missing newline to Logger.Hex

### DIFF
--- a/Arrowgene.Ddon.Server/ServerLogger.cs
+++ b/Arrowgene.Ddon.Server/ServerLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Network;
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.Server
 
         public void Hex(byte[] data)
         {
-            Info($"{Util.HexDump(data)}");
+            Info($"\n{Util.HexDump(data)}");
         }
 
         public void Info(Client client, string message)


### PR DESCRIPTION
Added a newline so the start of the hexdump starts inline with the rest of the hexdump instead of on the same line as the information message.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
