### PR TITLE
Added Hidell Plains world quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
@@ -1,0 +1,110 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Calamity at the Cathedral Ruins",
+    "quest_id": 20000000,
+    "base_level": 20,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 660
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 60
+        },
+        {
+            "type": "exp",
+            "amount": 770
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 7874,
+                    "num": 1
+                },
+                {
+                    "item_id": 35,
+                    "num": 3
+                },
+                {
+                    "item_id": 9396,
+                    "num": 2					
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 85,
+                "group_id": 7
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015600",
+                    "level": 20,
+                    "exp": 3000,
+                    "is_boss": true
+                },
+                {
+                    "enemy_id": "0x010308",
+                    "level": 20,
+                    "exp": 146,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010308",
+                    "level": 20,
+                    "exp": 146,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010308",
+                    "level": 20,
+                    "exp": 146,
+                    "is_boss": false					
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1
+            },
+            "npc_id": "Gordon",
+            "message_id": 11000,
+            "flags": [
+            {"type": "QstLayout", "action": "Set", "value": 984, "comment": "write something when you figure out what it does"}
+             ]			
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Gordon",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
@@ -1,0 +1,115 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Petition to Rid of Demons in Ruins",
+    "quest_id": 20000004,
+    "base_level": 13,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 60
+        },
+        {
+            "type": "exp",
+            "amount": 700
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 7872,
+                    "num": 3
+                },
+                {
+                    "item_id": 9373,
+                    "num": 2
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 88,
+                "group_id": 5
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false				
+                },
+                {
+                    "enemy_id": "0x010301",
+                    "level": 13,
+                    "exp": 37,
+                    "is_boss": false			
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 3
+            },
+            "npc_id": "Joseph",
+            "message_id": 11000
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 3
+            },
+            "announce_type": "Update",
+            "npc_id": "Joseph",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
@@ -1,0 +1,112 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Mysterious Monolith",
+    "quest_id": 20000005,
+    "base_level": 18,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 590
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 70
+        },
+        {
+            "type": "exp",
+            "amount": 830
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 8378,
+                    "num": 1
+                },
+                {
+                    "item_id": 61,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 146,
+                "group_id": 7
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x010207",
+                    "level": 18,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010207",
+                    "level": 18,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011120",
+                    "level": 18,
+                    "exp": 76,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011120",
+                    "level": 18,
+                    "exp": 76,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011120",
+                    "level": 18,
+                    "exp": 76,
+                    "is_boss": false					
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1
+            },
+            "npc_id": "Freya",
+            "message_id": 11000,
+            "flags": [
+            {"type": "QstLayout", "action": "Set", "value": 987, "comment": "write something when you figure out what it does"}
+             ]			
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Freya",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
@@ -1,0 +1,92 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Evil Lurking in the Tombs",
+    "quest_id": 20000006,
+    "base_level": 34,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 990
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 130
+        },
+        {
+            "type": "exp",
+            "amount": 1480
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 524,
+                    "num": 1
+                },
+                {
+                    "item_id": 7552,
+                    "num": 3
+                },
+                {
+                    "item_id": 9384,
+                    "num": 2					
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 239,
+                "group_id": 0
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015600",
+                    "level": 30,
+                    "exp": 5400,
+                    "is_boss": true			
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1
+            },
+            "npc_id": "Christoph",
+            "message_id": 11000,
+            "flags": [
+            {"type": "QstLayout", "action": "Set", "value": 988, "comment": "write something when you figure out what it does"}	
+             ]			
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Christoph",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
@@ -1,0 +1,155 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Raiding Orc Platoon",
+    "quest_id": 20000008,
+    "base_level": 11,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 360
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 50
+        },
+        {
+            "type": "exp",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 9239,
+                    "num": 1
+                },
+                {
+                    "item_id": 9408,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0",
+            "stage_id": {
+                "id": 1,
+                "group_id": 22
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015800",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015800",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015800",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015800",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                }
+            ]					
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 36
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015801",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015801",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015801",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015801",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015801",
+                    "level": 11,
+                    "exp": 80,
+                    "is_boss": false					
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1
+            },
+            "npc_id": "ArisenCorpsRegimentalSoldier8",
+            "message_id": 11000,
+            "flags": [
+            {"type": "QstLayout", "action": "Set", "value": 989, "comment": "write something when you figure out what it does"}
+             ]
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [1]			
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "ArisenCorpsRegimentalSoldier8",
+            "message_id": 11005
+		    }
+	   ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
@@ -1,0 +1,128 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Traveler's Scout",
+    "quest_id": 20000010,
+    "base_level": 11,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 360
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 50
+        },
+        {
+            "type": "exp",
+            "amount": 430
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 94,
+                    "num": 1
+                },
+                {
+                    "item_id": 9409,
+                    "num": 1
+                },
+                {
+                    "item_id": 9393,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 38
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x011000",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 45
+                },
+                {
+                    "enemy_id": "0x011001",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 46
+                },
+                {
+                    "enemy_id": "0x011001",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 46
+                },
+                {
+                    "enemy_id": "0x011000",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 46
+                },
+                {
+                    "enemy_id": "0x011000",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 46					
+                },
+                {
+                    "enemy_id": "0x011004",
+                    "level": 11,
+                    "exp": 34,
+                    "is_boss": false,
+					"hm_present_no": 49				
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1
+            },
+            "npc_id": "Woman0",
+            "message_id": 11000,
+            "flags": [
+            {"type": "QstLayout", "action": "Set", "value": 990, "comment": "write something when you figure out what it does"}
+             ]
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Woman0",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
@@ -1,0 +1,101 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Seeking Peace",
+    "quest_id": 20000012,
+    "base_level": 42,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1380
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 270
+        },
+        {
+            "type": "exp",
+            "amount": 2420
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 9196,
+                    "num": 1
+                },
+                {
+                    "item_id": 7553,
+                    "num": 3
+                },
+                {
+                    "item_id": 9421,
+                    "num": 1					
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 290
+            },
+			"starting_index": 5,
+            "enemies": [
+                {
+                    "enemy_id": "0x015500",
+                    "level": 40,
+                    "exp": 3445,
+                    "is_boss": true			
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 3
+            },
+            "npc_id": "Joseph",
+            "message_id": 11000		
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]		
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 50,
+                "group_id": 0
+            },
+            "announce_type": "Update",
+            "npc_id": "Brandon",			
+            "message_id": 10915
+        },
+        {			
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 3,
+                "group_id": 0
+            },
+            "announce_type": "Update",
+            "npc_id": "Joseph",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000013.json
@@ -1,0 +1,85 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Beloved Forest",
+    "quest_id": 20000013,
+    "base_level": 15,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 490
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 80
+        },
+        {
+            "type": "exp",
+            "amount": 750
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 64,
+                    "num": 1
+                },
+                {
+                    "item_id": 42,
+                    "num": 2
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 72
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015502",
+                    "level": 15,
+                    "exp": 1500,
+                    "is_boss": true			
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 2
+            },
+            "npc_id": "Mayleaf0",
+            "message_id": 11000
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {			
+            "type": "KillGroup",
+            "announce_type": "Update",
+			"reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 2
+            },
+            "announce_type": "Update",
+            "npc_id": "Mayleaf0",
+            "message_id": 11005
+		    }
+	   ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
@@ -1,0 +1,114 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Price of Honor",
+    "quest_id": 20000016,
+    "base_level": 30,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 990
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 150
+        },
+        {
+            "type": "exp",
+            "amount": 1380
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 734,
+                    "num": 1
+                },
+                {
+                    "item_id": 9401,
+                    "num": 2
+                },
+                {
+                    "item_id": 9377,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 259
+            },
+            "starting_index": 2,
+            "enemies": [
+                {
+                    "enemy_id": "0x015800",
+                    "level": 30,
+                    "exp": 250,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x015800",
+                    "level": 30,
+                    "exp": 250,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 2224, "comment": "Spawns Fallen Knight"}
+            ],
+            "stage_id": {
+                "id": 2
+            },
+            "npc_id": "Heinz2",
+            "message_id": 11372
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "CollectItem",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 2225, "comment": "Spawns Glowing Message"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 2
+            },
+            "flags": [
+                {"type": "QstLayout", "action": "Clear", "value": 2225, "comment": "Spawns Glowing Message"}
+            ],
+            "announce_type": "Update",
+            "npc_id": "Heinz2",
+            "message_id": 11842
+        }
+    ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
@@ -1,0 +1,71 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Whispers of the Dark",
+    "quest_id": 20005004,
+    "base_level": 13,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 60
+        },
+        {
+            "type": "exp",
+            "amount": 600
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 83,
+                    "num": 1
+                },
+                {
+                    "item_id": 57,
+                    "num": 3
+                },
+                {
+                    "item_id": 9373,
+                    "num": 2					
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 88,
+                "group_id": 4
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015600",
+                    "level": 13,
+                    "exp": 480,
+                    "is_boss": true			
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0]
+        }
+    ]
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
@@ -1,0 +1,71 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Man-Eating Ogre Appears!",
+    "quest_id": 20005011,
+    "base_level": 26,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 850
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 130
+        },
+        {
+            "type": "exp",
+            "amount": 1020
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 842,
+                    "num": 1
+                },
+                {
+                    "item_id": 35,
+                    "num": 3
+                },
+                {
+                    "item_id": 9396,
+                    "num": 2					
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 11
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015500",
+                    "level": 26,
+                    "exp": 1024,
+                    "is_boss": true					
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0]
+        }
+    ]
+}
+


