### PR TITLE
Pawn training implementation

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -62,8 +62,19 @@ CREATE TABLE IF NOT EXISTS ddon_pawn
     "name"                TEXT                              NOT NULL,
     "hm_type"             SMALLINT                          NOT NULL,
     "pawn_type"           SMALLINT                          NOT NULL,
+    "training_points"     INTEGER                           NOT NULL,
+    "available_training"  INTEGER                           NOT NULL,
     CONSTRAINT fk_pawn_character_common_id FOREIGN KEY ("character_common_id") REFERENCES ddon_character_common ("character_common_id") ON DELETE CASCADE,
     CONSTRAINT fk_character_character_id FOREIGN KEY ("character_id") REFERENCES ddon_character ("character_id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS ddon_pawn_training_status
+(
+    "pawn_id"         INTEGER  NOT NULL,
+    "job"             SMALLINT NOT NULL,
+    "training_status" BLOB     NOT NULL,
+    CONSTRAINT pk_pawn_training_status PRIMARY KEY (pawn_id, job),
+    CONSTRAINT fk_pawn_training_status_pawn_id FOREIGN KEY ("pawn_id") REFERENCES ddon_pawn ("pawn_id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS ddon_edit_info

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -45,6 +45,12 @@ namespace Arrowgene.Ddon.Database
         bool DeletePawn(uint pawnId);
         bool UpdatePawnBaseInfo(Pawn pawn);
 
+        // Pawn Training Status
+        bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);
+        bool InsertPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);
+        bool InsertIfNotExistsPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);
+        bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);
+
         // CharacterJobData
         bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData);
         bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawnTrainingStatus.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawnTrainingStatus.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        protected static readonly string[] PawnTrainingStatusFields = new string[]
