### PR TITLE
Add support for quests in party

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -499,7 +499,7 @@ CREATE TABLE IF NOT EXISTS "ddon_bazaar_exhibition" (
 );
 
 CREATE TABLE IF NOT EXISTS "ddon_reward_box" (
-	"uniq_reward_id"	INTEGER NOT NULL,
+	"uniq_reward_id"	INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	"character_common_id"	INTEGER NOT NULL,
 	"quest_id"	INTEGER NOT NULL,
 	"num_random_rewards"	INTEGER NOT NULL,
@@ -507,7 +507,6 @@ CREATE TABLE IF NOT EXISTS "ddon_reward_box" (
 	"random_reward1_index"	INTEGER NOT NULL,
 	"random_reward2_index"	INTEGER NOT NULL,
 	"random_reward3_index"	INTEGER NOT NULL,
-	PRIMARY KEY("uniq_reward_id" AUTOINCREMENT),
 	CONSTRAINT "fk_ddon_reward_box_character_common_id" FOREIGN KEY("character_common_id") REFERENCES "ddon_character_common"("character_common_id") ON DELETE CASCADE
 );
 
@@ -523,5 +522,12 @@ CREATE TABLE IF NOT EXISTS "ddon_completed_quests" (
 	"character_common_id"	INTEGER NOT NULL,
 	"quest_type"	INTEGER NOT NULL,
 	"quest_id"	INTEGER NOT NULL,
+    "clear_count"	INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY("character_common_id") REFERENCES "ddon_character_common"("character_common_id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "ddon_priority_quests" (
+	"character_common_id"	INTEGER NOT NULL,
+	"quest_id"	INTEGER NOT NULL,
+	FOREIGN KEY("character_common_id") REFERENCES "ddon_character_common"("character_common_id") ON DELETE CASCADE
 );

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -187,7 +187,8 @@ namespace Arrowgene.Ddon.Database
         List<QuestBoxRewards> SelectBoxRewardItems(uint commonId);
 
         // Completed Quests
-        List<QuestId> GetCompletedQuestsByType(uint characterCommonId, QuestType questType);
+        List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType);
+        CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId);
         bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType);
 
         // Quest Progress
@@ -195,5 +196,11 @@ namespace Arrowgene.Ddon.Database
         bool UpdateQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step);
         bool RemoveQuestProgress(uint characterCommonId, QuestId questId, QuestType questType);
         List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType);
+        QuestProgress GetQuestProgressById(uint characterCommonId, QuestId questId);
+
+        // Quest Priority
+        bool InsertPriorityQuest(uint characterCommonId, QuestId questId);
+        List<QuestId> GetPriorityQuests(uint characterCommonId);
+        bool DeletePriorityQuest(uint characterCommonId, QuestId questId);
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlPriorityQuests.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlPriorityQuests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Data.Common;
+using System.Reflection.Metadata.Ecma335;
+using System.Text.RegularExpressions;
+using System.Web;
+using System.Xml;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        /* ddon_completed_quests */
+        protected static readonly string[] PriorityQuestFields = new string[]
+        {
+            "character_common_id", "quest_id"
+        };
+
+        private readonly string SqlInsertIfNotExistPriorityQuestId = $"INSERT INTO \"ddon_priority_quests\" ({BuildQueryField(PriorityQuestFields)}) SELECT " +
+                                                                         $"{BuildQueryInsert(PriorityQuestFields)} WHERE NOT EXISTS (SELECT 1 FROM \"ddon_priority_quests\" WHERE " +
+                                                                         $"\"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id);";
+        private readonly string SqlSelectPriorityQuests = $"SELECT {BuildQueryField(PriorityQuestFields)} FROM \"ddon_priority_quests\" WHERE \"character_common_id\" = @character_common_id;";
+        private readonly string SqlDeletePriorityQuest = $"DELETE FROM \"ddon_priority_quests\" WHERE \"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id;";
+
+        public bool InsertPriorityQuest(uint characterCommonId, QuestId questId)
+        {
+            using TCon connection = OpenNewConnection();
+            return InsertPriorityQuest(connection, characterCommonId, questId);
+        }
+
+        public bool InsertPriorityQuest(TCon connection, uint characterCommonId, QuestId questId)
+        {
+            return ExecuteNonQuery(connection, SqlInsertIfNotExistPriorityQuestId, command =>
+            {
+                AddParameter(command, "character_common_id", characterCommonId);
+                AddParameter(command, "quest_id", (uint)questId);
+            }) == 1;
+        }
+
+        public List<QuestId> GetPriorityQuests(uint characterCommonId)
+        {
+            using TCon connection = OpenNewConnection();
+            return GetPriorityQuests(connection, characterCommonId);
+        }
+        public List<QuestId> GetPriorityQuests(TCon connection, uint characterCommonId)
+        {
+            List<QuestId> results = new List<QuestId>();
+            ExecuteInTransaction(conn =>
+            {
+                ExecuteReader(conn, SqlSelectPriorityQuests,
+                    command => {
+                        AddParameter(command, "@character_common_id", characterCommonId);
+                    }, reader => {
+                        while (reader.Read())
+                        {
+                            results.Add((QuestId)GetUInt32(reader, "quest_id"));
+                        }
+                    });
+            });
+            return results;
+        }
+
+        public bool DeletePriorityQuest(uint characterCommonId, QuestId questId)
+        {
+            using TCon connection = OpenNewConnection();
+            return DeletePriorityQuest(connection, characterCommonId, questId);
+        }
+
+        public bool DeletePriorityQuest(TCon connection, uint characterCommonId, QuestId questId)
+        {
+            return ExecuteNonQuery(connection, SqlDeletePriorityQuest, command =>
+            {
+                AddParameter(command, "@character_common_id", characterCommonId);
+                AddParameter(command, "quest_id", (uint)questId);
+            }) == 1;
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -383,6 +383,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new ProfileGetCharacterProfileHandler(this));
             AddHandler(new ProfileGetMyCharacterProfileHandler(this));
 
+            AddHandler(new QuestCancelPriorityQuestHandler(this));
             AddHandler(new QuestEndDistributionQuestCancelHandler(this));
             AddHandler(new QuestGetAdventureGuideQuestListHandler(this));
             AddHandler(new QuestGetAdventureGuideQuestNoticeHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -8,6 +8,7 @@ using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -50,11 +51,19 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 return;
             }
 
-            // TODO: Fetch all quests for the party, not just MSQ
-            var mainQuests = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.Main);
-            foreach (var mainQuest in mainQuests)
+            var quests = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+            foreach (var quest in quests)
             {
-                party.QuestState.AddNewQuest(mainQuest.QuestId, mainQuest.Step);
+                party.QuestState.AddNewQuest(quest.QuestId, quest.Step);
+            }
+
+            var worldQuests = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.World).Select(x => x.QuestId).ToList();
+            foreach (var quest in QuestManager.GetQuestsByType(QuestType.World))
+            {
+                if (!worldQuests.Contains(quest.Key))
+                {
+                    party.QuestState.AddNewQuest(quest.Key, 0);
+                }
             }
 
             S2CPartyPartyJoinNtc ntc = new S2CPartyPartyJoinNtc();

