### PR TITLE
Add rule to warp player during first MSQ

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000001.json
@@ -180,118 +180,141 @@
             ]
         }
     ],
-    "blocks": [
+    "processes": [
         {
-            "type": "Raw",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 284},
-                {"type": "QstLayout", "action": "Set", "value": 937}
-            ],
-            "check_commands": [
-                {"type": "EventEnd", "Param1": 101, "Param2": 10}
-            ],
-            "result_commands": [
-                {"type": "ExeEventAfterStageJump", "Param1": 101, "Param2": 10, "Param3": 0}
-            ]
-        },
-        {
-            "type": "Raw",
-            "announce_type": "Accept",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 4, "comment": "Leo Waiting for Action to Begin"},
-                {"type": "MyQst", "action": "Set", "value": 11, "comment": "Iris NPC FSM"}
-            ],
-            "check_commands": [
-                {"type": "SceHitIn", "Param1": 101, "Param2": 1}
-            ],
-            "result_commands": []
-        },
-        {
-            "type": "KillGroup",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 934, "comment": "Move in front of the enemy"},
-                {"type": "MyQst", "action": "Set", "value": 935, "comment": "Move in front of the enemy"}
-            ],
-            "groups": [0]
-        },
-        {
-            "type": "KillGroup",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 13, "comment": "Leo"},
-                {"type": "MyQst", "action": "Set", "value": 936, "comment": "Leo moves to next battle"},
-                {"type": "MyQst", "action": "Set", "value": 937, "comment": "Iris idle"},
-                {"type": "MyQst", "action": "Set", "value": 598, "comment": "Iris Moves to next battle"},
-                {"type": "MyQst", "action": "Set", "value": 942, "comment": "Leo moves to next battle"}
-            ],
-            "groups": [1]
-        },
-        {
-            "type": "KillGroup",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 946, "comment": "Leo moves to next battle"}
-            ],
-            "groups": [2]
-        },
-        {
-            "type": "Raw",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 18, "comment": "Move to end"},
-                {"type": "MyQst", "action": "Set", "value": 599, "comment": "Move Iris and Leo to gate"}
-            ],
-            "check_commands": [
-                {"type": "StageNo", "Param1": 423}
-            ],
-            "result_commands": []
-        },
-        {
-            "type": "Raw",
-            "flags": [
-                {"type": "QstLayout", "action": "Clear", "value": 284},
-                {"type": "QstLayout", "action": "Set", "value": 1277}
-            ],
-            "check_commands": [
-                {"type": "EventEnd", "Param1": 423, "Param2": 0}
-            ],
-            "result_commands": [
-                {"type": "EventExec", "Param1": 423, "Param2": 0, "Param3": 423, "Param4": 0}
-            ]
-        },
-        {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 20}
-            ],
-            "groups": [3]
-        },
-        {
-            "type": "KillGroup",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 649}
-            ],
-            "groups": [4]
-        },
-        {
-            "type": "KillGroup",
-            "groups": [5]
-        },
-        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 284},
+                        {"type": "QstLayout", "action": "Set", "value": 937}
+                    ],
+                    "check_commands": [
+                        {"type": "EventEnd", "Param1": 101, "Param2": 10}
+                    ],
+                    "result_commands": [
+                        {"type": "ExeEventAfterStageJump", "Param1": 101, "Param2": 10, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 1, "comment": "Starts check for login in second process"},
+                        {"type": "MyQst", "action": "Set", "value": 4, "comment": "Leo Waiting for Action to Begin"},
+                        {"type": "MyQst", "action": "Set", "value": 11, "comment": "Iris NPC FSM"}
+                    ],
+                    "check_commands": [
+                        {"type": "SceHitIn", "Param1": 101, "Param2": 1}
+                    ],
+                    "result_commands": [
+                    ]
+                },
+                {
+                    "type": "KillGroup",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 934, "comment": "Move in front of the enemy"},
+                        {"type": "MyQst", "action": "Set", "value": 935, "comment": "Move in front of the enemy"}
+                    ],
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 13, "comment": "Leo"},
+                        {"type": "MyQst", "action": "Set", "value": 936, "comment": "Leo moves to next battle"},
+                        {"type": "MyQst", "action": "Set", "value": 937, "comment": "Iris idle"},
+                        {"type": "MyQst", "action": "Set", "value": 598, "comment": "Iris Moves to next battle"},
+                        {"type": "MyQst", "action": "Set", "value": 942, "comment": "Leo moves to next battle"}
+                    ],
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 946, "comment": "Leo moves to next battle"}
+                    ],
+                    "groups": [2]
+                },
+                {
+                    "type": "Raw",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 18, "comment": "Move to end"},
+                        {"type": "MyQst", "action": "Set", "value": 599, "comment": "Move Iris and Leo to gate"}
+                    ],
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 423}
+                    ],
+                    "result_commands": []
+                },
+                {
+                    "type": "Raw",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 284},
+                        {"type": "QstLayout", "action": "Set", "value": 1277}
+                    ],
+                    "check_commands": [
+                        {"type": "EventEnd", "Param1": 423, "Param2": 0}
+                    ],
+                    "result_commands": [
+                        {"type": "EventExec", "Param1": 423, "Param2": 0, "Param3": 423, "Param4": 0}
+                    ]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 20}
+                    ],
+                    "groups": [3]
+                },
+                {
+                    "type": "KillGroup",
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 649}
+                    ],
+                    "groups": [4]
+                },
+                {
+                    "type": "KillGroup",
+                    "groups": [5]
+                },
+                {
 
-            "type": "Raw",
-            "check_commands": [
-                {"type": "EventEnd", "Param1": 423, "Param2": 5}
-            ],
-            "result_commands": [
-                {"type": "EventExec", "Param1": 423, "Param2": 5, "Param3": 101, "Param4": 0}
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "EventEnd", "Param1": 423, "Param2": 5}
+                    ],
+                    "result_commands": [
+                        {"type": "EventExec", "Param1": 423, "Param2": 5, "Param3": 101, "Param4": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "EventEnd", "Param1": 101, "Param2": 5}
+                    ],
+                    "result_commands": [
+                        {"type": "EventExec", "Param1": 101, "Param2": 5, "Param3": 200, "Param4": 1}
+                    ]
+                }
             ]
         },
         {
-            "type": "Raw",
-            "check_commands": [
-                {"type": "EventEnd", "Param1": 101, "Param2": 5}
-            ],
-            "result_commands": [
-                {"type": "EventExec", "Param1": 101, "Param2": 5, "Param3": 200, "Param4": 1}
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "IsLogin"},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "StageJump", "Param1": 101, "Param2":  0}
+                    ]
+                }
             ]
         }
     ]


### PR DESCRIPTION
If a player logs out or disconnects during the first MSQ, when they log back in, they will be warped back to the tutorial stage.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
