### PR TITLE
feat: Track HP and Stamina properly after upgrades and logout

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -149,9 +149,6 @@ CREATE TABLE IF NOT EXISTS ddon_status_info
     "revive_point"        SMALLINT            NOT NULL,
     "hp"                  INTEGER             NOT NULL,
     "white_hp"            INTEGER             NOT NULL,
-    "max_hp"              INTEGER             NOT NULL,
-    "stamina"             INTEGER             NOT NULL,
-    "max_stamina"         INTEGER             NOT NULL,
     CONSTRAINT fk_status_info_character_common_id FOREIGN KEY ("character_common_id") REFERENCES ddon_character_common ("character_common_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -36,7 +36,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         // Im not convinced most of these fields have to be stored in DB
         private static readonly string[] CDataStatusInfoFields = new string[]
         {
-            "character_common_id", "revive_point", "hp", "white_hp", "max_hp", "stamina", "max_stamina"
+            "character_common_id", "revive_point", "hp", "white_hp"
         };
 
         private readonly string SqlInsertCharacterCommon = $"INSERT INTO \"ddon_character_common\" ({BuildQueryField(CharacterCommonFields)}) VALUES ({BuildQueryInsert(CharacterCommonFields)});";
@@ -291,6 +291,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             common.Job = (JobId) GetByte(reader, "job");
             common.HideEquipHead = GetBoolean(reader, "hide_equip_head");
             common.HideEquipLantern = GetBoolean(reader, "hide_equip_lantern");
+            common.JewelrySlotNum = 0;
 
             common.EditInfo.Sex = GetByte(reader, "sex");
             common.EditInfo.Voice = GetByte(reader, "voice");
@@ -368,9 +369,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             common.StatusInfo.RevivePoint = GetByte(reader, "revive_point");
             common.StatusInfo.HP = GetUInt32(reader, "hp");
             common.StatusInfo.WhiteHP = GetUInt32(reader, "white_hp");
-            common.StatusInfo.MaxHP = GetUInt32(reader, "max_hp");
-            common.StatusInfo.Stamina = GetUInt32(reader, "stamina");
-            common.StatusInfo.MaxStamina = GetUInt32(reader, "max_stamina");
         }
 
         private void AddParameter(TCom command, CharacterCommon common)
@@ -454,11 +452,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             AddParameter(command, "@motion_filter", common.EditInfo.MotionFilter);
             // CDataStatusInfoFields
             AddParameter(command, "@revive_point", common.StatusInfo.RevivePoint);
-            AddParameter(command, "@hp", common.StatusInfo.HP);
-            AddParameter(command, "@white_hp", common.StatusInfo.WhiteHP);
-            AddParameter(command, "@max_hp", common.StatusInfo.MaxHP);
-            AddParameter(command, "@stamina", common.StatusInfo.Stamina);
-            AddParameter(command, "@max_stamina", common.StatusInfo.MaxStamina);
+            AddParameter(command, "@hp", common.GreenHp);
+            AddParameter(command, "@white_hp", common.WhiteHp);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -11,13 +12,16 @@ namespace Arrowgene.Ddon.GameServer.Handler
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(LobbyLobbyLeaveHandler));
 
+        private CharacterManager _CharacterManager;
 
         public LobbyLobbyLeaveHandler(DdonGameServer server) : base(server)
         {
             server.ClientConnectionChangeEvent += OnClientConnectionChangeEvent;
+            _CharacterManager = server.CharacterManager;
         }
 
         // I have no idea on when this gets called, not when exiting the game, thats for sure
+        // - Return to title makes this happen
         public override void Handle(GameClient client, StructurePacket<C2SLobbyLeaveReq> packet)
         {
             client.Send(new S2CLobbyLeaveRes());
@@ -45,6 +49,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         otherClient.Send(ntc);
                     }
                 }
+
+                _CharacterManager.UpdateDatabaseOnExit(client.Character);
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/RpcHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/RpcHandler.cs
@@ -21,10 +21,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             IBuffer buffer = new StreamBuffer(rpcData);
             buffer.SetPositionStart();
 
+            // It seems like MsgIdFull  is almost like a "message class"
+            // where RpcId is a unique action?
             RpcPacketHeader Header = new RpcPacketHeader().Read(buffer);
             if (gRpcPacketHandlers.ContainsKey(Header.MsgIdFull))
             {
-                gRpcPacketHandlers[Header.MsgIdFull].Handle(client.Character, buffer);
+                gRpcPacketHandlers[Header.MsgIdFull].Handle(client.Character, Header, buffer);
             }
         }
 

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/IRpcPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/IRpcPacket.cs
@@ -6,6 +6,6 @@ namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
 {
     public interface IRpcPacket
     {
-        public void Handle(Character character, IBuffer buffer);
+        public void Handle(Character character, RpcPacketHeader packetHeader, IBuffer buffer);
     }
 }

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcHeartbeatPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcHeartbeatPacket.cs
@@ -29,19 +29,31 @@ namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
         public UInt16 Unk4 { get; set; }
         public UInt16 Stamina { get; set; }
 
