### PR TITLE
Implement query for completed quest IDs

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestCompletedListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestCompletedListHandler.cs
@@ -1,13 +1,16 @@
-﻿using Arrowgene.Buffers;
+using Arrowgene.Buffers;
 using Arrowgene.Ddon.GameServer.Dump;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
-    public class QuestGetQuestCompletedListHandler : PacketHandler<GameClient>
+    public class QuestGetQuestCompletedListHandler : GameRequestPacketHandler<C2SQuestGetQuestCompleteListReq, S2CQuestGetQuestCompleteListRes>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(QuestGetQuestCompletedListHandler));
 
@@ -16,17 +19,24 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        public override PacketId Id => PacketId.C2S_QUEST_GET_QUEST_COMPLETE_LIST_REQ;
-
-        public override void Handle(GameClient client, IPacket packet)
+        public override S2CQuestGetQuestCompleteListRes Handle(GameClient client, C2SQuestGetQuestCompleteListReq packet)
         {
-            IBuffer buffer = new StreamBuffer();
-            buffer.WriteUInt32(0);
-            buffer.WriteUInt32(0);
-            buffer.WriteUInt32(0);
-            Packet p = new Packet(PacketId.S2C_QUEST_GET_QUEST_COMPLETE_LIST_RES, buffer.GetAllBytes());
-            client.Send(p);
-           // client.Send(GameFull.Dump_126);
+            // client.Send(GameFull.Dump_126);
+            var result = new S2CQuestGetQuestCompleteListRes()
+            {
+                QuestType = packet.QuestType
+            };
+
+            var completedQuestIds = Server.Database.GetCompletedQuestsByType(client.Character.CommonId, (QuestType) packet.QuestType);
+            foreach (var questId in completedQuestIds)
+            {
+                result.QuestIdList.Add(new CDataQuestId()
+                {
+                    QuestId = (uint) questId
+                });
+            }
+
+            return result;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -359,11 +359,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
                                 // case QuestType.World:
                                 checkCommands.Add(QuestManager.CheckCommand.IsOrderLightQuest((int)questBlock.QuestOrderDetails.QuestId));
                                 break;
-                            case QuestType.WorldSetting:
+                            case QuestType.WorldManage:
                                 checkCommands.Add(QuestManager.CheckCommand.IsOrderWorldQuest((int)questBlock.QuestOrderDetails.QuestId));
-                                break;
-                            case QuestType.Pawn:
-                                // checkCommands.Add(QuestManager.CheckCommand.IsOrderPawnQuest())
                                 break;
                         }
                     }

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -411,6 +411,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SQuestQuestProgressReq.Serializer());
             Create(new C2SQuestDecideDeliveryItemReq.Serializer());
             Create(new C2SQuestGetRewardBoxListReq.Serializer());
+            Create(new C2SQuestGetQuestCompleteListReq.Serializer());
 
             Create(new C2SServerGameTimeGetBaseInfoReq.Serializer());
             Create(new C2SServerGetRealTimeReq.Serializer());
@@ -706,6 +707,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CQuestQuestLogInfoRes.Serializer());
             Create(new CDataLightQuestClearList.Serializer());
 
+            Create(new S2CQuestGetQuestCompleteListRes.Serializer());
             Create(new S2CQuestGetLightQuestListRes.Serializer());
             Create(new S2CQuestGetLotQuestListRes.Serializer());
             Create(new S2CQuestGetMainQuestListRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetQuestCompleteListReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetQuestCompleteListReq.cs
@@ -1,0 +1,35 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SQuestGetQuestCompleteListReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_QUEST_GET_QUEST_COMPLETE_LIST_REQ;
+
+        public C2SQuestGetQuestCompleteListReq()
+        {
+        }
+
+        public byte QuestType { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SQuestGetQuestCompleteListReq>
+        {
+            public override void Write(IBuffer buffer, C2SQuestGetQuestCompleteListReq obj)
+            {
+                WriteByte(buffer, obj.QuestType);
+            }
+
+            public override C2SQuestGetQuestCompleteListReq Read(IBuffer buffer)
+            {
+                C2SQuestGetQuestCompleteListReq obj = new C2SQuestGetQuestCompleteListReq();
+                obj.QuestType = ReadByte(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetQuestCompleteListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetQuestCompleteListRes.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestGetQuestCompleteListRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_QUEST_GET_QUEST_COMPLETE_LIST_RES;
+
+        public S2CQuestGetQuestCompleteListRes()
+        {
+            QuestIdList = new List<CDataQuestId>();
+        }
+
+        public byte QuestType {  get; set; }
+        public List<CDataQuestId> QuestIdList { get; set; }
+
+
+        public class Serializer : PacketEntitySerializer<S2CQuestGetQuestCompleteListRes>
+        {
+            public override void Write(IBuffer buffer, S2CQuestGetQuestCompleteListRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteByte(buffer, obj.QuestType);
+                WriteEntityList<CDataQuestId>(buffer, obj.QuestIdList);
+            }
+
+            public override S2CQuestGetQuestCompleteListRes Read(IBuffer buffer)
+            {
+                S2CQuestGetQuestCompleteListRes obj = new S2CQuestGetQuestCompleteListRes();
+                ReadServerResponse(buffer, obj);
+                obj.QuestType = ReadByte(buffer);
+                obj.QuestIdList = ReadEntityList<CDataQuestId>(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestType.cs
@@ -2,6 +2,25 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 {
     public enum QuestType : uint
     {
+        Unknown = 0,
+        Light = 1,
+        Set = 2,
+        Main = 3,
+        Tutorial = 4,
+        Limited = 5,
+        CycleContents = 6,
+        CycleContentsQuest = 7,
+        WorldManage = 8,
+        TimeGain = 9, // Queried when logging in
+        Unk0 = 10,
+        Unk1 = 11, // Queried when logging in
+
+        // Pseudo Categories
+        World = 1,
+
+#if false
+// Seems game has 2 different sets of quest IDs
+// which one is the right one to use???
         Main = 0,
         Set = 1,
         Light = 2,
@@ -15,8 +34,6 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         Pawn = 10,
         DebugTool = 11,
         ManagerNum = 12,
-
-        // Pseudo Categories
-        World = 2,
+#endif
     }
 }


### PR DESCRIPTION
Added support for updating the list of completed quests after the player enters the game. This should resolve issues where players need to log out and back in after progressing far enough to unlock various features in the game.

# DB Migration
Since the quest type enum values changed again, we need to update the quest type field in the DB.

Update the quest type field from `0` to `3` in the tables `ddon_completed_quests` and `ddon_quest_progress`

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