--- a/Arrowgene.Ddon.GameServer/Handler/QuestCancelPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestCancelPriorityQuestHandler.cs
@@ -1,32 +1,39 @@
+using Arrowgene.Buffers;
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Dump;
+using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using Arrowgene.Networking.Tcp.Consumer.BlockingQueueConsumption;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
-    public class QuestSetPriorityQuestHandler : GameStructurePacketHandler<C2SQuestSetPriorityQuestReq>
+    public class QuestCancelPriorityQuestHandler : GameRequestPacketHandler<C2SQuestCancelPriorityQuestReq, S2CQuestCancelPriorityQuestRes>
     {
-        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(QuestSetPriorityQuestHandler));
-        
-        public QuestSetPriorityQuestHandler(DdonGameServer server) : base(server)
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(QuestCancelPriorityQuestHandler));
+
+        public QuestCancelPriorityQuestHandler(DdonGameServer server) : base(server)
         {
         }
 
-        public override void Handle(GameClient client, StructurePacket<C2SQuestSetPriorityQuestReq> packet)
+        public override S2CQuestCancelPriorityQuestRes Handle(GameClient client, C2SQuestCancelPriorityQuestReq packet)
         {
-            QuestId questId = (QuestId)packet.Structure.QuestScheduleId;
+            QuestId questId = (QuestId) packet.QuestScheduleId;
+
+            Server.Database.DeletePriorityQuest(client.Character.CommonId, questId);
 
             S2CQuestSetPriorityQuestNtc ntc = new S2CQuestSetPriorityQuestNtc()
             {
                 CharacterId = client.Character.CharacterId
             };
-
-            Server.Database.InsertPriorityQuest(client.Character.CommonId, questId);
 
             var prioirtyQuests = Server.Database.GetPriorityQuests(client.Character.CommonId);
             foreach (var priorityQuestId in prioirtyQuests)
@@ -38,10 +45,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             client.Party.SendToAll(ntc);
 
-            client.Send(new S2CQuestSetPriorityQuestRes()
+            return new S2CQuestCancelPriorityQuestRes()
             {
-                QuestScheduleId = packet.Structure.QuestScheduleId
-            });
+                QuestScheduleId = packet.QuestScheduleId
+            };
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
@@ -48,9 +48,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             // pcap.MainQuestIdList; (this will add back all missing functionality which depends on complete MSQ)
             var completedMsq = Server.Database.GetCompletedQuestsByType(client.Character.CommonId, QuestType.Main);
-            foreach (var questId in completedMsq)
+            foreach (var msq in completedMsq)
             {
-                ntc.MainQuestIdList.Add(new CDataQuestId() { QuestId = (uint) questId });
+                ntc.MainQuestIdList.Add(new CDataQuestId() { QuestId = (uint) msq.QuestId });
+            }
+
+            if (client.Party != null)
+            {
+                var priorityQuests = Server.Database.GetPriorityQuests(client.Party.Leader.Client.Character.CommonId);
+                foreach (var questId in priorityQuests)
+                {
+                    var quest = QuestManager.GetQuest(questId);
+                    ntc.PriorityQuestList.Add(new CDataPriorityQuest()
+                    {
+                        QuestId = (uint)quest.QuestId,
+                        QuestScheduleId = (uint)quest.QuestScheduleId
+                    });
+                }
             }
 
             client.Send(ntc);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetMainQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetMainQuestListHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using System.Dynamic;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -24,6 +25,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // client.Send(GameFull.Dump_123);
 
             S2CQuestGetMainQuestListRes res = new S2CQuestGetMainQuestListRes();
+            S2CQuestGetMainQuestNtc ntc = new S2CQuestGetMainQuestNtc();
             foreach (var questId in client.Party.QuestState.GetActiveQuestIds())
             {
                 var quest = QuestManager.GetQuest(questId);
@@ -31,8 +33,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     var questState = client.Party.QuestState.GetQuestState(questId);
                     res.MainQuestList.Add(quest.ToCDataQuestList(questState.Step));
+                    ntc.MainQuestList.Add(quest.ToCDataMainQuestList(questState.Step));
                 }
             }
+
+            client.Party.SendToAllExcept(ntc, client);
 
             // res.MainQuestList.Add(Quest25);    // Can't find this quest
             // res.MainQuestList.Add(Quest30260); // Hopes Bitter End (White Dragon)

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
@@ -32,15 +32,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             CDataPriorityQuestSetting setting = new CDataPriorityQuestSetting();
             setting.CharacterId = partyLeader.Client.Character.CharacterId;
 
-            foreach (var questId in partyLeader.Client.Character.PriorityQuests)
+            var priorityQuests = Server.Database.GetPriorityQuests(partyLeader.Client.Character.CommonId);
+            foreach (var questId in priorityQuests)
             {
-                // TODO: Currently we are using the questId as the schedule
-                // TODO: ID but we might want to make that unique at some point.
-                setting.PriorityQuestList.Add(new CDataPriorityQuest()
-                {
-                    QuestId = (uint) questId,
-                    QuestScheduleId = (uint) questId,
-                });
+                var quest = QuestManager.GetQuest(questId);
+                var questState = client.Party.QuestState.GetQuestState(quest);
+                setting.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState.Step));
             }
 
             res.PriorityQuestSettingsList.Add(setting);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
@@ -37,6 +37,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 var quest = QuestManager.GetQuest(questId);
                 var questState = client.Party.QuestState.GetQuestState(quest);
+                if (questState == null)
+                {
+                    // Quest State should not be null, but don't crash
+                    // Just delete the quest from priority list
+                    Server.Database.DeletePriorityQuest(partyLeader.Client.Character.CommonId, questId);
+                    Logger.Error($"Client {partyLeader.Client.Character.CommonId} has priority quest for quest state which doesn't exist");
+                    continue;
+                }
+
                 setting.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState.Step));
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestCompletedListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestCompletedListHandler.cs
@@ -27,12 +27,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 QuestType = packet.QuestType
             };
 
