### PR TITLE
Fixes for some World Quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 770
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 660
@@ -18,21 +22,20 @@
             "amount": 60
         },
         {
-            "type": "exp",
-            "amount": 770
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Iron Ingot",
                     "item_id": 7874,
                     "num": 1
                 },
                 {
+                    "comment" : "Superior Healing Potion",
                     "item_id": 35,
                     "num": 3
                 },
                 {
+                    "comment" : "Throwing Rock",
                     "item_id": 9396,
                     "num": 2
                 }
@@ -47,28 +50,53 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x015600",
+                    "comment" : "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "named_enemy_params_id": 54,
                     "level": 20,
-                    "exp": 3000,
-                    "is_boss": true
+                    "exp": 510
                 },
                 {
+                    "comment" : "Skeleton Mage",
                     "enemy_id": "0x010308",
+                    "named_enemy_params_id": 54,
                     "level": 20,
-                    "exp": 146,
-                    "is_boss": false
+                    "exp": 510
                 },
                 {
-                    "enemy_id": "0x010308",
+                    "comment" : "Skeleton Knight",
+                    "enemy_id": "0x010301",
+                    "named_enemy_params_id": 53,
                     "level": 20,
-                    "exp": 146,
-                    "is_boss": false
+                    "exp": 384
                 },
                 {
-                    "enemy_id": "0x010308",
+                    "comment" : "Skeleton Knight",
+                    "enemy_id": "0x010301",
+                    "named_enemy_params_id": 53,
                     "level": 20,
-                    "exp": 146,
-                    "is_boss": false
+                    "exp": 384
+                },
+                {
+                    "comment" : "Skeleton Knight",
+                    "enemy_id": "0x010301",
+                    "named_enemy_params_id": 53,
+                    "level": 20,
+                    "exp": 384
+                },
+                {
+                    "comment" : "Skeleton Knight",
+                    "enemy_id": "0x010301",
+                    "named_enemy_params_id": 53,
+                    "level": 20,
+                    "exp": 384
+                },
+                {
+                    "comment" : "Skeleton Knight",
+                    "enemy_id": "0x010301",
+                    "named_enemy_params_id": 53,
+                    "level": 20,
+                    "exp": 384
                 }
             ]
         }
@@ -82,7 +110,7 @@
                 "layer_no": 1
             },
             "npc_id": "Gordon",
-            "message_id": 11000,
+            "message_id": 8620,
             "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 984}
             ]
@@ -107,7 +135,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Gordon",
-            "message_id": 11005
+            "message_id": 8623
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 700
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 420
@@ -18,17 +22,15 @@
             "amount": 60
         },
         {
-            "type": "exp",
-            "amount": 700
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Dull Iron Ingot",
                     "item_id": 7872,
                     "num": 3
                 },
                 {
+                    "comment" : "Recovery Decoction",
                     "item_id": 9373,
                     "num": 2
                 }
@@ -43,40 +45,60 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false
+                    "exp": 214
                 },
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false
+                    "exp": 214
                 },
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false
+                    "exp": 214
                 },
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false
+                    "exp": 214
                 },
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false				
+                    "exp": 214
                 },
                 {
-                    "enemy_id": "0x010301",
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 37,
-                    "is_boss": false			
+                    "exp": 214
+                },
+                {
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
+                    "level": 13,
+                    "exp": 214
+                },
+                {
+                    "comment" : "Undead (Male)",
+                    "enemy_id": "0x010500",
+                    "named_enemy_params_id": 53,
+                    "level": 13,
+                    "exp": 214
                 }
             ]
         }
@@ -88,17 +110,17 @@
                 "id": 3
             },
             "npc_id": "Joseph",
-            "message_id": 11000
+            "message_id": 10714
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {           
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
@@ -108,8 +130,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Joseph",
-            "message_id": 11005
-		    }
-	   ]
+            "message_id": 10718
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 830
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 590
@@ -18,17 +22,15 @@
             "amount": 70
         },
         {
-            "type": "exp",
-            "amount": 830
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Vigorous Legs",
                     "item_id": 8378,
                     "num": 1
                 },
                 {
+                    "comment" : "Superior Gala Extract",
                     "item_id": 61,
                     "num": 3
                 }
