### PR TITLE
Adjust some World Quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -287,6 +287,16 @@ namespace Arrowgene.Ddon.GameServer.Quests
                         resultCommands.Add(QuestManager.ResultCommand.QstTalkChg(questBlock.NpcOrderDetails[0].NpcId, questBlock.NpcOrderDetails[0].MsgId));
                     }
                     break;
+                case QuestBlockType.NewNpcTalkAndOrder:
+                    {
+                        checkCommands.Add(QuestManager.CheckCommand.QuestNpcTalkAndOrderUi(
+                            StageManager.ConvertIdToStageNo(questBlock.NpcOrderDetails[0].StageId),
+                            (int)questBlock.NpcOrderDetails[0].StageId.GroupId,
+                            questBlock.NpcOrderDetails[0].StageId.LayerNo,
+                            (int)quest.QuestId));
+                        resultCommands.Add(QuestManager.ResultCommand.QstTalkChg(questBlock.NpcOrderDetails[0].NpcId, questBlock.NpcOrderDetails[0].MsgId));
+                    }
+                    break;
                 case QuestBlockType.PartyGather:
                     {
                         checkCommands.Add(QuestManager.CheckCommand.Prt(StageManager.ConvertIdToStageNo(questBlock.StageId), questBlock.PartyGatherPoint.x, questBlock.PartyGatherPoint.y, questBlock.PartyGatherPoint.z));
@@ -420,8 +430,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     {
                         var orderDetails = questBlock.NpcOrderDetails[0];
                         var questCommand = questBlock.ShowMarker ?
-                            QuestManager.CheckCommand.NewTalkNpc(StageManager.ConvertIdToStageNo(orderDetails.StageId), (int)orderDetails.StageId.GroupId, orderDetails.StageId.LayerNo, (int)orderDetails.QuestId) :
-                            QuestManager.CheckCommand.NewTalkNpcWithoutMarker(StageManager.ConvertIdToStageNo(orderDetails.StageId), (int)orderDetails.StageId.GroupId, orderDetails.StageId.LayerNo, (int)orderDetails.QuestId);
+                            QuestManager.CheckCommand.NewTalkNpc(StageManager.ConvertIdToStageNo(orderDetails.StageId), (int)orderDetails.StageId.GroupId, orderDetails.StageId.LayerNo, (int) quest.QuestId) :
+                            QuestManager.CheckCommand.NewTalkNpcWithoutMarker(StageManager.ConvertIdToStageNo(orderDetails.StageId), (int)orderDetails.StageId.GroupId, orderDetails.StageId.LayerNo, (int) quest.QuestId);
                         checkCommands.Add(questCommand);
                         resultCommands.Add(QuestManager.ResultCommand.QstTalkChg(orderDetails.NpcId, orderDetails.MsgId));
                     }

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -409,6 +409,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         }
                         break;
                     case QuestBlockType.NpcTalkAndOrder:
+                    case QuestBlockType.NewNpcTalkAndOrder:
                         {
                             if (!Enum.TryParse(jblock.GetProperty("npc_id").GetString(), true, out NpcId npcId))
                             {
@@ -483,18 +484,11 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                                 questBlock.ShowMarker = jShowMarker.GetBoolean();
                             }
 
-                            QuestId questId = QuestId.None;
-                            if (jblock.TryGetProperty("quest_id", out JsonElement jQuestId))
-                            {
-                                questId = (QuestId) jQuestId.GetUInt32();
-                            }
-
                             questBlock.NpcOrderDetails.Add(new QuestNpcOrder()
                             {
                                 NpcId = npcId,
                                 MsgId = jblock.GetProperty("message_id").GetInt32(),
-                                StageId = ParseStageId(jblock.GetProperty("stage_id")),
-                                QuestId = questId
+                                StageId = ParseStageId(jblock.GetProperty("stage_id"))
                             });
                         }
                         break;

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
@@ -37,10 +37,11 @@
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
                 "id": 25,
-                "group_id": 1
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "Peddler",
             "message_id": 10734,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002.json