-            var completedQuestIds = Server.Database.GetCompletedQuestsByType(client.Character.CommonId, (QuestType) packet.QuestType);
-            foreach (var questId in completedQuestIds)
+            var completedQuests = Server.Database.GetCompletedQuestsByType(client.Character.CommonId, (QuestType) packet.QuestType);
+            foreach (var completedQuest in completedQuests)
             {
                 result.QuestIdList.Add(new CDataQuestId()
                 {
-                    QuestId = (uint) questId
+                    QuestId = (uint) completedQuest.QuestId
                 });
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -34,6 +34,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var quest = QuestManager.GetQuest(questId);
                 if (quest.QuestType == QuestType.World)
                 {
+
+                    var questStats = Server.Database.GetCompletedQuestsById(client.Party.Leader.Client.Character.CommonId, quest.QuestId);
                     var questState = client.Party.QuestState.GetQuestState(questId);
                     /**
                      * World quests get added here instead of QuestGetWorldManageQuestListHandler because
@@ -43,11 +45,24 @@ namespace Arrowgene.Ddon.GameServer.Handler
                      */
                     res.SetQuestList.Add(new CDataSetQuestList()
                     {
-                        Detail = new CDataSetQuestDetail() { IsDiscovery = quest.IsDiscoverable },
+                        Detail = new CDataSetQuestDetail() 
+                        { 
+                            IsDiscovery = (questStats == null) ? quest.IsDiscoverable : true,
+                            ClearCount = (questStats == null) ? 0 : questStats.ClearCount
+                        },
                         Param = quest.ToCDataQuestList(questState.Step),
                     });
                 }
             }
+
+            S2CQuestGetSetQuestListNtc ntc = new S2CQuestGetSetQuestListNtc()
+            { 
+                SelectCharacterId = client.Party.Leader.Client.Character.CharacterId,
+                SetQuestList = res.SetQuestList
+            };
+
+            client.Party.SendToAll(ntc);
+
 
             client.Send(res);
         }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestLeaderQuestProgressRequestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestLeaderQuestProgressRequestHandler.cs
@@ -22,7 +22,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ProcessNo = packet.Structure.ProcessNo
             });
 
-            // TODO: Send NTC
+            // TODO: Send NTC?
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -1,13 +1,17 @@
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -53,67 +57,29 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 partyQuestState.UpdateProcessState(questId, res.QuestProcessState);
 
-                if (questProgressState == QuestProgressState.Checkpoint)
+                if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.World)
                 {
-                    var leaderCommonId = client.Party.Leader.Client.Character.CommonId;
-
-                    var questState = client.Party.QuestState.GetQuestState(quest);
-                    questState.Step += 1;
-
-                    Server.Database.UpdateQuestProgress(leaderCommonId, quest.QuestId, quest.QuestType, questState.Step);
+                    foreach (var memberClient in client.Party.Clients)
+                    {
+                        var questProgress = Server.Database.GetQuestProgressById(memberClient.Character.CommonId, quest.QuestId);
+                        if (questProgress == null)
+                        {
+                            if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, 0))
+                            {
+                                Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
+                            }
+                        }
+                    }
                 }
 
-
-                if (questProgressState == QuestProgressState.Complete)
+                if (questProgressState == QuestProgressState.Checkpoint || questProgressState == QuestProgressState.Accepted)
                 {
-                    SendRewards(client, client.Character, quest);
-
-                    S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
-                    {
-                        QuestScheduleId = (uint)questId,
-                        RandomRewardNum = quest.RandomRewardNum(),
-                        ChargeRewardNum = quest.RewardParams.ChargeRewardNum,
-                        ProgressBonusNum = quest.RewardParams.ProgressBonusNum,
-                        IsRepeatReward = quest.RewardParams.IsRepeatReward,
-                        IsUndiscoveredReward = quest.RewardParams.IsUndiscoveredReward,
-                        IsHelpReward = quest.RewardParams.IsHelpReward,
-                        IsPartyBonus = quest.RewardParams.IsPartyBonus,
-                    };
-
-                    client.Party.SendToAll(completeNtc);
-
-                    if (quest.HasRewards())
-                    {
-                        foreach (var memberClient in client.Party.Clients) 
-                        {
-                            Server.RewardManager.AddQuestRewards(memberClient, quest);
-                        }
-                    }
-
-                    // Remove the quest data from the party object
-                    partyQuestState.CompleteQuest(questId);
-
-                    if (quest.QuestType == QuestType.Main)
-                    {
-                        var leaderCommonId = client.Party.Leader.Client.Character.CommonId;
-                        // TODO: Eventually handle all types of quests and for all members
-                        Server.Database.RemoveQuestProgress(leaderCommonId, quest.QuestId, quest.QuestType);
-                        if (quest.NextQuestId != QuestId.None)
-                        {
-                            var nextQuest = QuestManager.GetQuest(quest.NextQuestId);
-                            Server.Database.InsertQuestProgress(leaderCommonId, nextQuest.QuestId, nextQuest.QuestType, 0);
-                        }
-
-                        Server.Database.InsertIfNotExistCompletedQuest(leaderCommonId, quest.QuestId, quest.QuestType);
-                    }
-
-                    if (quest.ResetPlayerAfterQuest)
-                    {
-                        foreach (var memberClient in client.Party.Clients)
-                        {
-                            Server.CharacterManager.UpdateCharacterExtendedParamsNtc(memberClient, memberClient.Character);
-                        }
-                    }
+                    partyQuestState.UpdatePartyQuestProgress(Server, client.Party, questId);
+                }
+                else if (questProgressState == QuestProgressState.Complete)
+                {
+                    res.QuestProgressResult = 3; // ProcessEnd
+                    CompleteQuest(quest, client, client.Party, partyQuestState);
                 }
 
                 if (res.QuestProcessState.Count > 0)
@@ -124,44 +90,68 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
-            S2CQuestQuestProgressNtc ntc = new S2CQuestQuestProgressNtc()
+            foreach (var memberClient in client.Party.Clients)
             {
-                ProgressCharacterId = client.Character.CharacterId,
-                QuestScheduleId = res.QuestScheduleId,
-                QuestProcessStateList = res.QuestProcessState,
-            };
-            client.Party.SendToAllExcept(ntc, client);
+                if (memberClient == client)
+                {
+                    continue;
+                }
+
+                S2CQuestQuestProgressNtc ntc = new S2CQuestQuestProgressNtc()
+                {
+                    ProgressCharacterId = memberClient.Character.CharacterId,
+                    QuestScheduleId = res.QuestScheduleId,
+                    QuestProcessStateList = res.QuestProcessState,
+                };
+
+                memberClient.Send(ntc);
+            }
 
             client.Send(res);
         }
 