+        {
+            "pawn_id", "job", "training_status"
+        };
+
+        private readonly string SqlInsertPawnTrainingStatus =
+            $"INSERT INTO \"ddon_pawn_training_status\" ({BuildQueryField(PawnTrainingStatusFields)}) VALUES ({BuildQueryInsert(PawnTrainingStatusFields)});";
+
+        protected virtual string SqlInsertIfNotExistsPawnTrainingStatus { get; } =
+            $"INSERT INTO \"ddon_pawn_training_status\" ({BuildQueryField(PawnTrainingStatusFields)}) SELECT {BuildQueryInsert(PawnTrainingStatusFields)} WHERE NOT EXISTS (SELECT 1 FROM \"ddon_pawn_training_status\" WHERE \"pawn_id\" = @pawn_id AND \"job\" = @job);";
+
+        private static readonly string SqlUpdatePawnTrainingStatus =
+            $"UPDATE \"ddon_pawn_training_status\" SET {BuildQueryUpdate(PawnTrainingStatusFields)} WHERE \"pawn_id\" = @pawn_id AND \"job\" = @job;";
+
+        private static readonly string SqlSelectPawnTrainingStatus =
+            $"SELECT {BuildQueryField(PawnTrainingStatusFields)} FROM \"ddon_pawn_training_status\" WHERE \"pawn_id\" = @pawn_id AND \"job\" = @job;";
+
+        private static readonly string SqlSelectPawnTrainingStatusByPawn =
+            $"SELECT {BuildQueryField(PawnTrainingStatusFields)} FROM \"ddon_pawn_training_status\" WHERE \"pawn_id\" = @pawn_id;";
+
+        private const string SqlDeletePawnTrainingStatus = "DELETE FROM \"ddon_pawn_training_status\" WHERE \"pawn_id\"=@pawn_id AND \"job\" = @job;";
+
+        public bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            using TCon connection = OpenNewConnection();
+            return ReplacePawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus);
+        }
+
+        public bool ReplacePawnTrainingStatus(TCon connection, uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            Logger.Debug("Inserting character job data.");
+            if (!InsertIfNotExistsPawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus))
+            {
+                Logger.Debug("Character job data already exists, replacing.");
+                return UpdatePawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus);
+            }
+            return true;
+        }
+
+        public bool InsertPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            using TCon connection = OpenNewConnection();
+            return InsertPawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus);
+        }
+
+        public bool InsertPawnTrainingStatus(TCon connection, uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            return ExecuteNonQuery(connection, SqlInsertPawnTrainingStatus, command => {
+                AddParameter(command, "@pawn_id", pawnId);
+                AddParameter(command, "@job", (byte) job);
+                AddParameter(command, "@training_status", pawnTrainingStatus);
+            }) == 1;
+        }
+        
+        public bool InsertIfNotExistsPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            using TCon connection = OpenNewConnection();
+            return InsertIfNotExistsPawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus);
+        }
+
+        public bool InsertIfNotExistsPawnTrainingStatus(TCon connection, uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            return ExecuteNonQuery(connection, SqlInsertIfNotExistsPawnTrainingStatus, command => {
+                AddParameter(command, "@pawn_id", pawnId);
+                AddParameter(command, "@job", (byte) job);
+                AddParameter(command, "@training_status", pawnTrainingStatus);
+            }) == 1;
+        }
+
+        public bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            using TCon connection = OpenNewConnection();
+            return UpdatePawnTrainingStatus(connection, pawnId, job, pawnTrainingStatus);
+        }
+
+        public bool UpdatePawnTrainingStatus(TCon connection, uint pawnId, JobId job, byte[] pawnTrainingStatus)
+        {
+            return ExecuteNonQuery(connection, SqlUpdatePawnTrainingStatus, command => {
+                AddParameter(command, "@pawn_id", pawnId);
+                AddParameter(command, "@job", (byte) job);
+                AddParameter(command, "@training_status", pawnTrainingStatus);
+            }) == 1;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -139,7 +139,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 changeJobResponse.EquipJobItemList = jobItems;
                 changeJobResponse.Unk0.Unk0 = (byte) jobId;
                 // changeJobResponse.Unk0.Unk1 = pawn.Storage.getAllStoragesAsCDataCharacterItemSlotInfoList(); // TODO: What
-                // changeJobResponse.Unk1 // TODO: its the same thing as in CDataPawnInfo
+                changeJobResponse.TrainingStatus = pawn.TrainingStatus.GetValueOrDefault(pawn.Job, new byte[64]);
                 changeJobResponse.SpSkillList = pawn.SpSkillList;
                 client.Send(changeJobResponse);
             }

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -356,6 +356,8 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new PawnJoinPartyMypawnHandler(this));
             AddHandler(new PawnPawnLostHandler(this));
             AddHandler(new PawnTrainingGetPreparetionInfoToAdviceHandler(this));
+            AddHandler(new PawnTrainingGetTrainingStatusHandler(this));
+            AddHandler(new PawnTrainingSetTrainingStatusHandler(this));
 
             AddHandler(new ProfileGetCharacterProfileHandler(this));
             AddHandler(new ProfileGetMyCharacterProfileHandler(this));

--- a/Arrowgene.Ddon.GameServer/GameStructure.cs
+++ b/Arrowgene.Ddon.GameServer/GameStructure.cs
@@ -158,7 +158,7 @@ public static class GameStructure
         // TODO: ShareRange, Likability, Unk0, Unk1
         cDataPawnInfo.ShareRange = 1;
         cDataPawnInfo.Likability = 2;
-        cDataPawnInfo.TrainingStatus = new byte[64];
+        cDataPawnInfo.TrainingStatus = pawn.TrainingStatus.GetValueOrDefault(pawn.Job, new byte[64]);
         cDataPawnInfo.Unk1 = new CData_772E80() {Unk0 = 0x7530, Unk1 = 0x3, Unk2 = 0x3, Unk3 = 0x1, Unk4 = 0x3};
         cDataPawnInfo.SpSkillList = pawn.SpSkillList;
     }

--- a/Arrowgene.Ddon.GameServer/GameStructure.cs
+++ b/Arrowgene.Ddon.GameServer/GameStructure.cs
@@ -158,7 +158,7 @@ public static class GameStructure
         // TODO: ShareRange, Likability, Unk0, Unk1
         cDataPawnInfo.ShareRange = 1;
         cDataPawnInfo.Likability = 2;