@@ -40,10 +40,11 @@
             "comment": "process 0",
             "blocks": [
                 {
-                    "type": "NpcTalkAndOrder",
+                    "type": "NewNpcTalkAndOrder",
                     "stage_id": {
                         "id": 1,
-                        "group_id": 0
+                        "group_id": 1,
+                        "layer_no": 1
                     },
                     "npc_id": "WhiteKnight0",
                     "message_id": 8629,
@@ -58,10 +59,11 @@
                     "check_flags": [1, 2, 3, 4, 5]
                 },
                 {
-                    "type": "NpcTalkAndOrder",
+                    "type": "NewTalkToNpc",
                     "stage_id": {
                         "id": 1,
-                        "group_id": 0
+                        "group_id": 1,
+                        "layer_no": 1
                     },
                     "npc_id": "WhiteKnight0",
                     "message_id": 8633
@@ -78,8 +80,7 @@
                 {
                     "type": "TalkToNpc",
                     "stage_id": {
-                        "id": 25,
-                        "group_id": 0
+                        "id": 25
                     },
                     "npc_id": "Bob",
                     "message_id": 8630
@@ -105,12 +106,16 @@
                         "group_id": 2,
                         "layer_no": 1
                     },
-                    "layout_flags_on": [1125]
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1125}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
                     "announce_type": "Update",
-                    "layout_flags_off": [1125],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 1125}
+                    ],
                     "set_flags": [2]
                 }
             ]
@@ -129,13 +134,17 @@
                         "group_id": 3,
                         "layer_no": 1
                     },
-                    "layout_flags_on": [1126]
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1126}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
                     "announce_type": "Update",
-                    "layout_flags_off": [1126],
-                    "set_flags": [3]
+                    "set_flags": [3],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 1126}
+                    ]
                 }
             ]
         },
@@ -153,13 +162,17 @@
                         "group_id": 4,
                         "layer_no": 1
                     },
-                    "layout_flags_on": [1127]
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1127}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
                     "announce_type": "Update",
-                    "layout_flags_off": [1127],
-                    "set_flags": [4]
+                    "set_flags": [4],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 1127}
+                    ]
                 }
             ]
         },
@@ -177,13 +190,17 @@
                         "group_id": 5,
                         "layer_no": 1
                     },
-                    "layout_flags_on": [1128]
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1128}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
                     "announce_type": "Update",
-                    "layout_flags_off": [1128],
-                    "set_flags": [5]
+                    "set_flags": [5],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 1128}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
@@ -67,7 +67,7 @@
                     "exp": 80,
                     "is_boss": false
                 }
-            ]					
+            ]
         },
         {
             "stage_id": {
@@ -103,32 +103,34 @@
                     "enemy_id": "0x015801",
                     "level": 11,
                     "exp": 80,
-                    "is_boss": false					
+                    "is_boss": false
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "ArisenCorpsRegimentalSoldier8",
             "message_id": 11000,
             "flags": [
-            {"type": "QstLayout", "action": "Set", "value": 989, "comment": "write something when you figure out what it does"}
-             ]
+                {"type": "QstLayout", "action": "Set", "value": 989, "comment": "Spawns Arisen Corps Regimental Solider"}
+            ]
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
@@ -136,20 +138,22 @@
             "announce_type": "Update",
             "groups": [1]
         },
-        {			
+        {
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
-            "groups": [1]			
+            "reset_group": false,
+            "groups": [1]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "ArisenCorpsRegimentalSoldier8",
             "message_id": 11005
-		    }
-	   ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000.json
@@ -68,12 +68,13 @@
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
+            "npc_id": "Yuni",
             "stage_id": {
                 "id": 1,
-                "group_id": 0
+                "group_id": 1,
+                "layer_no": 1
             },
-            "npc_id": "Yuni",
             "message_id": 10782,
             "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 992}
@@ -92,13 +93,14 @@
             "groups": [0]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
+            "npc_id": "Yuni",
             "stage_id": {
                 "id": 1,
-                "group_id": 0
+                "group_id": 1,
+                "group_id": 1
             },
             "announce_type": "Update",
-            "npc_id": "Yuni",
             "message_id": 10785
         }
     ]

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestBlockType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestBlockType.cs
@@ -17,6 +17,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         KillGroup,
         TalkToNpc,
         NewTalkToNpc,
+        NewNpcTalkAndOrder,
         DeliverItems,
         SeekOutEnemiesAtMarkedLocation,
         CollectItem,

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestNpcOrder.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestNpcOrder.cs
@@ -10,9 +10,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
     {
         public NpcId NpcId { get; set; }
         public int MsgId { get; set; }
-
         public StageId StageId { get; set; }
-        public QuestId QuestId { get; set; }
 
         public QuestNpcOrder()
         {


### PR DESCRIPTION
- Added a new quest block type called "NewNpcTalkAndOrder" which allows the quest marker to show on NPCs that are spawned by quest flags.
- Fixed an issue with the quest "Beach Bandits" where the marker was showing up in the wrong location.
- Fixed an issue with the quest "A Transporter's Tragedy" where shiny items were no longer collectable.
- Adjusted existing quests "The Woes of A Merchant", "A Transporter's Tragedy", "Beach Bandits" and "The Raiding Orc Platoon" to use new order and talk commands.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