-        private void SendRewards(GameClient client, Character character, Quest quest)
+        private void CompleteQuest(Quest quest, GameClient client, PartyGroup party, PartyQuestState partyQuestState)
         {
-            S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
+            // Distribute rewards to the party
+            partyQuestState.DistributePartyQuestRewards(Server, party, quest.QuestId);
+
+            // Resolve quest state for all members participating in the quest
+            partyQuestState.CompletePartyQuestProgress(Server, party, quest.QuestId);
+
+            S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
             {
-                UpdateType = (ushort)ItemNoticeType.Quest
+                QuestScheduleId = (uint)quest.QuestId,
+                RandomRewardNum = quest.RandomRewardNum(),
+                ChargeRewardNum = quest.RewardParams.ChargeRewardNum,
+                ProgressBonusNum = quest.RewardParams.ProgressBonusNum,
+                IsRepeatReward = quest.RewardParams.IsRepeatReward,
+                IsUndiscoveredReward = quest.RewardParams.IsUndiscoveredReward,
+                IsHelpReward = quest.RewardParams.IsHelpReward,
+                IsPartyBonus = quest.RewardParams.IsPartyBonus,
+            };
+            client.Party.SendToAll(completeNtc);
+
+            S2CQuestSetPriorityQuestNtc priorityNtc = new S2CQuestSetPriorityQuestNtc()
+            {
+                CharacterId = client.Character.CharacterId
             };
 
-            foreach (var walletReward in quest.WalletRewards)
+            // Get the new list of priority quests from the leader
+            var prioirtyQuests = Server.Database.GetPriorityQuests(party.Leader.Client.Character.CommonId);
+            foreach (var priorityQuestId in prioirtyQuests)
             {
-                Server.WalletManager.AddToWallet(character, walletReward.Type, walletReward.Value);
+                var priorityQuest = QuestManager.GetQuest(priorityQuestId);
+                var priorityQuestState = party.QuestState.GetQuestState(priorityQuestId);
+                priorityNtc.PriorityQuestList.Add(priorityQuest.ToCDataPriorityQuest(priorityQuestState.Step));
+            }
+            client.Party.SendToAll(priorityNtc);
 
-                updateCharacterItemNtc.UpdateWalletList.Add(new CDataUpdateWalletPoint()
+            if (quest.ResetPlayerAfterQuest)
+            {
+                foreach (var memberClient in client.Party.Clients)
                 {
-                    Type = walletReward.Type,
-                    Value = Server.WalletManager.GetWalletAmount(character, walletReward.Type),
-                    AddPoint = (int)walletReward.Value
-                });
-            }
-
-            if (updateCharacterItemNtc.UpdateWalletList.Count > 0)
-            {
-                client.Send(updateCharacterItemNtc);
-            }
-
-            foreach (var expPoint in quest.ExpRewards)
-            {
-                Server.ExpManager.AddExp(client, character, expPoint.Reward, 0, 2); // I think type 2 means quest
+                    Server.CharacterManager.UpdateCharacterExtendedParamsNtc(memberClient, memberClient.Character);
+                }
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -62,12 +62,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     foreach (var memberClient in client.Party.Clients)
                     {
                         var questProgress = Server.Database.GetQuestProgressById(memberClient.Character.CommonId, quest.QuestId);
-                        if (questProgress == null)
+                        if (questProgress != null)
                         {
-                            if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, 0))
-                            {
-                                Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
-                            }
+                            continue;
+                        }
+
+                        // Add a new world quest record for the player
+                        if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, 0))
+                        {
+                            Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
                         }
                     }
                 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestSendLeaderQuestOrderConditionInfoHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSendLeaderQuestOrderConditionInfoHandler.cs
@@ -20,14 +20,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 S2CQuestSendLeaderQuestOrderConditionInfoNtc ntc = new S2CQuestSendLeaderQuestOrderConditionInfoNtc() {
                     OrderConditionInfoList = packet.Structure.OrderConditionInfoList
                 };
-                foreach(GameClient member in client.Party.Clients)
-                {
-                    if(member.Character.CharacterId != member.Party.Leader.Client.Character.CharacterId)
-                    {
-                        // Disconnects you for some reason
-                        //member.Send(ntc);
-                    }
-                }
+
+                client.Party.SendToAllExcept(ntc, client);
             }
             
             client.Send(new S2CQuestSendLeaderQuestOrderConditionInfoRes());

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -613,9 +613,8 @@ namespace Arrowgene.Ddon.GameServer.Party
                 client.InstanceGatheringItemManager.Clear();
                 client.InstanceDropItemManager.Clear();
             }
-
-            QuestState.ResetInstanceQuestState();
             OmManager.ResetAllOmData(InstanceOmData);
+            QuestState.ResetInstanceQuestState();
         }
 
         public PartyMember GetPartyMemberByCharacter(CharacterCommon characterCommon)

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -428,7 +428,7 @@ namespace Arrowgene.Ddon.GameServer.Party
             var questState = party.QuestState.GetQuestState(quest);
             foreach (var memberClient in party.Clients)
             {
-                var result = server.Database.GetQuestProgressById(memberClient.Character.CommonId, questId);
+                var result = server.Database.GetQuestProgressById(memberClient.Character.CommonId, quest.QuestId);
                 if (result == null)
                 {
                     continue;
@@ -439,8 +439,8 @@ namespace Arrowgene.Ddon.GameServer.Party
                     continue;
                 }
 
-                server.Database.DeletePriorityQuest(memberClient.Character.CommonId, questId);
-                server.Database.RemoveQuestProgress(memberClient.Character.CommonId, questId, quest.QuestType);
+                server.Database.DeletePriorityQuest(memberClient.Character.CommonId, quest.QuestId);
+                server.Database.RemoveQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType);
                 if (quest.NextQuestId != QuestId.None)
                 {
                     var nextQuest = QuestManager.GetQuest(quest.NextQuestId);

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Quests;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
@@ -113,9 +114,6 @@ namespace Arrowgene.Ddon.GameServer.Party
             ActiveQuests = new Dictionary<QuestId, QuestState>();
             QuestLookupTable = new Dictionary<StageId, List<QuestId>>();
             CompletedWorldQuests = new List<QuestId>();
-
-            // Populate world into the completed category so when the instance gets reloaded they are set
-            CompletedWorldQuests.AddRange(QuestManager.GetQuestsByType(QuestType.World).Select(x => x.Key));
         }
 
         public void AddNewQuest(Quest quest, uint step = 0)
@@ -239,7 +237,7 @@ namespace Arrowgene.Ddon.GameServer.Party
             }
         }
 
-        public void AddNewQuest(QuestId questId, uint step = 0)
+        public void AddNewQuest(QuestId questId, uint step)
         {
             var quest = QuestManager.GetQuest(questId);
             AddNewQuest(quest, step);
@@ -278,7 +276,7 @@ namespace Arrowgene.Ddon.GameServer.Party
 
                 if (quest.NextQuestId != 0)
                 {
-                    AddNewQuest(quest.NextQuestId);
+                    AddNewQuest(quest.NextQuestId, 0);
                 }
             }
         }
@@ -391,10 +389,136 @@ namespace Arrowgene.Ddon.GameServer.Party
             // Add all world quests
             foreach (var questId in CompletedWorldQuests)
             {
-                AddNewQuest(questId);
+                AddNewQuest(questId, 0);
             }
 
             CompletedWorldQuests.Clear();
