### PR TITLE
Save Rewards in the db

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -496,3 +496,16 @@ CREATE TABLE IF NOT EXISTS "ddon_bazaar_exhibition" (
     "expire"          DATETIME                          NOT NULL,
     FOREIGN KEY("character_id") REFERENCES "ddon_character"("character_id")
 );
+
+CREATE TABLE IF NOT EXISTS "ddon_reward_box" (
+	"uniq_reward_id"	INTEGER NOT NULL,
+	"character_common_id"	INTEGER NOT NULL,
+	"quest_id"	INTEGER NOT NULL,
+	"num_random_rewards"	INTEGER NOT NULL,
+	"random_reward0_index"	INTEGER NOT NULL,
+	"random_reward1_index"	INTEGER NOT NULL,
+	"random_reward2_index"	INTEGER NOT NULL,
+	"random_reward3_index"	INTEGER NOT NULL,
+	PRIMARY KEY("uniq_reward_id" AUTOINCREMENT),
+	CONSTRAINT "fk_ddon_reward_box_character_common_id" FOREIGN KEY("character_common_id") REFERENCES "ddon_character_common"("character_common_id") ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -1,7 +1,9 @@
+using System.Collections;
 using System.Collections.Generic;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
 
 namespace Arrowgene.Ddon.Database
 {
@@ -178,5 +180,10 @@ namespace Arrowgene.Ddon.Database
         List<BazaarExhibition> FetchCharacterBazaarExhibitions(uint characterId);
         List<BazaarExhibition> SelectActiveBazaarExhibitionsByItemIdExcludingOwn(uint itemId, uint excludedCharacterId);
         List<BazaarExhibition> SelectActiveBazaarExhibitionsByItemIdsExcludingOwn(List<uint> itemIds, uint excludedCharacterId);
+
+        // Rewards
+        bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards);
+        bool DeleteBoxRewardItem(uint commonId, uint uniqId);
+        List<QuestBoxRewards> SelectBoxRewardItems(uint commonId);
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection.Metadata.Ecma335;
+using System.Text.RegularExpressions;
+using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+
+        private readonly int MAX_RANDOM_REWARDS = 4;
+        protected static readonly string[] RewardBoxFields = new string[]
+        {
+            /* uniq_reward_id */  "character_common_id", "quest_id", "num_random_rewards", "random_reward0_index", "random_reward1_index", "random_reward2_index", "random_reward3_index"
+        };
+
+        private readonly string SqlInsertRewardBoxItems = $"INSERT INTO \"ddon_reward_box\" ({BuildQueryField(RewardBoxFields)}) VALUES ({BuildQueryInsert(RewardBoxFields)});";
+        private readonly string SqlSelectRewardBoxItems = $"SELECT \"uniq_reward_id\", {BuildQueryField(RewardBoxFields)} FROM \"ddon_reward_box\" WHERE \"character_common_id\" = @character_common_id;";
+        private readonly string SqlDeleteRewardBoxItem = $"DELETE FROM \"ddon_reward_box\" WHERE \"uniq_reward_id\"=@uniq_reward_id AND \"character_common_id\"=@character_common_id;";
+
+        public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards)
+        {
+            using TCon connection = OpenNewConnection();
+            return InsertBoxRewardItems(connection, commonId, rewards);
+        }
+
+        public bool InsertBoxRewardItems(TCon conn, uint commonId, QuestBoxRewards rewards)
+        {
+            return ExecuteNonQuery(conn, SqlInsertRewardBoxItems, command =>
+            {
+                AddParameter(command, "character_common_id", commonId);
+                AddParameter(command, "quest_id", (uint) rewards.QuestId);
+                AddParameter(command, "num_random_rewards", rewards.NumRandomRewards);
+
+                int i;
+                for(i = 0; i < rewards.NumRandomRewards; i++)
+                {
+                    AddParameter(command, $"random_reward{i}_index", rewards.RandomRewardIndices[i]);
+                }
+
+                for (; i < MAX_RANDOM_REWARDS; i++)
+                {
+                    AddParameter(command, $"random_reward{i}_index", 0);
+                }
+            }, out long autoIncrement) == 1;
+        }
+
+        public List<QuestBoxRewards> SelectBoxRewardItems(uint commonId)
+        {
+            using TCon connection = OpenNewConnection();
+            return SelectBoxRewardItems(connection, commonId);
+        }
+
+        public List<QuestBoxRewards> SelectBoxRewardItems(TCon conn, uint commonId)
+        {
+            List<QuestBoxRewards> results = new List<QuestBoxRewards>();
+
+            ExecuteInTransaction(conn =>
+            {
+                ExecuteReader(conn, SqlSelectRewardBoxItems,
+                    command => {
+                        AddParameter(command, "@character_common_id", commonId);
+                    }, reader => {
+                        while (reader.Read())
+                        {
+                            var result = ReadDatabaseQuestBoxReward(reader);
+                            results.Add(result);
+                        }
+                    });
+            });
+
+            return results;
+        }
+
+        public bool DeleteBoxRewardItem(uint commonId, uint uniqId)
+        {
+            using TCon connection = OpenNewConnection();
+            return DeleteBoxRewardItem(connection, commonId, uniqId);
+        }
+
+        public bool DeleteBoxRewardItem(TCon conn, uint commonId, uint uniqId)
+        {
+            return ExecuteNonQuery(conn, SqlDeleteRewardBoxItem, command =>
+            {
+                AddParameter(command, "@character_common_id", commonId);
+                AddParameter(command, "@uniq_reward_id", uniqId);
+            }) == 1;
+        }
+
+        private QuestBoxRewards ReadDatabaseQuestBoxReward(TReader reader)
+        {
+            QuestBoxRewards obj = new QuestBoxRewards();
+            obj.UniqRewardId = GetUInt32(reader, "uniq_reward_id");
+            obj.CharacterCommonId = GetUInt32(reader, "character_common_id");
+            obj.QuestId = (QuestId) GetUInt32(reader, "quest_id");
+            obj.NumRandomRewards = GetInt32(reader, "num_random_rewards");
+
+            for (int i = 0; i < obj.NumRandomRewards; i++)
+            {
+                obj.RandomRewardIndices.Add(GetInt32(reader, $"random_reward{i}_index"));
+            }
+
+            return obj;
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -1,0 +1,45 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.GameServer.Quests;
+using Arrowgene.Logging;
+using System.Collections.Generic;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model;
+
+namespace Arrowgene.Ddon.GameServer.Characters
+{
+    public class RewardManager
+    {
+        private readonly int MAX_REWARD_BOX_RESULTS = 100;
+
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(RewardManager));
+
+        private readonly DdonGameServer _Server;
+        public RewardManager(DdonGameServer server)
+        {
+            _Server = server;
+        }
+
+        public bool AddQuestRewards(GameClient client, Quest quest)
+        {
+            var rewards = quest.GenerateBoxRewards();
+
+            var currentRewards = GetQuestBoxRewards(client);
+            if (currentRewards.Count >= MAX_REWARD_BOX_RESULTS)
+            {
+                return false;
+            }
+
+            return _Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards);
+        }
+
+        public List<QuestBoxRewards> GetQuestBoxRewards(GameClient client)
+        {
+            return _Server.Database.SelectBoxRewardItems(client.Character.CommonId);
+        }
+
+        public bool DeleteQuestBoxReward(GameClient client, uint uniqId)
+        {
+            return _Server.Database.DeleteBoxRewardItem(client.Character.CommonId, uniqId);
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -69,6 +69,7 @@ namespace Arrowgene.Ddon.GameServer
             WalletManager = new WalletManager(database);
             CharacterManager = new CharacterManager(this);
             BazaarManager = new BazaarManager(this);
+            RewardManager = new RewardManager(this);
 
             // Orb Management is slightly complex and requires updating fields across multiple systems
             OrbUnlockManager = new OrbUnlockManager(database, WalletManager, JobManager, CharacterManager);
@@ -91,6 +92,7 @@ namespace Arrowgene.Ddon.GameServer
         public CharacterManager CharacterManager { get; }
         public EquipManager EquipManager { get; }
         public BazaarManager BazaarManager { get; }
+        public RewardManager RewardManager { get; }
         public GameRouter Router { get; }
 
         public ChatLogHandler ChatLogHandler { get; }
@@ -396,7 +398,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new QuestGetPriorityQuestHandler(this));
             AddHandler(new QuestGetQuestCompletedListHandler(this));
             AddHandler(new QuestGetQuestPartyBonusListHandler(this));
-            AddHandler(new QuestGetRewardBoxHandler(this));
+            AddHandler(new QuestGetRewardBoxListHandler(this));
             AddHandler(new QuestGetRewardBoxItemHandler(this));
             AddHandler(new QuestGetSetQuestInfoListHandler(this));
             AddHandler(new QuestGetSetQuestListHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
@@ -1,6 +1,7 @@
 using Arrowgene.Buffers;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Dump;
+using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -10,12 +11,15 @@ using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using Arrowgene.Networking.Tcp.Consumer.BlockingQueueConsumption;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
     public class QuestGetRewardBoxItemHandler : GameRequestPacketHandler<C2SQuestGetRewardBoxItemReq, S2CQuestGetRewardBoxItemRes>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(QuestGetRewardBoxItemHandler));
+
+
 
         public QuestGetRewardBoxItemHandler(DdonGameServer server) : base(server)
         {
@@ -25,25 +29,28 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             // client.Send(GameFull.Dump_902);
 
+            var questBoxRewards = Server.RewardManager.GetQuestBoxRewards(client);
+
             var rewardIndex = packet.ListNo;
-            if (rewardIndex == 0 || rewardIndex > client.Character.QuestRewards.Count)
+            if (rewardIndex == 0 || rewardIndex > questBoxRewards.Count)
             {
                 Logger.Error($"Illegal reward request sent to server.");
                 return new S2CQuestGetRewardBoxItemRes() { Error = 1};
             }
 
             // Make zero based index
-            var boxRewards = client.Character.QuestRewards[(int)(rewardIndex - 1)];
+            var questBoxReward = questBoxRewards[(int)(rewardIndex - 1)];
+            var rewards = Quest.AsCDataRewardBoxItems(questBoxReward);
 
             S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
             {
                 UpdateType = 0
             };
 
+
             foreach (var boxReward in packet.GetRewardBoxItemList)
             {
-                var reward = boxRewards.Rewards[boxReward.UID];
-
+                var reward = rewards.Single(x => x.UID == boxReward.UID);
                 if (Server.ItemManager.IsItemWalletPoint(reward.ItemId))
                 {
                     (WalletType walletType, uint amount) = Server.ItemManager.ItemToWalletPoint(reward.ItemId);
@@ -58,8 +65,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             client.Send(updateCharacterItemNtc);
 
-            // Remove this reward from the list
-            client.Character.QuestRewards.RemoveAt((int)(rewardIndex - 1));
+            Server.RewardManager.DeleteQuestBoxReward(client, questBoxReward.UniqRewardId);
 
             return new S2CQuestGetRewardBoxItemRes();
         }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -83,7 +83,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     {
                         foreach (var memberClient in client.Party.Clients) 
                         {
-                            memberClient.Character.QuestRewards.Add(quest.GetBoxRewards());
+                            Server.RewardManager.AddQuestRewards(memberClient, quest);
                         }
                     }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -144,6 +144,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
         private void ParseRewards(QuestAssetData assetData, JsonElement quest)
         {
+            uint randomRewards = 0;
             foreach (var reward in quest.GetProperty("rewards").EnumerateArray())
             {
                 var rewardType = reward.GetProperty("type").GetString();
@@ -160,6 +161,15 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         QuestRewardItem rewardItem = null;
                         if (questRewardType == QuestRewardType.Random)
                         {
+                            if (randomRewards >= 4)
+                            {
+                                Logger.Error("Client only supports a maximum of 4 random rewards per quest. Skipping.");
+                                continue;
+                            }
+
+                            // Keep track of random rewards for the quest
+                            randomRewards += 1;
+
                             rewardItem = new QuestRandomRewardItem();
                             foreach (var item in reward.GetProperty("loot_pool").EnumerateArray())
                             {
@@ -189,13 +199,13 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                             rewardItem = new QuestFixedRewardItem()
                             {
                                 LootPool = new List<LootPoolItem>()
-                                        {
-                                            new FixedLootPoolItem()
-                                            {
-                                                ItemId = item.GetProperty("item_id").GetUInt32(),
-                                                Num = item.GetProperty("num").GetUInt16(),
-                                            }
-                                        }
+                                {
+                                    new FixedLootPoolItem()
+                                    {
+                                        ItemId = item.GetProperty("item_id").GetUInt32(),
+                                        Num = item.GetProperty("num").GetUInt16(),
+                                    }
+                                }
                             };
                         }
                         else

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -410,6 +410,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SQuestDeliverItemReq.Serializer());
             Create(new C2SQuestQuestProgressReq.Serializer());
             Create(new C2SQuestDecideDeliveryItemReq.Serializer());
+            Create(new C2SQuestGetRewardBoxListReq.Serializer());
 
             Create(new C2SServerGameTimeGetBaseInfoReq.Serializer());
             Create(new C2SServerGetRealTimeReq.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetRewardBoxListReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetRewardBoxListReq.cs
@@ -1,0 +1,22 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SQuestGetRewardBoxListReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_QUEST_GET_REWARD_BOX_LIST_REQ;
+
+        public class Serializer : PacketEntitySerializer<C2SQuestGetRewardBoxListReq>
+        {
+            public override void Write(IBuffer buffer, C2SQuestGetRewardBoxListReq obj)
+            {
+            }
+
+            public override C2SQuestGetRewardBoxListReq Read(IBuffer buffer)
+            {
+                return new C2SQuestGetRewardBoxListReq();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Character.cs
+++ b/Arrowgene.Ddon.Shared/Model/Character.cs
@@ -37,7 +37,6 @@ namespace Arrowgene.Ddon.Shared.Model
             OnlineStatus = OnlineStatus.Offline;
 
             PriorityQuests = new List<QuestId>();
-            QuestRewards = new List<QuestBoxRewards>();
         }
 
         public int AccountId { get; set; }
@@ -76,7 +75,6 @@ namespace Arrowgene.Ddon.Shared.Model
         public uint LastEnteredShopId { get; set; }
 
         public List<QuestId> PriorityQuests { get; set; }
-        public List<QuestBoxRewards> QuestRewards { get; set; }
 
         public Pawn PawnBySlotNo(byte SlotNo)
         {

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
@@ -1,10 +1,7 @@
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Arrowgene.Ddon.Shared.Model.Quest
 {
@@ -96,9 +93,15 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
     public class QuestRandomRewardItem : QuestRewardItem
     {
+        public int ItemIndex { get; private set; }
+
         public QuestRandomRewardItem() : base(QuestRewardType.Random)
         {
+        }
 
+        public QuestRandomRewardItem(int itemIndex) : base(QuestRewardType.Random)
+        {
+            ItemIndex = itemIndex;
         }
 
         public override List<CDataRewardBoxItem> AsCDataRewardBoxItems()
@@ -109,11 +112,10 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             };
         }
 
-        private CDataRewardBoxItem AsCDataRewardBoxItem()
+        public CDataRewardBoxItem AsCDataRewardBoxItem()
         {
-            var itemIndex = Roll();
-            var item = LootPool[itemIndex];
-
+            
+            var item = LootPool[ItemIndex];
             return new CDataRewardBoxItem()
             {
                 ItemId = item.ItemId,
@@ -122,7 +124,24 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             };
         }
 
-        private int Roll()
+        public CDataRewardBoxItem AsCDataRewardBoxItem(int index)
+        {
+            var item = LootPool[index];
+            return new CDataRewardBoxItem()
+            {
+                ItemId = item.ItemId,
+                Num = item.Num,
+                Type = (byte)RewardType
+            };
+        }
+
+        public int Roll()
+        {
+            ItemIndex = RollInternal();
+            return ItemIndex;
+        }
+
+        private int RollInternal()
         {
             Random rnd = new Random();
             double target = rnd.NextDouble();
@@ -151,14 +170,15 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
     public class QuestBoxRewards
     {
+        public uint UniqRewardId { get; set; }
+        public uint CharacterCommonId { get; set; }
+        public QuestId QuestId { get; set; }
+        public int NumRandomRewards { get; set; }
+        public List<int> RandomRewardIndices { get; set; }
+
         public QuestBoxRewards()
         {
-            // Rewards = new List<CDataRewardBoxItem>();
-            Rewards = new Dictionary<string, CDataRewardBoxItem>();
+            RandomRewardIndices = new List<int>();
         }
-
-        public QuestId QuestId { get; set; }
-        // public List<CDataRewardBoxItem> Rewards { get; set; }
-        public Dictionary<string, CDataRewardBoxItem> Rewards { get; set; }
     }
 }


### PR DESCRIPTION
- Save unclaimed rewards in the database.
- Limit up to 100 items stored per character.
- Add check for more than 4 random rewards for a quest in the asset
  deserializer.
- Added a req packet for the box list handler and changed the parent
  type.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
