### PR TITLE
Allow having different pawn SP skills equipped per job

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -395,9 +395,10 @@ CREATE TABLE IF NOT EXISTS ddon_pawn_reaction
 CREATE TABLE IF NOT EXISTS ddon_sp_skill
 (
     "pawn_id"     INTEGER  NOT NULL,
+    "job"         SMALLINT NOT NULL,
     "sp_skill_id" SMALLINT NOT NULL,
     "sp_skill_lv" SMALLINT NOT NULL,
-    CONSTRAINT pk_ddon_sp_skill PRIMARY KEY (pawn_id, sp_skill_id),
+    CONSTRAINT pk_ddon_sp_skill PRIMARY KEY (pawn_id, job, sp_skill_id),
     CONSTRAINT fk_sp_skill_pawn_id FOREIGN KEY ("pawn_id") REFERENCES ddon_pawn ("pawn_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -52,8 +52,8 @@ namespace Arrowgene.Ddon.Database
         bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);
 
         // Pawn Sp Skills
-        bool InsertSpSkill(uint pawnId, CDataSpSkill spSkill);
-        bool DeleteSpSkill(uint pawnId, byte spSkillId);
+        bool InsertSpSkill(uint pawnId, JobId job, CDataSpSkill spSkill);
+        bool DeleteSpSkill(uint pawnId, JobId job, byte spSkillId);
 
         // CharacterJobData
         bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData);

--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -140,7 +140,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 changeJobResponse.Unk0.Unk0 = (byte) jobId;
                 // changeJobResponse.Unk0.Unk1 = pawn.Storage.getAllStoragesAsCDataCharacterItemSlotInfoList(); // TODO: What
                 changeJobResponse.TrainingStatus = pawn.TrainingStatus.GetValueOrDefault(pawn.Job, new byte[64]);
-                changeJobResponse.SpSkillList = pawn.SpSkillList;
+                changeJobResponse.SpSkillList = pawn.SpSkills.GetValueOrDefault(pawn.Job, new List<CDataSpSkill>());
                 client.Send(changeJobResponse);
             }
             else

--- a/Arrowgene.Ddon.GameServer/GameStructure.cs
+++ b/Arrowgene.Ddon.GameServer/GameStructure.cs
@@ -160,7 +160,7 @@ public static class GameStructure
         cDataPawnInfo.Likability = 2;
         cDataPawnInfo.TrainingStatus = pawn.TrainingStatus.GetValueOrDefault(pawn.Job, new byte[64]);
         cDataPawnInfo.Unk1 = new CData_772E80() {Unk0 = 0x7530, Unk1 = 0x3, Unk2 = 0x3, Unk3 = 0x1, Unk4 = 0x3};
-        cDataPawnInfo.SpSkillList = pawn.SpSkillList;
+        cDataPawnInfo.SpSkillList = pawn.SpSkills.GetValueOrDefault(pawn.Job, new List<CDataSpSkill>());
     }
 
     public static void CDataCharacterLevelParam(CDataCharacterLevelParam characterLevelParam, CharacterCommon character)

--- a/Arrowgene.Ddon.GameServer/Handler/PawnSpSkillGetActiveSkillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnSpSkillGetActiveSkillHandler.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
@@ -19,7 +21,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
             S2CPawnSpSkillGetActiveSkillRes res = new S2CPawnSpSkillGetActiveSkillRes();
-            res.SpSkillList = pawn.SpSkillList;
+            res.SpSkillList = pawn.SpSkills.GetValueOrDefault(packet.Structure.JobId, new List<CDataSpSkill>());
             res.ActiveSpSkillSlots = 3; // Value taken from the tutorial picture
             client.Send(res);
         }

--- a/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PawnPartyMember.cs
@@ -28,7 +28,7 @@ public class PawnPartyMember : PartyMember
         GameStructure.CDataContextPlayerInfo(partyContextPawn.PlayerInfo, Pawn);
         partyContextPawn.PawnReactionList = Pawn.PawnReactionList;
         partyContextPawn.TrainingStatus = Pawn.TrainingStatus.GetValueOrDefault(Pawn.Job, new byte[64]);
-        partyContextPawn.SpSkillList = Pawn.SpSkillList;
+        partyContextPawn.SpSkillList = Pawn.SpSkills.GetValueOrDefault(Pawn.Job, new List<CDataSpSkill>());
         GameStructure.CDataContextResist(partyContextPawn.ResistInfo, Pawn);
         partyContextPawn.EditInfo = Pawn.EditInfo;
 