-        cDataPawnInfo.Unk0 = new byte[64];
+        cDataPawnInfo.TrainingStatus = new byte[64];
         cDataPawnInfo.Unk1 = new CData_772E80() {Unk0 = 0x7530, Unk1 = 0x3, Unk2 = 0x3, Unk3 = 0x1, Unk4 = 0x3};
         cDataPawnInfo.SpSkillList = pawn.SpSkillList;
     }

--- a/Arrowgene.Ddon.GameServer/Handler/PawnTrainingGetPreparetionInfoToAdviceHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnTrainingGetPreparetionInfoToAdviceHandler.cs
@@ -21,16 +21,43 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override void Handle(GameClient client, StructurePacket<C2SPawnTrainingGetPreparetionInfoToAdviceReq> req)
         {
             // TODO: Proper implementation
-            S2CPawnTrainingGetPreparetionInfoToAdviceRes res = new S2CPawnTrainingGetPreparetionInfoToAdviceRes();
-            // TODO: res.Unk0
-            res.PawnTrainingPreparationInfoToAdvices = client.Character.Pawns
-            .Select(pawn => new CDataPawnTrainingPreparationInfoToAdvice()
-                {
-                    PawnId = pawn.PawnId,
-                    // TODO: Unk0 and Unk1
-                })
-            .ToList();
+            S2CPawnTrainingGetPreparetionInfoToAdviceRes res = new S2CPawnTrainingGetPreparetionInfoToAdviceRes
+            {
+                // TODO: Figure out
+                Unk0 = 0,
+                PawnTrainingPreparationInfoToAdvices = client.Character.Pawns
+                    .Select(pawn => new CDataPawnTrainingPreparationInfoToAdvice()
+                    {
+                        PawnId = pawn.PawnId,
+                        // TODO: Figure out. Training lv? Training xp?
+                        Unk0 = 0,
+                        Unk1 = 0
+                    })
+                    .ToList()
+            };
             client.Send(res);
         }