@@ -39,74 +41,86 @@
         {
             "stage_id": {
                 "id": 146,
-                "group_id": 7
+                "group_id": 8
             },
             "enemies": [
                 {
+                    "comment" : "Alchemized Goblin Fighter",
+                    "enemy_id": "0x011121",
+                    "named_enemy_params_id": 53,
+                    "level": 18,
+                    "exp": 384
+                },
+                {
+                    "comment" : "Alchemized Goblin Fighter",
+                    "enemy_id": "0x011121",
+                    "named_enemy_params_id": 53,
+                    "level": 18,
+                    "exp": 384
+                },
+                {
+                    "comment" : "Alchemized Goblin Fighter",
+                    "enemy_id": "0x011121",
+                    "named_enemy_params_id": 53,
+                    "level": 18,
+                    "exp": 384
+                },
+                {
+                    "comment" : "Alchemized Wolf",
                     "enemy_id": "0x010207",
                     "level": 18,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 384
                 },
                 {
+                    "comment" : "Alchemized Wolf",
                     "enemy_id": "0x010207",
                     "level": 18,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 384
                 },
                 {
-                    "enemy_id": "0x011120",
+                    "comment" : "Alchemized Wolf",
+                    "enemy_id": "0x010207",
                     "level": 18,
-                    "exp": 76,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x011120",
-                    "level": 18,
-                    "exp": 76,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x011120",
-                    "level": 18,
-                    "exp": 76,
-                    "is_boss": false					
+                    "exp": 384
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "Freya",
-            "message_id": 11000,
+            "message_id": 10756,
             "flags": [
-            {"type": "QstLayout", "action": "Set", "value": 987, "comment": "write something when you figure out what it does"}
-             ]			
+            {"type": "QstLayout", "action": "Set", "value": 987}
+             ]          
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {           
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "Freya",
-            "message_id": 11005
-		    }
-	   ]
+            "message_id": 10759
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
@@ -3,10 +3,14 @@
     "type": "World",
     "comment": "The Evil Lurking in the Tombs",
     "quest_id": 20000006,
-    "base_level": 34,
+    "base_level": 30,
     "minimum_item_rank": 0,
     "discoverable": true,
     "rewards": [
+        {
+            "type": "exp",
+            "amount": 1480
+        },
         {
             "type": "wallet",
             "wallet_type": "Gold",
@@ -18,23 +22,22 @@
             "amount": 130
         },
         {
-            "type": "exp",
-            "amount": 1480
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Battle Sallet",
                     "item_id": 524,
                     "num": 1
                 },
                 {
+                    "comment" : "Healing Elixir",
                     "item_id": 7552,
                     "num": 3
                 },
                 {
+                    "comment" : "Sprite's Amulet",
                     "item_id": 9384,
-                    "num": 2					
+                    "num": 2                    
                 }
             ]
         }
@@ -42,51 +45,68 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 239,
-                "group_id": 0
+                "id": 238,
+                "group_id": 9
             },
             "enemies": [
                 {
+                    "comment" : "Wight",
                     "enemy_id": "0x015600",
+                    "named_enemy_params_id": 54,
                     "level": 30,
-                    "exp": 5400,
-                    "is_boss": true			
+                    "exp": 9960         
+                },
+                {
+                    "comment" : "Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 54,
+                    "level": 30,
+                    "exp": 9960         
+                },
+                {
+                    "comment" : "Stout Undead",
+                    "enemy_id": "0x010502",
+                    "level": 28,
+                    "exp": 874         
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "Christoph",
-            "message_id": 11000,
+            "message_id": 11011,
             "flags": [
-            {"type": "QstLayout", "action": "Set", "value": 988, "comment": "write something when you figure out what it does"}	
-             ]			
+            {"type": "QstLayout", "action": "Set", "value": 988}    
+             ]          
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {           
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "Christoph",
-            "message_id": 11005
-		    }
-	   ]
+            "message_id": 11014
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 500
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 360
@@ -18,17 +22,15 @@
             "amount": 50
         },
         {
-            "type": "exp",
-            "amount": 500
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Crest of Poison",
                     "item_id": 9239,
                     "num": 1
                 },
                 {
+                    "comment" : "Meatloaf",
                     "item_id": 9408,
                     "num": 1
                 }