+        }
+
+        public bool UpdatePartyQuestProgress(DdonGameServer server, PartyGroup party, QuestId questId)
+        {
+            Quest quest = QuestManager.GetQuest(questId);
+
+            var questState = party.QuestState.GetQuestState(quest);
+            foreach (var memberClient in party.Clients)
+            {
+                var result = server.Database.GetQuestProgressById(memberClient.Character.CommonId, questId);
+                if (result == null)
+                {
+                    continue;
+                }
+
+                if (result.Step != questState.Step)
+                {
+                    continue;
+                }
+
+                server.Database.UpdateQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, questState.Step + 1);
+            }
+
+            questState.Step += 1;
+
+            return true;
+        }
+
+        public bool CompletePartyQuestProgress(DdonGameServer server, PartyGroup party, QuestId questId)
+        {
+            Quest quest = QuestManager.GetQuest(questId);
+
+            var questState = party.QuestState.GetQuestState(quest);
+            foreach (var memberClient in party.Clients)
+            {
+                var result = server.Database.GetQuestProgressById(memberClient.Character.CommonId, questId);
+                if (result == null)
+                {
+                    continue;
+                }
+
+                if (result.Step != questState.Step)
+                {
+                    continue;
+                }
+
+                server.Database.DeletePriorityQuest(memberClient.Character.CommonId, questId);
+                server.Database.RemoveQuestProgress(memberClient.Character.CommonId, questId, quest.QuestType);
+                if (quest.NextQuestId != QuestId.None)
+                {
+                    var nextQuest = QuestManager.GetQuest(quest.NextQuestId);
+                    server.Database.InsertQuestProgress(memberClient.Character.CommonId, nextQuest.QuestId, nextQuest.QuestType, 0);
+                }
+
+                server.Database.InsertIfNotExistCompletedQuest(memberClient.Character.CommonId, quest.QuestId, quest.QuestType);
+            }
+
+            // Remove the quest data from the party object
+            CompleteQuest(quest.QuestId);
+
+            return true;
+        }
+
+        public bool DistributePartyQuestRewards(DdonGameServer server, PartyGroup party, QuestId questId)
+        {
+            Quest quest = QuestManager.GetQuest(questId);
+
+            var questState = party.QuestState.GetQuestState(quest);
+            foreach (var memberClient in party.Clients)
+            {
+                // If this is a main quest, check to see that the member is currently on this quest, otherwise don't reward
+                if (quest.QuestType == QuestType.Main)
+                {
+                    var result = server.Database.GetQuestProgressById(memberClient.Character.CommonId, questId);
+                    if (result == null)
+                    {
+                        continue;
+                    }
+
+                    if (result.Step != questState.Step)
+                    {
+                        continue;
+                    }
+                }
+
+                // Check for Item Rewards
+                if (quest.HasRewards())
+                {
+                    server.RewardManager.AddQuestRewards(memberClient, quest);
+                }
+
+                // Check for Exp, Rift and Gold Rewards
+                SendWalletRewards(server, memberClient, quest);
+            }
+
+            return true;
+        }
+
+        private void SendWalletRewards(DdonGameServer server, GameClient client, Quest quest)
+        {
+            S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
+            {
+                UpdateType = (ushort)ItemNoticeType.Quest
+            };
+
+            foreach (var walletReward in quest.WalletRewards)
+            {
+                server.WalletManager.AddToWallet(client.Character, walletReward.Type, walletReward.Value);
+
+                updateCharacterItemNtc.UpdateWalletList.Add(new CDataUpdateWalletPoint()
+                {
+                    Type = walletReward.Type,
+                    Value = server.WalletManager.GetWalletAmount(client.Character, walletReward.Type),
+                    AddPoint = (int)walletReward.Value
+                });
+            }
+
+            if (updateCharacterItemNtc.UpdateWalletList.Count > 0)
+            {
+                client.Send(updateCharacterItemNtc);
+            }
+
+            foreach (var expPoint in quest.ExpRewards)
+            {
+                server.ExpManager.AddExp(client, client.Character, expPoint.Reward, 0, 2); // I think type 2 means quest
+            }
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -127,12 +127,14 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 {
                     QuestScheduleId = (uint)QuestId,
                     ProcessNo = proccessState.ProcessNo,
-                    SequenceNo = 0,
+                    SequenceNo = proccessState.SequenceNo,
                     BlockNo = proccessState.BlockNo,
+#if false
                     WorkList = new List<CDataQuestProgressWork>()
                     {
                         QuestManager.NotifyCommand.KilledTargetEnemySetGroup((int) questLocation.QuestLayoutFlag, StageManager.ConvertIdToStageNo(stageId), (int) stageId.GroupId)
                     }
+#endif
                 });
             }
         }
@@ -160,6 +162,10 @@ namespace Arrowgene.Ddon.GameServer.Quests
             else if (questBlock.IsCheckpoint)
             {
                 questProgressState = QuestProgressState.Checkpoint;
+            }
+            else if (questBlock.AnnounceType == QuestAnnounceType.Accept)
+            {
+                questProgressState = QuestProgressState.Accepted;
             }
             else
             {

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -1,5 +1,7 @@
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Handler;
 using Arrowgene.Ddon.GameServer.Party;
+using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -49,6 +51,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
     public abstract class Quest
     {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(Quest));
+
         protected List<QuestProcess> Processes { get; set; }
         public readonly QuestId QuestId;
         public readonly bool IsDiscoverable;
@@ -141,11 +145,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
                         questFlags[flag.Type][flag.Value] = flag;
                     }
                 }
+            }
 
-                if (stepsFound == step)
-                {
-                    break;
-                }
+            if (step != stepsFound)
+            {
+                throw new QuestRestoreProgressFailedException(QuestId, step, stepsFound);
             }
 
             result.Add(new CDataQuestProcessState(Processes[0].Blocks[i].QuestProcessState));
@@ -607,6 +611,14 @@ namespace Arrowgene.Ddon.GameServer.Quests
     public class QuestDoesNotExistException : ResponseErrorException
     {
         public QuestDoesNotExistException(QuestId questId) : base(ErrorCode.ERROR_CODE_QUEST_INTERNAL_ERROR, $"The quest ${questId} does not exist")
+        {
+        }
+    }
+
+    public class QuestRestoreProgressFailedException : ResponseErrorException
+    {
+        public QuestRestoreProgressFailedException(QuestId questId, uint step, uint stepsFound) : 
+            base(ErrorCode.ERROR_CODE_QUEST_DIFFERENT_PROGRESS, $"Failed to restore progress for {questId} (Step({step}) != StepsFound({stepsFound}))")
         {
         }
     }

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -678,6 +678,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     ProcessNo = questProcess.ProcessNo,
                     BlockNo = blockIndex,
                     SequenceNo = 1,