@@ -50,7 +50,7 @@ public class PawnPartyMember : PartyMember
         GameStructure.CDataContextPlayerInfo(partyContextPawn.PlayerInfo, Pawn);
         partyContextPawn.PawnReactionList = Pawn.PawnReactionList;
         partyContextPawn.TrainingStatus = Pawn.TrainingStatus.GetValueOrDefault(Pawn.Job, new byte[64]);
-        partyContextPawn.SpSkillList = Pawn.SpSkillList;
+        partyContextPawn.SpSkillList = Pawn.SpSkills.GetValueOrDefault(Pawn.Job, new List<CDataSpSkill>());
         GameStructure.CDataContextResist(partyContextPawn.ResistInfo, Pawn);
         partyContextPawn.EditInfo = Pawn.EditInfo;
 

--- a/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
@@ -2048,24 +2048,30 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                     MotionNo = myPawnCsvData.EndOfCombatId
                 }
             };
-            pawn.SpSkillList = new List<CDataSpSkill>()
+            pawn.SpSkills = new Dictionary<JobId, List<CDataSpSkill>>()
             {
-                new CDataSpSkill()
                 {
-                    SpSkillId = myPawnCsvData.SpSkillSlot1Id,
-                    SpSkillLv = myPawnCsvData.SpSkillSlot1Lv
-                },
-                new CDataSpSkill()
-                {
-                    SpSkillId = myPawnCsvData.SpSkillSlot2Id,
-                    SpSkillLv = myPawnCsvData.SpSkillSlot2Lv
-                },
-                new CDataSpSkill()
-                {
-                    SpSkillId = myPawnCsvData.SpSkillSlot3Id,
-                    SpSkillLv = myPawnCsvData.SpSkillSlot3Lv
+                    myPawnCsvData.Job,
+                    new List<CDataSpSkill>()
+                    {
+                        new CDataSpSkill()
+                        {
+                            SpSkillId = myPawnCsvData.SpSkillSlot1Id,
+                            SpSkillLv = myPawnCsvData.SpSkillSlot1Lv
+                        },
+                        new CDataSpSkill()
+                        {
+                            SpSkillId = myPawnCsvData.SpSkillSlot2Id,
+                            SpSkillLv = myPawnCsvData.SpSkillSlot2Lv
+                        },
+                        new CDataSpSkill()
+                        {
+                            SpSkillId = myPawnCsvData.SpSkillSlot3Id,
+                            SpSkillLv = myPawnCsvData.SpSkillSlot3Lv
+                        }
+                    }.Where(spSkill => spSkill.SpSkillId != 0).ToList()
                 }
-            }.Where(spSkill => spSkill.SpSkillId != 0).ToList();
+            };
             pawn.TrainingPoints = int.MaxValue;
             pawn.AvailableTraining = uint.MaxValue;
             return pawn;

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -11,7 +11,7 @@ namespace Arrowgene.Ddon.Shared.Model
             Name = string.Empty;
             OnlineStatus = OnlineStatus.None;
             PawnReactionList = new List<CDataPawnReaction>();
-            SpSkillList = new List<CDataSpSkill>();
+            SpSkills = new Dictionary<JobId, List<CDataSpSkill>>();
             // TODO: Fetch from DB
             CraftData = new CDataPawnCraftData() {
                 CraftExp = 0,
@@ -55,10 +55,10 @@ namespace Arrowgene.Ddon.Shared.Model
         public byte PawnType { get; set; }
 
         public List<CDataPawnReaction> PawnReactionList { get; set; }
-        public List<CDataSpSkill> SpSkillList { get; set; }
         public CDataPawnCraftData CraftData { get; set; }
 
         public Dictionary<JobId, byte[]> TrainingStatus { get; set; }
+        public Dictionary<JobId, List<CDataSpSkill>> SpSkills { get; set; }
         public uint TrainingPoints { get; set; } // Training xp?
         public uint AvailableTraining { get; set; } // Training lv?
     }


### PR DESCRIPTION
Fixes issue #327 

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch

# DB Migration Script
```sql
DROP TABLE IF EXISTS ddon_sp_skill;

CREATE TABLE IF NOT EXISTS ddon_sp_skill
(
    "pawn_id"     INTEGER  NOT NULL,
    "job"         SMALLINT NOT NULL,
    "sp_skill_id" SMALLINT NOT NULL,
    "sp_skill_lv" SMALLINT NOT NULL,
    CONSTRAINT pk_ddon_sp_skill PRIMARY KEY (pawn_id, job, sp_skill_id),
    CONSTRAINT fk_sp_skill_pawn_id FOREIGN KEY ("pawn_id") REFERENCES ddon_pawn ("pawn_id") ON DELETE CASCADE
);
```