@@ -37,35 +39,45 @@
     ],
     "enemy_groups": [
         {
-            "comment": "GroupId: 0",
             "stage_id": {
                 "id": 1,
                 "group_id": 22
             },
             "enemies": [
                 {
+                    "comment" : "Orc Soldier",
                     "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
+                    "comment" : "Orc Soldier",
                     "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
-                    "enemy_id": "0x015800",
+                    "comment" : "Orc Banger",
+                    "enemy_id": "0x015802",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
+                    "comment" : "Orc Soldier",
                     "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
+                },
+                {
+                    "comment" : "Orc Banger",
+                    "enemy_id": "0x015802",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 160
                 }
             ]
         },
@@ -76,34 +88,39 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x015801",
+                    "comment" : "Orc Soldier",
+                    "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
-                    "enemy_id": "0x015801",
+                    "comment" : "Orc Soldier",
+                    "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
-                    "enemy_id": "0x015801",
+                    "comment" : "Orc Banger",
+                    "enemy_id": "0x015802",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
-                    "enemy_id": "0x015801",
+                    "comment" : "Orc Banger",
+                    "enemy_id": "0x015802",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 },
                 {
-                    "enemy_id": "0x015801",
+                    "comment" : "Orc Soldier",
+                    "enemy_id": "0x015800",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 80,
-                    "is_boss": false
+                    "exp": 160
                 }
             ]
         }
@@ -117,9 +134,9 @@
                 "layer_no": 1
             },
             "npc_id": "ArisenCorpsRegimentalSoldier8",
-            "message_id": 11000,
+            "message_id": 10817,
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 989, "comment": "Spawns Arisen Corps Regimental Solider"}
+                {"type": "QstLayout", "action": "Set", "value": 989}
             ]
         },
         {
@@ -153,7 +170,7 @@
             },
             "announce_type": "Update",
             "npc_id": "ArisenCorpsRegimentalSoldier8",
-            "message_id": 11005
+            "message_id": 10821
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 430
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 360
@@ -18,21 +22,20 @@
             "amount": 50
         },
         {
-            "type": "exp",
-            "amount": 430
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Battle Shield",
                     "item_id": 94,
                     "num": 1
                 },
                 {
+                    "comment" : "Lestania Wine",
                     "item_id": 9409,
                     "num": 1
                 },
                 {
+                    "comment" : "Water Flask",
                     "item_id": 9393,
                     "num": 3
                 }
