### PR TITLE
fix: Fix issue with deliver quest NPC text

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -334,10 +334,10 @@ namespace Arrowgene.Ddon.GameServer.Quests
                         List<CDataQuestCommand> deliveryRequests = new List<CDataQuestCommand>();
                         foreach (var item in questBlock.DeliveryRequests)
                         {
-                            deliveryRequests.Add(QuestManager.CheckCommand.DeliverItem((int)item.ItemId, (int)item.Amount));
+                            deliveryRequests.Add(QuestManager.CheckCommand.DeliverItem((int)item.ItemId, (int)item.Amount, questBlock.NpcOrderDetails[0].NpcId, questBlock.NpcOrderDetails[0].MsgId));
                         }
                         result.CheckCommandList = QuestManager.CheckCommand.AddCheckCommands(deliveryRequests);
-                        result.ResultCommandList.Add(QuestManager.ResultCommand.SetDeliverInfo(StageManager.ConvertIdToStageNo(questBlock.StageId), questBlock.NpcOrderDetails[0].NpcId, 1, 0));
+                        result.ResultCommandList.Add(QuestManager.ResultCommand.SetDeliverInfo(StageManager.ConvertIdToStageNo(questBlock.StageId), questBlock.NpcOrderDetails[0].NpcId, questBlock.NpcOrderDetails[0].MsgId));
                         // result.ResultCommandList.Add(QuestManager.ResultCommand.SetDeliverInfoQuest(StageManager.ConvertIdToStageNo(questBlock.StageId), (int) questBlock.StageId.GroupId, 1, 0));
                     }
                     break;

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
@@ -60,7 +60,7 @@
                     "amount": 2
                 }
             ],
-            "message_id": 1124
+            "message_id": 10737
         }
     ]
 }


### PR DESCRIPTION
Fixed an issue where the message id was not being assigned to the proper field in a delivery quest.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