-        public override void Handle(Character character, IBuffer buffer)
+        public override void Handle(Character character, RpcPacketHeader packetHeader, IBuffer buffer)
         {
-            RpcHeartbeatPacket obj = Read(buffer);
+            // Seems like RPCId = 0x00000000000007d0 and SearchId = 0x00000000
+            // correspond with the players character
+            //
+            // Pawns get other packets with the same RpcPacketHeader.MsgIdFull value
+            // but different RpcId and SearchId values
+            // RpcId=0x00000000000007d1, SearchId = 0x00000001
+            // RpcId=0x00000000000007d2, SearchId = 0x00000002
+            // RpcId=0x00000000000007d3, SearchId = 0x00000003
 
-            if (obj.IsCharacter)
+            // Support only the player for now
+            if (packetHeader.RpcId == (ulong) RpcId.HeartBeatPlayer && packetHeader.SearchId == 0)
             {
+                RpcHeartbeatPacket obj = ReadPacketData(buffer);
                 character.X = obj.PosX;
                 character.Y = obj.PosY;
                 character.Z = obj.PosZ;
+
+                character.GreenHp = obj.GreenHP;
+                character.WhiteHp = obj.WhiteHP;
             }
         }
 
-        private RpcHeartbeatPacket Read(IBuffer buffer)
+        private RpcHeartbeatPacket ReadPacketData(IBuffer buffer)
         {
             RpcHeartbeatPacket obj = new RpcHeartbeatPacket();
             obj.Unk0 = ReadUInt64(buffer); // nNetMsgData::CtrlBase::stMsgCtrlBaseData.mUniqueId ?

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcLoginPacket.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcLoginPacket.cs
@@ -18,11 +18,11 @@ namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
         public byte[] Unk0 { get; set; }
         public UInt16 StageNo { get; set; }
 
-        public override void Handle(Character character, IBuffer buffer)
+        public override void Handle(Character character, RpcPacketHeader Header, IBuffer buffer)
         {
-            RpcLoginPacket obj = Read(buffer);
+            // TODO: Should we save the stage ID when logging in somewhere?
         }
-        private RpcLoginPacket Read(IBuffer buffer)
+        private RpcLoginPacket ReadPacketData(IBuffer buffer)
         {
             RpcLoginPacket obj = new RpcLoginPacket();
             obj.Unk0 = ReadBytes(buffer, Unk0.Length);

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketBase.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketBase.cs
@@ -10,7 +10,7 @@ namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
         {
         }
 
-        public abstract void Handle(Character character, IBuffer buffer);
+        public abstract void Handle(Character character, RpcPacketHeader packetHeader, IBuffer buffer);
 
         public byte[] ReadBytes(IBuffer buffer, int length)
         {

--- a/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketHeader.cs
+++ b/Arrowgene.Ddon.Shared/Entity/RpcPacketStructure/RpcPacketHeader.cs
@@ -20,9 +20,10 @@ namespace Arrowgene.Ddon.Shared.Entity.RpcPacketStructure
         public RpcMessageId MsgIdFull { get; set; }
         public UInt32 SearchId { get; set; }
 
-        public override void Handle(Character character, IBuffer buffer)
+        public override void Handle(Character character, RpcPacketHeader Header, IBuffer buffer)
         {
-            /* special case nothing to do */
+            /* special case nothing to do; should not be called */
+            throw new NotImplementedException();
         }
 
         public RpcPacketHeader Read(IBuffer buffer)

--- a/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
+++ b/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
@@ -58,5 +58,8 @@ namespace Arrowgene.Ddon.Shared.Model
         public double X { get; set; }
         public float Y { get; set; }
         public double Z { get; set; }
+
+        public uint GreenHp {  get; set; }
+        public uint WhiteHp { get; set; }
     }
 }

--- a/Arrowgene.Ddon.Shared/Model/RpcId.cs
+++ b/Arrowgene.Ddon.Shared/Model/RpcId.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum RpcId : ulong
+    {
+        HeartBeatPlayer = 0x00000000000007d0,
+        HeartBeatPawn1 = 0x00000000000007d1,
+        HeartBeatPawn2 = 0x00000000000007d2,
+        HeartBeatPawn3 = 0x00000000000007d3,
+    }
+}


### PR DESCRIPTION
When a user logs out or disconnects, the disconnect notification is raised.
When this happens, the current value of green and white HP is stored in the
DB. This value will then be used the next time the character is logged into.
When the user purchases an upgrade at the white dragon, HP and Stamina are
refilled to the max value.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