@@ -47,82 +50,91 @@
             },
             "enemies": [
                 {
+                    "comment" : "Rogue Fighter",
                     "enemy_id": "0x011000",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 45
+                    "exp": 160,
+                    "hm_present_no": 45
                 },
                 {
+                    "comment" : "Rogue Fighter",
+                    "enemy_id": "0x011000",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 160,
+                    "hm_present_no": 45
+                },
+                {
+                    "comment" : "Rogue Fighter",
+                    "enemy_id": "0x011000",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 160,
+                    "hm_present_no": 45
+                },
+                {
+                    "comment" : "Rogue Fighter",
+                    "enemy_id": "0x011000",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 160,
+                    "hm_present_no": 46
+                },
+                {
+                    "comment" : "Rogue Seeker",
                     "enemy_id": "0x011001",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 46
+                    "exp": 160,
+                    "hm_present_no": 46
                 },
                 {
+                    "comment" : "Rogue Seeker",
                     "enemy_id": "0x011001",
+                    "named_enemy_params_id": 53,
                     "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 46
-                },
-                {
-                    "enemy_id": "0x011000",
-                    "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 46
-                },
-                {
-                    "enemy_id": "0x011000",
-                    "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 46					
-                },
-                {
-                    "enemy_id": "0x011004",
-                    "level": 11,
-                    "exp": 34,
-                    "is_boss": false,
-					"hm_present_no": 49				
+                    "exp": 160,
+                    "hm_present_no": 46
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",
+            "type": "NewNpcTalkAndOrder",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "npc_id": "Woman0",
             "message_id": 11000,
             "flags": [
-            {"type": "QstLayout", "action": "Set", "value": 990, "comment": "write something when you figure out what it does"}
-             ]
+            {"type": "QstLayout", "action": "Set", "value": 990}
+            ]
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {           
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
+            "reset_group": false,
             "groups": [0]
         },
         {
-            "type": "TalkToNpc",
+            "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 1
+                "id": 1,
+                "group_id": 1,
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "Woman0",
             "message_id": 11005
-		    }
-	   ]
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 2420
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 1380
@@ -18,23 +22,22 @@
             "amount": 270
         },
         {
-            "type": "exp",
-            "amount": 2420
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Crest of Greater Power",
                     "item_id": 9196,
                     "num": 1
                 },
                 {
+                    "comment" : "Superior Healing Elixir",
                     "item_id": 7553,
                     "num": 3
                 },
                 {
+                    "comment" : "Witch's Brew",
                     "item_id": 9421,
-                    "num": 1					
+                    "num": 1                    
                 }
             ]
         }
@@ -45,13 +48,15 @@
                 "id": 1,
                 "group_id": 290
             },
-			"starting_index": 5,
+            "starting_index": 2,
             "enemies": [
                 {
-                    "enemy_id": "0x015500",
+                    "comment" : "Armored Cyclops (Club)",
+                    "enemy_id": "0x015003",
+                    "named_enemy_params_id": 54,
                     "level": 40,
-                    "exp": 3445,
-                    "is_boss": true			
+                    "exp": 37420,
+                    "is_boss": true         
                 }
             ]
         }
@@ -63,39 +68,36 @@
                 "id": 3
             },
             "npc_id": "Joseph",
-            "message_id": 11000		
+            "message_id": 11368     
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
             "groups": [0]
         },
-        {			
+        {           
             "type": "KillGroup",
             "announce_type": "Update",
-			"reset_group": false,
-            "groups": [0]		
+            "reset_group": false,
+            "groups": [0]       
         },
         {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 50,
-                "group_id": 0
+                "id": 50
             },
             "announce_type": "Update",
-            "npc_id": "Brandon",			
-            "message_id": 10915
+            "npc_id": "Brandon",            
+            "message_id": 11809
         },
-        {			
+        {           
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 3,
-                "group_id": 0
+                "id": 3
             },
             "announce_type": "Update",
             "npc_id": "Joseph",
-            "message_id": 11005
-		    }
-	   ]
+            "message_id": 11812
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000013.json
@@ -3,10 +3,14 @@
     "type": "World",
     "comment": "Beloved Forest",
     "quest_id": 20000013,
-    "base_level": 15,
+    "base_level": 12,
     "minimum_item_rank": 0,
     "discoverable": true,
     "rewards": [
+        {
+            "type": "exp",
+            "amount": 750
+        },
         {
             "type": "wallet",
             "wallet_type": "Gold",
@@ -18,17 +22,15 @@
             "amount": 80
         },
         {
-            "type": "exp",
-            "amount": 750
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Mace",
                     "item_id": 64,
                     "num": 1
                 },
                 {
+                    "comment" : "Conqueror's Periapt",
                     "item_id": 42,
                     "num": 2
                 }
@@ -43,9 +45,11 @@
             },
             "enemies": [
                 {
+                    "comment" : "Dread Ape",
                     "enemy_id": "0x015502",
+                    "named_enemy_params_id": 53,
                     "level": 15,
-                    "exp": 1500,
+                    "exp": 2760,
                     "is_boss": true			
                 }
             ]
