### PR TITLE
Quest Enemy Placement

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -170,8 +170,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
             {
                 foreach (var enemyGroupId in questBlock.EnemyGroupIds)
                 {
-                    var enemies = EnemyGroups[enemyGroupId];
-                    client.Party.QuestState.SetInstanceEnemies(this, enemies.StageId, (ushort)enemies.SubGroupId, enemies.AsInstancedEnemies());
+                    var enemyGroup = EnemyGroups[enemyGroupId];
+                    client.Party.QuestState.SetInstanceEnemies(this, enemyGroup.StageId, (ushort)enemyGroup.SubGroupId, enemyGroup.CreateNewInstance());
                 }
             }
             else
@@ -325,7 +325,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                         foreach (var groupId in questBlock.EnemyGroupIds)
                         {
                             var enemyGroup = quest.EnemyGroups[groupId];
-                            foreach (var enemy in enemyGroup.AsInstancedEnemies())
+                            foreach (var enemy in enemyGroup.CreateNewInstance())
                             {
                                 checkCommands.Add(QuestManager.CheckCommand.EmHpLess(StageManager.ConvertIdToStageNo(enemyGroup.StageId), (int)enemyGroup.StageId.GroupId, enemy.Index, questBlock.EnemyHpPrecent));
                             }

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -330,7 +330,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 foreach (var groupId in process.Blocks[(int)processState.BlockNo - 1].EnemyGroupIds)
                 {
                     var enemyGroup = EnemyGroups[groupId];
-                    partyQuestState.SetInstanceEnemies(this, enemyGroup.StageId, (ushort)enemyGroup.SubGroupId, enemyGroup.AsInstancedEnemies());
+                    partyQuestState.SetInstanceEnemies(this, enemyGroup.StageId, (ushort)enemyGroup.SubGroupId, enemyGroup.CreateNewInstance());
                 }
             }
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
@@ -96,26 +96,30 @@
                 "id": 77,
                 "group_id": 0
             },
+            "placement_type": "Manual",
             "enemies": [
-                {
-                    "comment" : "Damned Golem",
-                    "enemy_id": "0x015103",
-                    "level": 48,
-                    "exp": 5734
-                },
                 {
                     "comment" : "Iris",
                     "enemy_id": "0x011040",
                     "level": 48,
                     "exp": 57340,
                     "hm_present_no": 74,
-                    "is_boss": true
+                    "is_boss": true,
+                    "index": 0
                 },
                 {
                     "comment" : "Damned Golem",
                     "enemy_id": "0x015103",
                     "level": 48,
-                    "exp": 5734
+                    "exp": 5734,
+                    "index": 3
+                },
+                {
+                    "comment" : "Damned Golem",
+                    "enemy_id": "0x015103",
+                    "level": 48,
+                    "exp": 5734,
+                    "index": 4
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
@@ -12,6 +12,12 @@ namespace Arrowgene.Ddon.Shared.Model
             IsKilled = false;
         }
 
+        public InstancedEnemy(InstancedEnemy enemy) : base (enemy)
+        {
+            IsKilled = false;
+            Index = enemy.Index;
+        }
+
         public bool IsKilled { get; set; }
         public byte Index {  get; set; }
     }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestEnemyGroup.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestEnemyGroup.cs
@@ -7,23 +7,26 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public uint SubGroupId { get; set; }
         public StageId StageId { get; set; }
         public uint StartingIndex { get; set; }
-        public List<Enemy> Enemies { get; set; }
+        public List<InstancedEnemy> Enemies { get; set; }
+        public QuestEnemyPlacementType PlacementType { get; set; }
 
         public QuestEnemyGroup()
         {
-            Enemies = new List<Enemy>();
+            Enemies = new List<InstancedEnemy>();
             StageId = StageId.Invalid;
+            PlacementType = QuestEnemyPlacementType.Automatic;
         }
 
-        public List<InstancedEnemy> AsInstancedEnemies()
+        public List<InstancedEnemy> CreateNewInstance()
         {
             List<InstancedEnemy> results = new List<InstancedEnemy>();
+
             for (var i = 0; i < Enemies.Count; i++)
             {
                 var enemy = Enemies[i];
                 results.Add(new InstancedEnemy(enemy)
                 {
-                    Index = (byte)(i + StartingIndex)
+                    Index = (PlacementType == QuestEnemyPlacementType.Automatic) ? (byte)(i + StartingIndex) : enemy.Index
                 });
             }
             return results;

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestEnemyPlacementType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestEnemyPlacementType.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Model.Quest
+{
+    public enum QuestEnemyPlacementType : uint
+    {
+        Automatic,
+        Manual
+    }
+}


### PR DESCRIPTION
Added ability to specify automatic or manual placement of enemies.
- Automatic placement just uses the enemies position in the array + the starting_index value (if provided).
  - This is the default strategy if not provided. 
- Manual placement requires that every enemy as an additional "index" field, specifying the position in the group.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
