### PR TITLE
Quest Enemy Spawn Adjustments

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -82,7 +82,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 group = client.Party.InstanceEnemyManager.GetAssets(StageId.FromStageLayoutId(layoutId), (byte) subGroupId);
             }
 
-            bool groupDestroyed = group.All(enemy => enemy.IsKilled);
+            bool groupDestroyed = group.Where(x => x.IsRequired).All(x => x.IsKilled);
             if (groupDestroyed)
             {
                 if (IsQuestControlled && quest != null)

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -143,8 +143,6 @@ namespace Arrowgene.Ddon.GameServer.Party
                     {
                         ActiveQuests[quest.QuestId].QuestEnemies[location.StageId] = new Dictionary<uint, List<InstancedEnemy>>();
                     }
-
-                    ActiveQuests[quest.QuestId].QuestEnemies[location.StageId][location.SubGroupId] = new List<InstancedEnemy>();
                 }
 
                 foreach (var request in quest.DeliveryItems)

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -204,12 +204,14 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 });
             }
 
+            bool ShouldResetGroup = false;
             if (questBlock.BlockType == QuestBlockType.DestroyGroup)
             {
+                ShouldResetGroup = true;
                 DestroyEnemiesForBlock(client, questBlock);
             }
 
-            if (questBlock.ResetGroup || questBlock.BlockType == QuestBlockType.DestroyGroup)
+            if (questBlock.ResetGroup || ShouldResetGroup)
             {
                 ResetEnemiesForBlock(client, questBlock);
             }

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -805,6 +805,12 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         index = jEnemyIndex.GetByte();
                     }
 
+                    bool isRequired = true;
+                    if (enemy.TryGetProperty("is_required", out JsonElement jIsRequired))
+                    {
+                        isRequired = jIsRequired.GetBoolean();
+                    }
+
                     var questEnemy = new InstancedEnemy()
                     {
                         EnemyId = Convert.ToUInt32(enemy.GetProperty("enemy_id").GetString(), 16),
@@ -813,8 +819,9 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         IsBossBGM = isBoss,
                         IsBossGauge = isBoss,
                         Scale = 100,
-                        EnemyTargetTypesId = 4,
+                        EnemyTargetTypesId = (byte)(isRequired ? 4 : 1),
                         Index = index,
+                        IsRequired = isRequired
                     };
 
                     ApplyOptionalEnemyKeys(enemy, questEnemy);

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -585,6 +585,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CInnGetStayPriceRes.Serializer());
             Create(new S2CInnStayInnRes.Serializer());
             Create(new S2CInnStayPenaltyHealInnRes.Serializer());
+            Create(new S2CInstanceEnemyDieNtc.Serializer());
             Create(new S2CInstanceSetOmInstantKeyValueNtc.Serializer());
             Create(new S2CInstanceExchangeOmInstantKeyValueNtc.Serializer());
             Create(new S2CInstanceAreaResetNtc.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstanceEnemyDieNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CInstanceEnemyDieNtc.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CInstanceEnemyDieNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_INSTANCE_ENEMY_DIE_NTC;
+
+        public CDataStageLayoutId LayoutId { get; set; }
+        public UInt32 SetId { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CInstanceEnemyDieNtc>
+        {
+            public override void Write(IBuffer buffer, S2CInstanceEnemyDieNtc obj)
+            {
+                WriteEntity<CDataStageLayoutId>(buffer, obj.LayoutId);
+                WriteUInt32(buffer, obj.SetId);
+            }
+
+            public override S2CInstanceEnemyDieNtc Read(IBuffer buffer)
+            {
+                S2CInstanceEnemyDieNtc obj = new S2CInstanceEnemyDieNtc();
+                obj.LayoutId = ReadEntity<CDataStageLayoutId>(buffer);
+                obj.SetId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
@@ -34,7 +34,7 @@
                 },
                 {
                     "item_id": 9396,
-                    "num": 2					
+                    "num": 2
                 }
             ]
         }
@@ -68,43 +68,47 @@
                     "enemy_id": "0x010308",
                     "level": 20,
                     "exp": 146,
-                    "is_boss": false					
+                    "is_boss": false
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "Gordon",
             "message_id": 11000,
             "flags": [
-            {"type": "QstLayout", "action": "Set", "value": 984, "comment": "write something when you figure out what it does"}
-             ]			
+                {"type": "QstLayout", "action": "Set", "value": 984}
+            ]
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "Gordon",
             "message_id": 11005
-		    }
-	   ]
+        }
+    ]
 }
 

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
@@ -41,13 +41,13 @@
     ],
     "enemy_groups": [
         {
-            "comment": "GroupId: 0",
             "stage_id": {
                 "id": 1,
                 "group_id": 26
             },
             "enemies": [
                 {
+                    "comment": "Cyclops",
                     "enemy_id": "0x015000",
                     "level": 12,
                     "exp": 1860,

--- a/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
@@ -10,14 +10,17 @@ namespace Arrowgene.Ddon.Shared.Model
         public InstancedEnemy(Enemy enemy) : base(enemy)
         {
             IsKilled = false;
+            IsRequired = true;
         }
 
         public InstancedEnemy(InstancedEnemy enemy) : base (enemy)
         {
             IsKilled = false;
             Index = enemy.Index;
+            IsRequired = enemy.IsRequired;
         }
 
+        public bool IsRequired { get; set; }
         public bool IsKilled { get; set; }
         public byte Index {  get; set; }
     }


### PR DESCRIPTION
- Fixed an issue where the quest enemies were being indicated as active before the step in the quest was reached.
- Add ability to mark an enemy in a group as required or not.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