@@ -58,7 +62,7 @@
                 "id": 2
             },
             "npc_id": "Mayleaf0",
-            "message_id": 11000
+            "message_id": 11369
         },
         {
             "type": "DiscoverEnemy",
@@ -78,8 +82,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Mayleaf0",
-            "message_id": 11005
-		    }
-	   ]
+            "message_id": 11818
+        }
+    ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
@@ -8,6 +8,10 @@
     "discoverable": true,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 1380
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 990
@@ -18,21 +22,20 @@
             "amount": 150
         },
         {
-            "type": "exp",
-            "amount": 1380
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Saintly Hood",
                     "item_id": 734,
                     "num": 1
                 },
                 {
+                    "comment" : "Enhanced Pickaxe",
                     "item_id": 9401,
                     "num": 2
                 },
                 {
+                    "comment" : "Fortifier",
                     "item_id": 9377,
                     "num": 3
                 }
@@ -48,16 +51,18 @@
             "starting_index": 2,
             "enemies": [
                 {
+                    "comment" : "Orc Soldier",
                     "enemy_id": "0x015800",
+                    "named_enemy_params_id": 54,
                     "level": 30,
-                    "exp": 250,
-                    "is_boss": false
+                    "exp": 996
                 },
                 {
+                    "comment" : "Orc Soldier",
                     "enemy_id": "0x015800",
+                    "named_enemy_params_id": 54,
                     "level": 30,
-                    "exp": 250,
-                    "is_boss": false
+                    "exp": 996
                 }
             ]
         }
@@ -111,4 +116,3 @@
         }
     ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
@@ -8,6 +8,10 @@
     "discoverable": false,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 600
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 420
@@ -18,21 +22,20 @@
             "amount": 60
         },
         {
-            "type": "exp",
-            "amount": 600
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Palm Flower",
                     "item_id": 83,
                     "num": 1
                 },
                 {
+                    "comment" : "Pickaxe",
                     "item_id": 57,
                     "num": 3
                 },
                 {
+                    "comment" : "Recovery Decoction",
                     "item_id": 9373,
                     "num": 2					
                 }
@@ -47,9 +50,11 @@
             },
             "enemies": [
                 {
+                    "comment" : "Wight",
                     "enemy_id": "0x015600",
+                    "named_enemy_params_id": 53,
                     "level": 13,
-                    "exp": 480,
+                    "exp": 2140,
                     "is_boss": true			
                 }
             ]
@@ -68,4 +73,3 @@
         }
     ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
@@ -8,6 +8,10 @@
     "discoverable": false,
     "rewards": [
         {
+            "type": "exp",
+            "amount": 1020
+        },
+        {
             "type": "wallet",
             "wallet_type": "Gold",
             "amount": 850
@@ -18,23 +22,22 @@
             "amount": 130
         },
         {
-            "type": "exp",
-            "amount": 1020
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment" : "Sergeant's Helm",
                     "item_id": 842,
                     "num": 1
                 },
                 {
-                    "item_id": 35,
+                    "comment" : "Wine-Boiled Mushroom",
+                    "item_id": 9411,
                     "num": 3
                 },
                 {
+                    "comment" : "Throwing Rock",
                     "item_id": 9396,
-                    "num": 2					
+                    "num": 2
                 }
             ]
         }
@@ -47,10 +50,12 @@
             },
             "enemies": [
                 {
+                    "comment" : "Ogre",
                     "enemy_id": "0x015500",
+                    "named_enemy_params_id": 54,
                     "level": 26,
-                    "exp": 1024,
-                    "is_boss": true					
+                    "exp": 7600,
+                    "is_boss": true
                 }
             ]
         }
@@ -68,4 +73,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
- Fixes for some of the World Quests that was introduced last week.
- Based on videos and 2 wikis.
- Changed exp values for enemies based on DDOn-Tools values.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