+
+        // PCAP:
+        // 0x0, 0x0, 0x0, 0x0,
+        // 0x0, 0x0, 0x0, 0x0, 
+        //
+        // 0x0, 0x0, 0x0, 0x6, 
+        // 
+        // 0x0, 0x0, 0x0, 0x3,
+        // 1:
+        //  0x0, 0xDA, 0x5D, 0x4E, 
+        //  0x0, 0x0, 0x0, 0x3, 
+        //  0x0, 0x0, 0x0, 0x0,
+        // 2:
+        //  0x0, 0xDA, 0x66, 0x8D,
+        //  0x0, 0x0, 0x0, 0x3, 
+        //  0x0, 0x0, 0x0, 0x1, 
+        // 3:
+        //  0x0, 0xDA, 0xB2, 0xF3, 
+        //  0x0, 0x0, 0x0, 0x0,
+        //  0x0, 0x0, 0x0, 0x6, 
+        //
+        // padding: 0x41, 0x6, 0x6A
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/PawnTrainingGetTrainingStatusHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnTrainingGetTrainingStatusHandler.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PawnTrainingGetTrainingStatusHandler : GameStructurePacketHandler<C2SPawnTrainingGetTrainingStatusReq>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnTrainingGetTrainingStatusHandler));
+        
+        public PawnTrainingGetTrainingStatusHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override void Handle(GameClient client, StructurePacket<C2SPawnTrainingGetTrainingStatusReq> packet)
+        {
+            Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
+            S2CPawnTrainingGetTrainingStatusRes res = new S2CPawnTrainingGetTrainingStatusRes();
+            res.TrainingStatus = pawn.TrainingStatus.GetValueOrDefault(packet.Structure.Job, new byte[64]);
+            res.TrainingPoints = pawn.TrainingPoints;
+            res.AvailableTraining = pawn.AvailableTraining;
+
+            client.Send(res);
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/PawnTrainingSetTrainingStatusHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnTrainingSetTrainingStatusHandler.cs
@@ -21,6 +21,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             pawn.TrainingStatus[packet.Structure.Job] = packet.Structure.TrainingStatus;
             pawn.TrainingPoints -= packet.Structure.SpentTrainingPoints;
 
+            Server.Database.ReplacePawnTrainingStatus(pawn.PawnId, packet.Structure.Job, packet.Structure.TrainingStatus);
+            Server.Database.UpdatePawnBaseInfo(pawn);
             
             S2CPawnTrainingSetTrainingStatusRes res = new S2CPawnTrainingSetTrainingStatusRes();
             client.Send(res);

--- a/Arrowgene.Ddon.GameServer/Handler/PawnTrainingSetTrainingStatusHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnTrainingSetTrainingStatusHandler.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PawnTrainingSetTrainingStatusHandler : GameStructurePacketHandler<C2SPawnTrainingSetTrainingStatusReq>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnTrainingSetTrainingStatusHandler));
+        
+        public PawnTrainingSetTrainingStatusHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override void Handle(GameClient client, StructurePacket<C2SPawnTrainingSetTrainingStatusReq> packet)
+        {
+            Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
+            pawn.TrainingStatus[packet.Structure.Job] = packet.Structure.TrainingStatus;
+            pawn.TrainingPoints -= packet.Structure.SpentTrainingPoints;
+
+            
+            S2CPawnTrainingSetTrainingStatusRes res = new S2CPawnTrainingSetTrainingStatusRes();
+            client.Send(res);
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
@@ -1,4 +1,4 @@
-using Arrowgene.Ddon.Server.Network;
+using System.Collections.Generic;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
@@ -27,7 +27,7 @@ public class PawnPartyMember : PartyMember
         partyContextPawn.Base.HmType = Pawn.HmType;
         GameStructure.CDataContextPlayerInfo(partyContextPawn.PlayerInfo, Pawn);
         partyContextPawn.PawnReactionList = Pawn.PawnReactionList;
-        partyContextPawn.Unk0 = new byte[64];
+        partyContextPawn.TrainingStatus = new byte[64];
         partyContextPawn.SpSkillList = Pawn.SpSkillList;
         GameStructure.CDataContextResist(partyContextPawn.ResistInfo, Pawn);
         partyContextPawn.EditInfo = Pawn.EditInfo;

--- a/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
@@ -27,7 +27,7 @@ public class PawnPartyMember : PartyMember
         partyContextPawn.Base.HmType = Pawn.HmType;
         GameStructure.CDataContextPlayerInfo(partyContextPawn.PlayerInfo, Pawn);
         partyContextPawn.PawnReactionList = Pawn.PawnReactionList;
-        partyContextPawn.TrainingStatus = new byte[64];
+        partyContextPawn.TrainingStatus = Pawn.TrainingStatus.GetValueOrDefault(Pawn.Job, new byte[64]);
         partyContextPawn.SpSkillList = Pawn.SpSkillList;
         GameStructure.CDataContextResist(partyContextPawn.ResistInfo, Pawn);
         partyContextPawn.EditInfo = Pawn.EditInfo;

--- a/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
@@ -2063,6 +2063,8 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                     SpSkillLv = myPawnCsvData.SpSkillSlot3Lv
                 }
             }.Where(spSkill => spSkill.SpSkillId != 0).ToList();
+            pawn.TrainingPoints = int.MaxValue;
+            pawn.AvailableTraining = uint.MaxValue;
             return pawn;
         }
 

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -362,6 +362,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SPawnJoinPartyMypawnReq.Serializer());
             Create(new C2SPawnPawnLostReq.Serializer());
             Create(new C2SPawnTrainingGetPreparetionInfoToAdviceReq.Serializer());
+            Create(new C2SPawnTrainingGetTrainingStatusReq.Serializer());
+            Create(new C2SPawnTrainingSetTrainingStatusReq.Serializer());
             Create(new C2SProfileGetCharacterProfileReq.Serializer());
             Create(new C2SProfileGetMyCharacterProfileReq.Serializer());
 
@@ -644,6 +646,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CPawnJoinPartyMypawnRes.Serializer());
             Create(new S2CPawnPawnLostRes.Serializer());
             Create(new S2CPawnTrainingGetPreparetionInfoToAdviceRes.Serializer());
