### PR TITLE
Added more safe areas to StageAreaChangeHandler.cs

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -15,15 +16,97 @@ namespace Arrowgene.Ddon.GameServer.Characters
     {
         private readonly static List<CDataStageInfo> StageList = EntitySerializer.Get<S2CStageGetStageListRes>().Read(GameDump.data_Dump_19).StageList;
 
-        public static StageNo ConvertIdToStageNo(StageId stageId)
+        public static StageNo ConvertIdToStageNo(uint stageId)
         {
             foreach (CDataStageInfo stageInfo in StageList)
             {
-                if (stageInfo.Id == stageId.Id)
-                    return (StageNo) stageInfo.StageNo;
+                if (stageInfo.Id == stageId)
+                    return (StageNo)stageInfo.StageNo;
             }
 
             return 0; // TODO: Maybe throw an exception?
+        }
+
+        public static StageNo ConvertIdToStageNo(StageId stageId)
+        {
+            return StageManager.ConvertIdToStageNo(stageId.Id);
+        }
+
+        // List of "safe" areas, where the context reset NTC will be sent.
+        // TODO: Complete with all the safe areas. Maybe move it to DB or config?
+        private static readonly HashSet<uint> SafeStageIds = new HashSet<uint>(){
+            2, // White Dragon Temple
+            341, // Dana Centrum
+            487, // Fortress City Megado: Residential Level
+            4, // Craft Room
+            5, // Cave Harbor
+            24, // White Deer Inn
+            25, // Black Grape Inn
+            26, // Sea Dragon Inn
+            48, // Singing Winds Inn
+            52, // Red Crystal Inn
+            53, // Sleeping Wolf Inn
+            61, // Golden Tankard Inn
+            66, // Gritten Fort
+            78, // Pawn Cathedral
+            98, // Hobolic Cave
+            137, // Mysree Grove Shrine
+            139, // Zandora Wastelands Shrine
+            141, // Breya Coast (Summer Event Hub Area)
+            237, // Mergoda Residential Area
+            317, // Expedition Garrison
+            339, // Protector's Retreat
+            340, // Morfaul Centrum
+            347, // Clan Hall
+            348, // Arisen's Room
+            377, // Glyndwr Centrum
+            384, // Hollow of Beginnings: Gathering Area
+            400, // Tower of Ivanos
+            401, // Spirit Arts Hut
+            411, // Manun Village
+            467, // Fort Thines
+            478, // Lookout Castle
+            480, // Bertha's Bandit Group Hideout
+            511, // Piremoth Traveler's Inn
+            512, // Rothgill Traveler's Inn
+            520, // Mephite Traveler's Inn
+            549, // Heroic Spirit Sleeping Path: Rathnite Foothills
+            557, // Heroic Spirit Sleeping Path: Feryana Wilderness
+            558, // Old Heroic Spirit Shrine
+            576, // Fort Thines: Great Dining Hall
+            580, // Fortress City Megado: Craft Room
+            584, // Eli Guard Tower
+            594  // Northern Bandit Hideout
+        };
+        public static bool IsSafeArea(uint stageId)
+        {
+            return SafeStageIds.Contains(stageId);
+        }
+
+        public static bool IsSafeArea(StageId stageId)
+        {
+            return StageManager.IsSafeArea(stageId.Id);
+        }
+
+        // List of lobby areas, where you're supposed to see all other players.
+        // TODO: Complete with all the safe areas. Maybe move it to DB or config?
+        private static readonly HashSet<uint> HubStageIds = new HashSet<uint>(){
+            2, // White Dragon Temple
+            141, // Breya Coast (Summer Event Hub Area)
+            341, // Dana Centrum
+            486, // Fortress City Megado: Residential Level
+            487, // Fortress City Megado: Residential Level
+            488, // Fortress City Megado: Royal Palace Level
+        };
+
+        public static bool IsHubArea(uint stageId)
+        {
+            return HubStageIds.Contains(stageId);
+        }
+
+        public static bool IsHubArea(StageId stageId)
+        {
+            return StageManager.IsHubArea(stageId.Id);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyDataMsgHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyDataMsgHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
@@ -11,16 +12,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
     public class LobbyLobbyDataMsgHandler : StructurePacketHandler<GameClient, C2SLobbyLobbyDataMsgReq>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(LobbyLobbyDataMsgHandler));
-
-        // List of lobby areas, where you're supposed to see all other players.
-        // TODO: Complete with all the safe areas. Maybe move it to DB or config?
-        private static readonly HashSet<uint> LobbyStageIds = new HashSet<uint>(){
-            2, // White Dragon Temple
-            341, // Dana Centrum
-            486, // Fortress City Megado: Residential Level
-            487, // Fortress City Megado: Residential Level
-            488, // Fortress City Megado: Royal Palace Level
-        };
 
         private readonly PartyManager _PartyManager;
 
@@ -38,7 +29,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             res.RpcPacket = packet.Structure.RpcPacket;
             res.OnlineStatus = client.Character.OnlineStatus;
 
-            if(!LobbyStageIds.Contains(client.Character.Stage.Id))
+            if(!StageManager.IsHubArea(client.Character.Stage))
             {
                 // We stick this in a seperate if statement so if the client
                 // is not in a party, we don't enter into the else condition

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -16,52 +16,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(StageAreaChangeHandler));
 
-        // List of "safe" areas, where the context reset NTC will be sent.
-        // TODO: Complete with all the safe areas. Maybe move it to DB or config?
-        private static readonly HashSet<uint> SafeStageIds = new HashSet<uint>(){
-            2, // White Dragon Temple
-            341, // Dana Centrum
-            487, // Fortress City Megado: Residential Level
-            4, // Craft Room
-            5, // Cave Harbor
-            24, // White Deer Inn
-            25, // Black Grape Inn
-            26, // Sea Dragon Inn
-            48, // Singing Winds Inn
-            52, // Red Crystal Inn
-            53, // Sleeping Wolf Inn
-            61, // Golden Tankard Inn
-            66, // Gritten Fort
-            78, // Pawn Cathedral
-            98, // Hobolic Cave
-            137, // Mysree Grove Shrine
-            139, // Zandora Wastelands Shrine
-            237, // Mergoda Residential Area
-            317, // Expedition Garrison
-            339, // Protector's Retreat
-            340, // Morfaul Centrum
-            347, // Clan Hall
-            348, // Arisen's Room
-            377, // Glyndwr Centrum            
-            384, // Hollow of Beginnings: Gathering Area
-            400, // Tower of Ivanos         
-            401, // Spirit Arts Hut
-            411, // Manun Village
-            467, // Fort Thines
-            478, // Lookout Castle
-            480, // Bertha's Bandit Group Hideout
-            511, // Piremoth Traveler's Inn
-            512, // Rothgill Traveler's Inn
-            520, // Mephite Traveler's Inn
-            549, // Heroic Spirit Sleeping Path: Rathnite Foothills
-            557, // Heroic Spirit Sleeping Path: Feryana Wilderness
-            558, // Old Heroic Spirit Shrine
-            576, // Fort Thines: Great Dining Hall
-            580, // Fortress City Megado: Craft Room
-            584, // Eli Guard Tower
-            594 // Northern Bandit Hideout
-        };
-
         public StageAreaChangeHandler(DdonGameServer server) : base(server)
         {
         }
@@ -69,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override void Handle(GameClient client, StructurePacket<C2SStageAreaChangeReq> packet)
         {
             S2CStageAreaChangeRes res = new S2CStageAreaChangeRes();
-            res.StageNo = ConvertIdToStageNo(packet.Structure.StageId);
+            res.StageNo = (uint) StageManager.ConvertIdToStageNo(packet.Structure.StageId);
             res.IsBase = false; // This is set true for audience chamber and WDT for exmaple
 
             client.Character.StageNo = res.StageNo;
@@ -82,7 +36,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Logger.Info($"StageNo:{client.Character.StageNo} StageId{packet.Structure.StageId}");
 
-            if (SafeStageIds.Contains(packet.Structure.StageId))
+            if (StageManager.IsSafeArea(client.Character.Stage))
             {
                 res.IsBase = true;
 
@@ -97,7 +51,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                     // TODO: Is it safe to iterate over player party members this way?
                     // TODO: Can this logic be made part of the party object instead?
-                    shouldReset &= SafeStageIds.Contains(((PlayerPartyMember)member).Client.Character.Stage.Id);
+                    shouldReset &= StageManager.IsSafeArea(((PlayerPartyMember)member).Client.Character.Stage);
                     if (!shouldReset)
                     {
                         // No need to loop over rest of party members
@@ -113,18 +67,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             client.Send(res);
-        }
-
-        private uint ConvertIdToStageNo(uint stageId)
-        {
-            foreach(CDataStageInfo stageInfo in (Server as DdonGameServer).StageList)
-            {
-                if(stageInfo.Id == stageId)
-                    return stageInfo.StageNo;
-            }
-
-            Logger.Error($"No stage found with Id:{stageId}");
-            return 0; // TODO: Maybe throw an exception?
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -19,7 +19,47 @@ namespace Arrowgene.Ddon.GameServer.Handler
         // List of "safe" areas, where the context reset NTC will be sent.
         // TODO: Complete with all the safe areas. Maybe move it to DB or config?
         private static readonly HashSet<uint> SafeStageIds = new HashSet<uint>(){
-            2 // White Dragon Temple
+            2, // White Dragon Temple
+            341, // Dana Centrum
+            487, // Fortress City Megado: Residential Level
+            4, // Craft Room
+            5, // Cave Harbor
+            24, // White Deer Inn
+            25, // Black Grape Inn
+            26, // Sea Dragon Inn
+            48, // Singing Winds Inn
+            52, // Red Crystal Inn
+            53, // Sleeping Wolf Inn
+            61, // Golden Tankard Inn
+            66, // Gritten Fort
+            78, // Pawn Cathedral
+            98, // Hobolic Cave
+            137, // Mysree Grove Shrine
+            139, // Zandora Wastelands Shrine
+            237, // Mergoda Residential Area
+            317, // Expedition Garrison
+            339, // Protector's Retreat
+            340, // Morfaul Centrum
+            347, // Clan Hall
+            348, // Arisen's Room
+            377, // Glyndwr Centrum            
+            384, // Hollow of Beginnings: Gathering Area
+            400, // Tower of Ivanos         
+            401, // Spirit Arts Hut
+            411, // Manun Village
+            467, // Fort Thines
+            478, // Lookout Castle
+            480, // Bertha's Bandit Group Hideout
+            511, // Piremoth Traveler's Inn
+            512, // Rothgill Traveler's Inn
+            520, // Mephite Traveler's Inn
+            549, // Heroic Spirit Sleeping Path: Rathnite Foothills
+            557, // Heroic Spirit Sleeping Path: Feryana Wilderness
+            558, // Old Heroic Spirit Shrine
+            576, // Fort Thines: Great Dining Hall
+            580, // Fortress City Megado: Craft Room
+            584, // Eli Guard Tower
+            594 // Northern Bandit Hideout
         };
 
         public StageAreaChangeHandler(DdonGameServer server) : base(server)


### PR DESCRIPTION
- Added more safe areas where reset NTC is sent.
- S2C_INSTANCE_AREA_RESET_NTC gets sent every time you zone in a safe area, meaning, when inside The White Dragon Temple, it'll happen a lot more, i don't know if this is a problem, if it is, i can remove the areas inside The White Dragon Temple until resolved.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
