### PR TITLE
Update Shop.json for Season 2 region.

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/Shop.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/Shop.json
@@ -12308,5 +12308,1245 @@
                 }
             ]
         }
+    },
+    {
+        "ShopId": 103,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9000,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 8,
+                    "ItemId": 9001,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 9,
+                    "ItemId": 9002,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 10,
+                    "ItemId": 9003,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 11,
+                    "ItemId": 9004,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 12,
+                    "ItemId": 8999,
+                    "Price": 24000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 200,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 194,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 8,
+                    "ItemId": 14737,
+                    "Price": 100,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 9,
+                    "ItemId": 14742,
+                    "Price": 14500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 10,
+                    "ItemId": 14747,
+                    "Price": 32000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 11,
+                    "ItemId": 14752,
+                    "Price": 64800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 12,
+                    "ItemId": 14757,
+                    "Price": 100800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 13,
+                    "ItemId": 14762,
+                    "Price": 151300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 202,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 3,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 9198,
+                    "Price": 4000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9202,
+                    "Price": 4000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 9257,
+                    "Price": 300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9258,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 9259,
+                    "Price": 300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9260,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9261,
+                    "Price": 300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9262,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 8,
+                    "ItemId": 9263,
+                    "Price": 300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 9,
+                    "ItemId": 9264,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 10,
+                    "ItemId": 9265,
+                    "Price": 300,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 11,
+                    "ItemId": 9266,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 12,
+                    "ItemId": 11725,
+                    "Price": 500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 13,
+                    "ItemId": 11728,
+                    "Price": 500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 14,
+                    "ItemId": 11729,
+                    "Price": 500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 15,
+                    "ItemId": 11732,
+                    "Price": 500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 16,
+                    "ItemId": 11736,
+                    "Price": 500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 17,
+                    "ItemId": 11731,
+                    "Price": 1500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 18,
+                    "ItemId": 11726,
+                    "Price": 1500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 19,
+                    "ItemId": 11730,
+                    "Price": 1500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 20,
+                    "ItemId": 11727,
+                    "Price": 2500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 21,
+                    "ItemId": 11733,
+                    "Price": 2500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 22,
+                    "ItemId": 11734,
+                    "Price": 2500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 23,
+                    "ItemId": 11735,
+                    "Price": 2500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 24,
+                    "ItemId": 11737,
+                    "Price": 3500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 25,
+                    "ItemId": 11738,
+                    "Price": 3500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 26,
+                    "ItemId": 11739,
+                    "Price": 3500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 27,
+                    "ItemId": 25738,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 28,
+                    "ItemId": 25768,
+                    "Price": 2500,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 29,
+                    "ItemId": 9294,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 30,
+                    "ItemId": 9296,
+                    "Price": 1000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 195,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 197,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 196,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 198,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 201,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
+    },
+    {
+        "ShopId": 199,
+        "Data": {
+            "Unk0": 0,
+            "Unk1": 0,
+            "WalletType": 1,
+            "GoodsParamList": [
+                {
+                    "Index": 0,
+                    "ItemId": 7554,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 1,
+                    "ItemId": 9363,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 2,
+                    "ItemId": 41,
+                    "Price": 2000,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 3,
+                    "ItemId": 9375,
+                    "Price": 800,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 4,
+                    "ItemId": 55,
+                    "Price": 30,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 5,
+                    "ItemId": 9401,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 6,
+                    "ItemId": 9402,
+                    "Price": 600,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                },
+                {
+                    "Index": 7,
+                    "ItemId": 9403,
+                    "Price": 1200,
+                    "Stock": 255,
+                    "Unk4": false,
+                    "Unk5": 0,
+                    "Unk6": 0,
+                    "Unk7": []
+                }
+            ]
+        }
     }
 ]


### PR DESCRIPTION
- Added items to all shop npcs in Season 2 areas.

Areas List: Expedition Garrison, Protector's Retreat, Dana, Manun Village, Hollow of Beginnings: Gathering Area, Morfaul, Glyndwr, Tower of Ivanos.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