+            Create(new S2CPawnTrainingGetTrainingStatusRes.Serializer());
+            Create(new S2CPawnTrainingSetTrainingStatusRes.Serializer());
             Create(new S2CProfileGetCharacterProfileRes.Serializer());
             Create(new S2CProfileGetMyCharacterProfileRes.Serializer());
 

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnTrainingGetTrainingStatusReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnTrainingGetTrainingStatusReq.cs
@@ -1,0 +1,32 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPawnTrainingGetTrainingStatusReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PAWN_TRAINING_GET_TRAINING_STATUS_REQ;
+
+        public uint PawnId { get; set; }
+        public JobId Job { get; set;}
+
+        public class Serializer : PacketEntitySerializer<C2SPawnTrainingGetTrainingStatusReq>
+        {
+            public override void Write(IBuffer buffer, C2SPawnTrainingGetTrainingStatusReq obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteByte(buffer, (byte) obj.Job);
+            }
+
+            public override C2SPawnTrainingGetTrainingStatusReq Read(IBuffer buffer)
+            {
+                C2SPawnTrainingGetTrainingStatusReq obj = new C2SPawnTrainingGetTrainingStatusReq();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.Job = (JobId) ReadByte(buffer);
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnTrainingSetTrainingStatusReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnTrainingSetTrainingStatusReq.cs
@@ -1,0 +1,43 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPawnTrainingSetTrainingStatusReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PAWN_TRAINING_SET_TRAINING_STATUS_REQ;
+
+        public C2SPawnTrainingSetTrainingStatusReq()
+        {
+            TrainingStatus = new byte[64];
+        }
+
+        public uint PawnId { get; set; }
+        public JobId Job { get; set; }
+        public byte[] TrainingStatus { get; set; }
+        public uint SpentTrainingPoints { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SPawnTrainingSetTrainingStatusReq>
+        {
+            public override void Write(IBuffer buffer, C2SPawnTrainingSetTrainingStatusReq obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteByte(buffer, (byte) obj.Job);
+                WriteByteArray(buffer, obj.TrainingStatus);
+                WriteUInt32(buffer, obj.SpentTrainingPoints);
+            }
+
+            public override C2SPawnTrainingSetTrainingStatusReq Read(IBuffer buffer)
+            {
+                C2SPawnTrainingSetTrainingStatusReq obj = new C2SPawnTrainingSetTrainingStatusReq();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.Job = (JobId) ReadByte(buffer);
+                obj.TrainingStatus = ReadByteArray(buffer, 64);
+                obj.SpentTrainingPoints = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CJobChangePawnJobRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CJobChangePawnJobRes.cs
@@ -18,7 +18,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             LearnNormalSkillParamList=new List<CDataLearnNormalSkillParam>();
             EquipJobItemList=new List<CDataEquipJobItem>();
             Unk0=new CDataJobChangeJobResUnk0();
-            Unk1 = new byte[64];
+            TrainingStatus = new byte[64];
             SpSkillList = new List<CDataSpSkill>();
         }
 
@@ -30,7 +30,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
         public List<CDataLearnNormalSkillParam> LearnNormalSkillParamList { get; set; }
         public List<CDataEquipJobItem> EquipJobItemList { get; set; }
         public CDataJobChangeJobResUnk0 Unk0 { get; set; }
-        public byte[] Unk1 { get; set; }
+        public byte[] TrainingStatus { get; set; }
         public List<CDataSpSkill> SpSkillList { get; set; }
 
 
@@ -47,7 +47,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 WriteEntityList<CDataLearnNormalSkillParam>(buffer, obj.LearnNormalSkillParamList);
                 WriteEntityList<CDataEquipJobItem>(buffer, obj.EquipJobItemList);
                 WriteEntity<CDataJobChangeJobResUnk0>(buffer, obj.Unk0);
-                WriteByteArray(buffer, obj.Unk1);
+                WriteByteArray(buffer, obj.TrainingStatus);
                 WriteEntityList<CDataSpSkill>(buffer, obj.SpSkillList);
             }
 
@@ -63,7 +63,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 obj.LearnNormalSkillParamList = ReadEntityList<CDataLearnNormalSkillParam>(buffer);
                 obj.EquipJobItemList = ReadEntityList<CDataEquipJobItem>(buffer);
                 obj.Unk0 = ReadEntity<CDataJobChangeJobResUnk0>(buffer);
-                obj.Unk1 = ReadByteArray(buffer, 64);
+                obj.TrainingStatus = ReadByteArray(buffer, 64);
                 obj.SpSkillList = ReadEntityList<CDataSpSkill>(buffer);
                 return obj;
             }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnTrainingGetTrainingStatusRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnTrainingGetTrainingStatusRes.cs
@@ -1,0 +1,40 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPawnTrainingGetTrainingStatusRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PAWN_TRAINING_GET_TRAINING_STATUS_RES;
+
+        public S2CPawnTrainingGetTrainingStatusRes()
+        {
+            TrainingStatus = new byte[64];
+        }
+
+        public byte[] TrainingStatus { get; set; }
+        public uint TrainingPoints { get; set; }
+        public uint AvailableTraining { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPawnTrainingGetTrainingStatusRes>
+        {
+            public override void Write(IBuffer buffer, S2CPawnTrainingGetTrainingStatusRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteByteArray(buffer, obj.TrainingStatus);
+                WriteUInt32(buffer, obj.TrainingPoints);
+                WriteUInt32(buffer, obj.AvailableTraining);
+            }
+
+            public override S2CPawnTrainingGetTrainingStatusRes Read(IBuffer buffer)
+            {
+                S2CPawnTrainingGetTrainingStatusRes obj = new S2CPawnTrainingGetTrainingStatusRes();
+                ReadServerResponse(buffer, obj);
+                obj.TrainingStatus = ReadByteArray(buffer, 64);
+                obj.TrainingPoints = ReadUInt32(buffer);
+                obj.AvailableTraining = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnTrainingSetTrainingStatusRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnTrainingSetTrainingStatusRes.cs
@@ -1,0 +1,25 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPawnTrainingSetTrainingStatusRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PAWN_TRAINING_SET_TRAINING_STATUS_RES;
+
+        public class Serializer : PacketEntitySerializer<S2CPawnTrainingSetTrainingStatusRes>
+        {
+            public override void Write(IBuffer buffer, S2CPawnTrainingSetTrainingStatusRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CPawnTrainingSetTrainingStatusRes Read(IBuffer buffer)
+            {
+                S2CPawnTrainingSetTrainingStatusRes obj = new S2CPawnTrainingSetTrainingStatusRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartyContextPawn.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartyContextPawn.cs
@@ -10,7 +10,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             Base = new CDataContextBase();
             PlayerInfo = new CDataContextPlayerInfo();
             PawnReactionList = new List<CDataPawnReaction>();
-            Unk0 = new byte[64];
+            TrainingStatus = new byte[64];
             SpSkillList = new List<CDataSpSkill>();
             ResistInfo = new CDataContextResist();
             EditInfo = new CDataEditInfo();
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public CDataContextBase Base { get; set; }
         public CDataContextPlayerInfo PlayerInfo { get; set; }
         public List<CDataPawnReaction> PawnReactionList { get; set; }
-        public byte[] Unk0 { get; set; }
+        public byte[] TrainingStatus { get; set; }
         public List<CDataSpSkill> SpSkillList { get; set; }
         public CDataContextResist ResistInfo { get; set; }
         public CDataEditInfo EditInfo { get; set; }
@@ -31,7 +31,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 WriteEntity<CDataContextBase>(buffer, obj.Base);
                 WriteEntity<CDataContextPlayerInfo>(buffer, obj.PlayerInfo);
                 WriteEntityList<CDataPawnReaction>(buffer, obj.PawnReactionList);
-                WriteByteArray(buffer, obj.Unk0);
+                WriteByteArray(buffer, obj.TrainingStatus);
                 WriteEntityList<CDataSpSkill>(buffer, obj.SpSkillList);
                 WriteEntity<CDataContextResist>(buffer, obj.ResistInfo);
                 WriteEntity<CDataEditInfo>(buffer, obj.EditInfo);
@@ -43,7 +43,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 obj.Base = ReadEntity<CDataContextBase>(buffer);
                 obj.PlayerInfo = ReadEntity<CDataContextPlayerInfo>(buffer);
                 obj.PawnReactionList = ReadEntityList<CDataPawnReaction>(buffer);
-                obj.Unk0 = ReadByteArray(buffer, 64);
+                obj.TrainingStatus = ReadByteArray(buffer, 64);
                 obj.SpSkillList = ReadEntityList<CDataSpSkill>(buffer);
                 obj.ResistInfo = ReadEntity<CDataContextResist>(buffer);
                 obj.EditInfo = ReadEntity<CDataEditInfo>(buffer);

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnInfo.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnInfo.cs
@@ -21,7 +21,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             ContextSkillList = new List<CDataContextAcquirementData>();
             ContextAbilityList = new List<CDataContextAcquirementData>();
             ExtendParam = new CDataOrbGainExtendParam();
-            Unk0 = new byte[64];
+            TrainingStatus = new byte[64];
             Unk1 = new CData_772E80();
             SpSkillList = new List<CDataSpSkill>();
         }
@@ -55,7 +55,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public byte PawnType { get; set; }
         public byte ShareRange { get; set; }
         public uint Likability { get; set; }
-        public byte[] Unk0 { get; set; }
+        public byte[] TrainingStatus { get; set; }
         public CData_772E80 Unk1 { get; set; }
         public List<CDataSpSkill> SpSkillList { get; set; }
 
@@ -92,7 +92,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 WriteByte(buffer, obj.PawnType);
                 WriteByte(buffer, obj.ShareRange);
                 WriteUInt32(buffer, obj.Likability);
-                WriteByteArray(buffer, obj.Unk0);
+                WriteByteArray(buffer, obj.TrainingStatus);
                 WriteEntity<CData_772E80>(buffer, obj.Unk1);
                 WriteEntityList<CDataSpSkill>(buffer, obj.SpSkillList);
             }
@@ -129,7 +129,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 obj.PawnType = ReadByte(buffer);
                 obj.ShareRange = ReadByte(buffer);
                 obj.Likability = ReadUInt32(buffer);
-                obj.Unk0 = ReadByteArray(buffer, 64);
+                obj.TrainingStatus = ReadByteArray(buffer, 64);
                 obj.Unk1 = ReadEntity<CData_772E80>(buffer);
                 obj.SpSkillList = ReadEntityList<CDataSpSkill>(buffer);
                 return obj ;

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnList.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnList.cs
@@ -18,7 +18,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public CDataPawnListData PawnListData { get; set; }
         public uint Unk0 { get; set; }
         public uint Unk1 { get; set; }
-        public uint Unk2 { get; set; }
+        public uint Unk2 { get; set; } // CDataPawnTrainingPreparationInfoToAdvice.Unk0
 
         public class Serializer : EntitySerializer<CDataPawnList>
         {

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnTrainingPreparationInfoToAdvice.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnTrainingPreparationInfoToAdvice.cs
@@ -5,7 +5,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
     public class CDataPawnTrainingPreparationInfoToAdvice
     {
         public uint PawnId { get; set; }
-        public uint Unk0 { get; set; }
+        public uint Unk0 { get; set; } // CDataPawnList.Unk2
         public uint Unk1 { get; set; }    
     
         public class Serializer : EntitySerializer<CDataPawnTrainingPreparationInfoToAdvice>

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 
@@ -30,6 +31,7 @@ namespace Arrowgene.Ddon.Shared.Model
                     new CDataPawnCraftSkill() {Type = 10, Level = 0}
                 }
             };
+            TrainingStatus = new Dictionary<JobId, byte[]>();
         }
         
         public Pawn(uint ownerCharacterId):this()
@@ -55,5 +57,9 @@ namespace Arrowgene.Ddon.Shared.Model
         public List<CDataPawnReaction> PawnReactionList { get; set; }
         public List<CDataSpSkill> SpSkillList { get; set; }
         public CDataPawnCraftData CraftData { get; set; }
+
+        public Dictionary<JobId, byte[]> TrainingStatus { get; set; }
+        public uint TrainingPoints { get; set; } // Training xp?
+        public uint AvailableTraining { get; set; } // Training lv?
     }
 }


### PR DESCRIPTION
Allow training pawns, persisting in the database. All possible trainings are unlocked from the beginning with points enough to train again and again.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