### PR DESCRIPTION
Authored by Dixdros

Hidell Plains
Lvl 7 - Request for Medicine - 薬を求めて
Lvl 8 - The Woes of A Merchant - ある行商人の悩み
Lvl 8 - An Assistant’s Assistant - 助手の助手
Lvl 8 - Crackdown on Store Vandals - 倉庫荒らしを懲らしめろ
Lvl 8 - A Heart Throbs Once More - ときめきをもう一度
Lvl 8 - Fabio’s Collectibles - ファビオの収集品
Lvl 8 - Confrontation with Scouts - Confrontation with the Scouts in the Dark
Lvl 9 - Fabio and Monster-Slaying - ファビオと魔物退治
Lvl 9 - A Transporter’s Tragedy - 輸送係の悲劇
Lvl 10 - Knight and Arisen - 騎士と覚者
Lvl 11 - The Traveller’s Scout - 旅人の露払い
Lvl 11 - Ambush In The Well’s Depths - 井戸底の伏兵達
Lvl 11 - The Raiding Orc Platoon -侵入のオーク小隊
Lvl 12 - The Knights’ Bitter Enemy - 騎士団の仇敵
Lvl 13 - A Petition to Rid of Demons in Ruins - 嘆願書対応　廃墟魔物退治
Lvl 13 - Whispers of the Dark - 闇からのささやき
Lvl 14 - Sky-Concealing Wings - 天を覆う翼 (Young Sphinx)
Lvl 15 - Beloved Forest - 愛しき森を― (Dread Ape)
Lvl 15 - Dweller in the Darkness - A mysterious creature (Dread Ape)
Lvl 16 - The Traveller’s Scout (II) - A mysterious creature
Lvl 18 - The Mysterious Monolith - A mysterious creature
Lvl 20 - A Calamity at the Cathedral Ruins - A mysterious creature
Lvl 26 - A Man-Eating Ogre Appears! - A little treasure, a little paradise!
Lvl 30 - The Price of Honour - A little treasure
Lvl 30 - The Evil Lurking in the Tombs - A little treasure (Wight)

Breya Coast
Lvl 8 - Dispatch A Clamor of Harpies! - Non-commercial use of weapons!
Lvl 9 - Boat’s Buddy - A must-have for all players
Lvl 11 - Beach Bandits - A must-have for all players

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