+                    AnnounceType = QuestAnnounceType.None
                 });
             }
             else
@@ -689,6 +690,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     BlockType = QuestBlockType.None,
                     BlockNo = blockIndex,
                     SequenceNo = 1,
+                    AnnounceType = QuestAnnounceType.None
                 });
             }
 

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -141,6 +141,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataLobbyMemberInfoSerializer());
             Create(new CDataLoginSettingSerializer());
             Create(new CDataLotQuestOrderList.Serializer());
+            Create(new CDataMainQuestList.Serializer());
             Create(new CDataMainQuestOrderList.Serializer());
             Create(new CDataMasterInfo.Serializer());
             Create(new CDataMatchingProfileSerializer());
@@ -154,6 +155,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataOrbCategoryStatusSerializer());
             Create(new CDataOrbGainExtendParam.Serializer());
             Create(new CDataOrbPageStatusSerializer());
+            Create(new CDataOrderConditionInfo.Serializer());
             Create(new CDataPartnerPawnInfo.Serializer());
             Create(new CDataPartyContextPawn.Serializer());
             Create(new CDataPartyListInfo.Serializer());
@@ -396,6 +398,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SProfileGetCharacterProfileReq.Serializer());
             Create(new C2SProfileGetMyCharacterProfileReq.Serializer());
 
+            Create(new C2SQuestCancelPriorityQuestReq.Serializer());
             Create(new C2SQuestGetLightQuestListReq.Serializer());
             Create(new C2SQuestGetLotQuestListReq.Serializer());
             Create(new C2SQuestGetPackageQuestListReq.Serializer());
@@ -708,13 +711,15 @@ namespace Arrowgene.Ddon.Shared.Entity
 
             Create(new S2CQuestQuestLogInfoRes.Serializer());
             Create(new CDataLightQuestClearList.Serializer());
-
+            Create(new S2CQuestCancelPriorityQuestRes.Serializer());
             Create(new S2CQuestGetQuestCompleteListRes.Serializer());
             Create(new S2CQuestGetLightQuestListRes.Serializer());
             Create(new S2CQuestGetLotQuestListRes.Serializer());
             Create(new S2CQuestGetMainQuestListRes.Serializer());
+            Create(new S2CQuestGetMainQuestNtc.Serializer());
             Create(new S2CQuestGetPartyQuestProgressInfoRes.Serializer());
             Create(new S2CQuestGetSetQuestListRes.Serializer());
+            Create(new S2CQuestGetSetQuestListNtc.Serializer());
             Create(new S2CQuestGetWorldManageQuestListNtc.Serializer());
             Create(new S2CQuestGetWorldManageQuestListRes.Serializer());
             Create(new S2CQuestJoinLobbyQuestInfoNtc.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestCancelPriorityQuestReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestCancelPriorityQuestReq.cs
@@ -1,0 +1,35 @@
+using System;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SQuestCancelPriorityQuestReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_QUEST_CANCEL_PRIORITY_QUEST_REQ;
+
+        public C2SQuestCancelPriorityQuestReq()
+        {
+        }
+
+        public UInt32 QuestScheduleId { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SQuestCancelPriorityQuestReq>
+        {
+            public override void Write(IBuffer buffer, C2SQuestCancelPriorityQuestReq obj)
+            {
+                WriteUInt32(buffer, obj.QuestScheduleId);
+            }
+
+            public override C2SQuestCancelPriorityQuestReq Read(IBuffer buffer)
+            {
+                C2SQuestCancelPriorityQuestReq obj = new C2SQuestCancelPriorityQuestReq();
+                obj.QuestScheduleId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetSetQuestListReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetSetQuestListReq.cs
@@ -23,6 +23,5 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 return obj;
             }
         }
-
     }
 }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestCancelPriorityQuestRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestCancelPriorityQuestRes.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestCancelPriorityQuestRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_QUEST_CANCEL_PRIORITY_QUEST_RES;
