### PR TITLE
fix: Fix issue with secret abilities on pawns

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
@@ -21713,23 +21713,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 Response.AbilityParamList = AllAbilities
                     .Where(x => x.Job == packet.Structure.Job).ToList();
             }
-            else
+            else if (packet.Structure.CharacterId == 0)
             {
-                uint commonId = 0;
-                uint characterId = packet.Structure.CharacterId;
-
-                // If the CharacterId is 0, it is the current player, otherwise it is a PawnId
-                if (characterId == 0)
-                {
-                    commonId = client.Character.CommonId;
-                }
-                else
-                {
-                    Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == characterId).Single();
-                    commonId = pawn.CommonId;
-                }
-
-                List<SecretAbility> UnlockedAbilities = _Database.SelectAllUnlockedSecretAbilities(commonId);
+                // Player characters come in as CharacterId == 0.
+                // Pawns seem to not need the information from this query. The UI still is populated by the skills
+                // acquired by the player character (is this intended?).
+                List<SecretAbility> UnlockedAbilities = _Database.SelectAllUnlockedSecretAbilities(client.Character.CharacterId);
                 Response.AbilityParamList = AllSecretAbilities.Where(x => UnlockedAbilities.Contains((SecretAbility)x.AbilityNo)).ToList();
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/SkillLearnPawnAbilityHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillLearnPawnAbilityHandler.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
@@ -22,7 +24,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override void Handle(GameClient client, StructurePacket<C2SSkillLearnPawnAbilityReq> packet)
         {
             Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
-            JobId augJob = SkillGetAcquirableAbilityListHandler.AllAbilities.Where(aug => aug.AbilityNo == packet.Structure.AbilityId).Select(aug => aug.Job).Single(); // why is this not in the packet
+
+
+            var AllAbilities = SkillGetAcquirableAbilityListHandler.AllAbilities.Concat(SkillGetAcquirableAbilityListHandler.AllSecretAbilities);
+
+            JobId augJob = AllAbilities.Where(aug => aug.AbilityNo == packet.Structure.AbilityId).Select(aug => aug.Job).Single(); // why is this not in the packet
             this.jobManager.UnlockAbility(Server.Database, client, pawn, augJob, packet.Structure.AbilityId, packet.Structure.AbilityLv);
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillSetPawnAbilityHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillSetPawnAbilityHandler.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
@@ -25,11 +27,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 Logger.Error(client, $"Requesting to set an ability to slot 0");
             }
-            
+
             // For some reason JobId is received as 0, unlike in SkillSetAbilityHandler, where it's set to its correct value
             // This is, also for whatever reason, important so it works properly, so we have to set it ourselves
             // TODO: Investigate this more, or optimize this
-            JobId abilityJob = SkillGetAcquirableAbilityListHandler.AllAbilities
+
+            var AllAbilities = SkillGetAcquirableAbilityListHandler.AllAbilities.Concat(SkillGetAcquirableAbilityListHandler.AllSecretAbilities);
+            JobId abilityJob = AllAbilities
                 .Where(aug => aug.AbilityNo == packet.Structure.SkillId )
                 .Select(aug => aug.Job)
                 .Single();


### PR DESCRIPTION
Fixed an issue where the lists for pawns were not searching in the correct location for skills. If a user tries to buy or equip a secret ability on a pawn it would cause a null pointer exception.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