+
+        public S2CQuestCancelPriorityQuestRes()
+        {
+        }
+
+        public UInt32 QuestScheduleId { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CQuestCancelPriorityQuestRes>
+        {
+            public override void Write(IBuffer buffer, S2CQuestCancelPriorityQuestRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteUInt32(buffer, obj.QuestScheduleId);
+            }
+
+            public override S2CQuestCancelPriorityQuestRes Read(IBuffer buffer)
+            {
+                S2CQuestCancelPriorityQuestRes obj = new S2CQuestCancelPriorityQuestRes();
+                ReadServerResponse(buffer, obj);
+                obj.QuestScheduleId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestCompleteNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestCompleteNtc.cs
@@ -7,7 +7,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 {
     public class S2CQuestCompleteNtc : IPacketStructure
     {
-        public PacketId Id => PacketId.S2C_QUEST_11_91_16_NTC;
+        public PacketId Id => PacketId.S2C_QUEST_QUEST_COMPLETE_NTC;
 
         public S2CQuestCompleteNtc()
         {

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetMainQuestNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetMainQuestNtc.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestGetMainQuestNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_QUEST_GET_MAIN_QUEST_LIST_NTC;
+
+        public S2CQuestGetMainQuestNtc()
+        {
+            MainQuestList = new List<CDataMainQuestList>();
+        }
+
+        public List<CDataMainQuestList> MainQuestList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CQuestGetMainQuestNtc>
+        {
+            public override void Write(IBuffer buffer, S2CQuestGetMainQuestNtc obj)
+            {
+                WriteEntityList<CDataMainQuestList>(buffer, obj.MainQuestList);
+            }
+
+            public override S2CQuestGetMainQuestNtc Read(IBuffer buffer)
+            {
+                S2CQuestGetMainQuestNtc obj = new S2CQuestGetMainQuestNtc();
+                obj.MainQuestList = ReadEntityList<CDataMainQuestList>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetSetQuestListNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetSetQuestListNtc.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestGetSetQuestListNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_QUEST_GET_SET_QUEST_LIST_NTC;
+
+        public S2CQuestGetSetQuestListNtc()
+        {
+            SelectCharacterId = 0;
+            DistributeId = 0;
+            SetQuestList = new List<CDataSetQuestList>();
+        }
+
+        public uint SelectCharacterId { get; set; }
+        public uint DistributeId {  get; set; }
+        public List<CDataSetQuestList> SetQuestList {  get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CQuestGetSetQuestListNtc>
+        {
+            public override void Write(IBuffer buffer, S2CQuestGetSetQuestListNtc obj)
+            {
+                WriteUInt32(buffer, obj.SelectCharacterId);
+                WriteUInt32(buffer, obj.DistributeId);
+                WriteEntityList<CDataSetQuestList>(buffer, obj.SetQuestList);
+            }
+
+            public override S2CQuestGetSetQuestListNtc Read(IBuffer buffer)
+            {
+                S2CQuestGetSetQuestListNtc obj = new S2CQuestGetSetQuestListNtc();
+                obj.SelectCharacterId = ReadUInt32(buffer);
+                obj.DistributeId = ReadUInt32(buffer);
+                obj.SetQuestList = ReadEntityList<CDataSetQuestList>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataMainQuestList.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataMainQuestList.cs
@@ -1,0 +1,29 @@
+using Arrowgene.Buffers;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataMainQuestList
+    {
+        public CDataMainQuestList()
+        {
+            Param = new CDataQuestList();
+        }
+
+        public CDataQuestList Param { get; set; }
+
+        public class Serializer : EntitySerializer<CDataMainQuestList>
+        {
+            public override void Write(IBuffer buffer, CDataMainQuestList obj)
+            {
+                WriteEntity<CDataQuestList>(buffer, obj.Param);
+            }
+
+            public override CDataMainQuestList Read(IBuffer buffer)
+            {
+                CDataMainQuestList obj = new CDataMainQuestList();
+                obj.Param = ReadEntity<CDataQuestList>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestCommand.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestCommand.cs
@@ -9,6 +9,19 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public int Param02 { get; set; }
         public int Param03 { get; set; }
         public int Param04 { get; set; }
+
+        public CDataQuestCommand()
+        {
+        }
+
+        public CDataQuestCommand(CDataQuestCommand obj)
+        {
+            Command = obj.Command;
+            Param01 = obj.Param01;
+            Param02 = obj.Param02;
+            Param03 = obj.Param03;
+            Param04 = obj.Param04;
+        }
     
         public class Serializer : EntitySerializer<CDataQuestCommand>
         {

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestProcessState.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestProcessState.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Arrowgene.Buffers;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure;
@@ -10,6 +11,16 @@ public class CDataQuestProcessState
         WorkList = new List<CDataQuestProgressWork>();
         CheckCommandList = new List<MtTypedArrayCDataQuestCommand>();
         ResultCommandList = new List<CDataQuestCommand>();
+    }
+
+    public CDataQuestProcessState(CDataQuestProcessState obj)
+    {
+        ProcessNo = obj.ProcessNo;
+        SequenceNo = obj.SequenceNo;
+        BlockNo = obj.BlockNo;
+        WorkList = obj.WorkList.Select(x => new CDataQuestProgressWork(x)).ToList();
+        ResultCommandList = obj.ResultCommandList.Select(x => new CDataQuestCommand(x)).ToList();
+        CheckCommandList = obj.CheckCommandList.Select(x => new MtTypedArrayCDataQuestCommand(x)).ToList();
     }
 
     public ushort ProcessNo { get; set; }
@@ -51,6 +62,11 @@ public class CDataQuestProcessState
         public MtTypedArrayCDataQuestCommand()
         {
             ResultCommandList = new List<CDataQuestCommand>();
+        }
+
+        public MtTypedArrayCDataQuestCommand(MtTypedArrayCDataQuestCommand obj)
+        {
+            ResultCommandList = obj.ResultCommandList.Select(x => new CDataQuestCommand(x)).ToList();
         }
 
         public class Serializer : EntitySerializer<MtTypedArrayCDataQuestCommand>

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestProgressWork.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataQuestProgressWork.cs
@@ -4,6 +4,19 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
     public class CDataQuestProgressWork
     {
+        public CDataQuestProgressWork()
+        {
+        }
+
+        public CDataQuestProgressWork(CDataQuestProgressWork obj)
+        {
+            CommandNo = obj.CommandNo;
+            Work01 = obj.Work01;
+            Work02 = obj.Work02;
+            Work03 = obj.Work03;
+            Work04 = obj.Work04;
+        }
+
         public uint CommandNo { get; set; }
         public int Work01 { get; set; }
         public int Work02 { get; set; }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000002.json
@@ -94,6 +94,7 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
             "announce_type": "Update",
             "stage_id": {
                 "id": 3,
@@ -104,6 +105,7 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
             "stage_id": {
                 "id": 3,
                 "group_id": 1
@@ -113,11 +115,12 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 3,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "TheWhiteDragon",
             "message_id": 0
         },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000004.json
@@ -86,19 +86,21 @@
         },
         {
             "type": "raw",
+            "checkpoint": true,
+            "announce_type": "Update",
             "check_commands": [
                 {"type": "OpenAreaMaster", "Param1": 1}
             ],
-            "result_commands": [],
-            "announce_type": "Update"
+            "result_commands": []
         },
         {
             "type": "IsStageNo",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 78,
                 "group_id": 1
-            },
-            "announce_type": "Update"
+            }
         },
         {
             "type": "TalkToNpc",
@@ -113,6 +115,7 @@
         {
             "type": "Raw",
             "announce_type": "Update",
+            "checkpoint": true,
             "check_commands": [
                 {"type": "IsReleaseWarpPointAnyone", "Param1": 4}
             ],
@@ -120,11 +123,12 @@
         },
         {
             "type": "TalkToNpc",
+            "announce_type": "Update",
+            "checkpoint": true,
             "stage_id": {
                 "id": 78,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "Alvar",
             "message_id": 7539
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000005.json
@@ -108,6 +108,7 @@
         },
         {
             "type": "PartyGather",
+            "announce_type": "Accept",
             "stage_id": {
                 "id": 240,
                 "group_id": 1
@@ -117,7 +118,6 @@
                 "y": -3049,
                 "z": -49369
             },
-            "announce_type": "Accept",
             "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 907, "comment": "Dead Knights (Ark 576)"},
                 {"type": "QstLayout", "action": "Set", "value": 976, "comment": "NPC: Klaus0, Iris, Fabio0"},
@@ -155,6 +155,7 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
             "announce_type": "Update",
             "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 911, "comment": "Blocks boss fight exits"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000006.json
@@ -122,6 +122,7 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
             "stage_id": {
                 "id": 67
             },
@@ -156,11 +157,12 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 67,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 912, "comment": "Mine Rock Wall"},
                 {"type": "QstLayout", "action": "Clear", "value": 977, "comment": "Spawns Gerd and the White Knights outside Glowworm Cave"},
@@ -171,6 +173,8 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 1
             },
@@ -178,8 +182,7 @@
                 "x": -76088,
                 "y": 4285,
                 "z": 32829
-            },
-            "announce_type": "Update"
+            }
         },
         {
             "type": "PlayEvent",
@@ -190,11 +193,12 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 3,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "Joseph",
             "message_id": 7615
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000007.json
@@ -91,6 +91,7 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
             "announce_type": "Update",
             "stage_id": {
                 "id": 80
@@ -110,6 +111,7 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
             "announce_type": "Update",
             "stage_id": {
                 "id": 3

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000009.json
@@ -217,6 +217,7 @@
         },
         {
             "type": "PartyGather",
+            "checkpoint": true,
             "announce_type": "Update",
             "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 982, "comment": "Spawns Vanessa in the Audience Chamber"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000025.json
@@ -91,6 +91,7 @@
         },
         {
             "type": "PartyGather",
+            "announce_type": "Accept",
             "stage_id": {
                 "id": 66,
                 "group_id": 1
@@ -99,8 +100,7 @@
                 "x": -3082,
                 "y": 0,
                 "z": -183
-            },
-            "announce_type": "Accept"
+            }
         },
         {
             "type": "Raw",
@@ -113,6 +113,7 @@
         },
         {
             "type": "DiscoverEnemy",
+            "checkpoint": true,
             "announce_type": "Update",
             "groups": [0]
         },
@@ -124,6 +125,7 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
             "stage_id": {
                 "id": 66,
                 "group_id": 1
@@ -134,6 +136,7 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
             "stage_id": {
                 "id": 3,
                 "group_id": 1
@@ -144,6 +147,7 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
             "stage_id": {
                 "id": 3,
                 "group_id": 1

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000026.json
@@ -95,11 +95,12 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 78,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 898},
                 {"type": "QstLayout", "action": "Set", "value": 973, "comment": "Pawn Dungeon Entrance (wall)"},
@@ -110,11 +111,12 @@
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 3,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "Mysial0",
             "message_id": 10915
         },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000027.json
@@ -95,26 +95,29 @@
         },
         {
             "type": "KillGroup",
+            "checkpoint": true,
             "announce_type": "Update",
             "groups": [0]
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 95,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "Gilstan",
             "message_id": 10953
         },
         {
             "type": "TalkToNpc",
+            "checkpoint": true,
+            "announce_type": "Update",
             "stage_id": {
                 "id": 3,
                 "group_id": 1
             },
-            "announce_type": "Update",
             "npc_id": "Leo0",
             "message_id": 10960
         }

--- a/Arrowgene.Ddon.Shared/Model/Character.cs
+++ b/Arrowgene.Ddon.Shared/Model/Character.cs
@@ -35,8 +35,6 @@ namespace Arrowgene.Ddon.Shared.Model
             Pawns = new List<Pawn>();
             ReleasedWarpPoints = new List<ReleasedWarpPoint>();
             OnlineStatus = OnlineStatus.Offline;
-
-            PriorityQuests = new List<QuestId>();
         }
 
         public int AccountId { get; set; }
@@ -73,8 +71,6 @@ namespace Arrowgene.Ddon.Shared.Model
 
         // TODO: Move to a more sensible place
         public uint LastEnteredShopId { get; set; }
-
-        public List<QuestId> PriorityQuests { get; set; }
 
         public Pawn PawnBySlotNo(byte SlotNo)
         {

--- a/Arrowgene.Ddon.Shared/Model/Quest/CompletedQuest.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/CompletedQuest.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Model.Quest
+{
+    public class CompletedQuest
+    {
+        public QuestType QuestType { get; set; }
+        public QuestId QuestId { get; set; }
+        public uint ClearCount { get; set; }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestProgress.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestProgress.cs
@@ -14,4 +14,13 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public QuestType QuestType { get; set; }
         public uint Step { get; set; }
     }
+
+    public enum QuestProgressStatus : uint
+    {
+        ExecuteCommand = 0,
+        QuestProgress = 1,
+        WaitProgress = 2,
+        ProcessEnd = 3,
+        Error = 4
+    }
 }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestType.cs
@@ -17,6 +17,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
         // Pseudo Categories
         World = 1,
+        All
 
 #if false
 // Seems game has 2 different sets of quest IDs

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -753,7 +753,7 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_QUEST_11_88_16_NTC = new PacketId(11, 88, 16, "S2C_QUEST_11_88_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_QUEST_JOIN_LOBBY_QUEST_INFO_NTC = new PacketId(11, 89, 16, "S2C_QUEST_JOIN_LOBBY_QUEST_INFO_NTC", ServerType.Game, PacketSource.Server, "S2C_QUEST_11_89_16_NTC");
         public static readonly PacketId S2C_QUEST_PROGRESS_WORK_SAVE_NTC = new PacketId(11, 90, 16, "S2C_QUEST_PROGRESS_WORK_SAVE_NTC", ServerType.Game, PacketSource.Server, "S2C_QUEST_11_90_16_NTC");
-        public static readonly PacketId S2C_QUEST_11_91_16_NTC = new PacketId(11, 91, 16, "S2C_QUEST_11_91_16_NTC", ServerType.Game, PacketSource.Server); // Mission Completed
+        public static readonly PacketId S2C_QUEST_QUEST_COMPLETE_NTC = new PacketId(11, 91, 16, "S2C_QUEST_QUEST_COMPLETE_NTC", ServerType.Game, PacketSource.Server, "S2C_QUEST_11_91_16_NTC"); // Mission Completed
         public static readonly PacketId S2C_QUEST_11_92_16_NTC = new PacketId(11, 92, 16, "S2C_QUEST_11_92_16_NTC", ServerType.Game, PacketSource.Server); // Mission Started
         public static readonly PacketId S2C_QUEST_11_93_16_NTC = new PacketId(11, 93, 16, "S2C_QUEST_11_93_16_NTC", ServerType.Game, PacketSource.Server); // Mission completed
         public static readonly PacketId S2C_QUEST_11_94_16_NTC = new PacketId(11, 94, 16, "S2C_QUEST_11_94_16_NTC", ServerType.Game, PacketSource.Server); // Mission  All completed
@@ -2664,7 +2664,7 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_QUEST_11_88_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_JOIN_LOBBY_QUEST_INFO_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_PROGRESS_WORK_SAVE_NTC);
-            AddPacketIdEntry(packetIds, S2C_QUEST_11_91_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_QUEST_QUEST_COMPLETE_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_92_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_93_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_94_16_NTC);


### PR DESCRIPTION
- Party list updates with proper progress.
- Track completion of world quests.
- Add a new column to track number of times a quest is completed.
- Treat quest accept as a checkpoint for saving progress.
- Fix issue where shallow copy didn't really shallow copy in the quest structure.
- Fix issue where changing additional members of quest structure on accident.

## Migration Scripts

```sql
CREATE TABLE IF NOT EXISTS "ddon_priority_quests" (
	"character_common_id"	INTEGER NOT NULL,
	"quest_id"	INTEGER NOT NULL,
	FOREIGN KEY("character_common_id") REFERENCES "ddon_character_common"("character_common_id") ON DELETE CASCADE
);
```

Add a new column to the `ddon_completed_quests` called `clear_count`
```sql
"clear_count"	INTEGER NOT NULL DEFAULT 1
```

Remove primary key constraint from `ddon_quest_progress` for `character_common_id` which was added by mistake.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
