### PR TITLE
Add underflow and overflow detection

### DIFF
--- a/Arrowgene.Ddon.Cli/Arrowgene.Ddon.Cli.csproj
+++ b/Arrowgene.Ddon.Cli/Arrowgene.Ddon.Cli.csproj
@@ -9,6 +9,12 @@
         <Version>$(Version)</Version>
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Client\Arrowgene.Ddon.Client.csproj" />

--- a/Arrowgene.Ddon.Client/Arrowgene.Ddon.Client.csproj
+++ b/Arrowgene.Ddon.Client/Arrowgene.Ddon.Client.csproj
@@ -10,6 +10,14 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Arrowgene.Buffers" Version="1.0.2" />

--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -10,6 +10,14 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
       <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />

--- a/Arrowgene.Ddon.GameServer/Arrowgene.Ddon.GameServer.csproj
+++ b/Arrowgene.Ddon.GameServer/Arrowgene.Ddon.GameServer.csproj
@@ -9,6 +9,12 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Server\Arrowgene.Ddon.Server.csproj" />

--- a/Arrowgene.Ddon.LoginServer/Arrowgene.Ddon.LoginServer.csproj
+++ b/Arrowgene.Ddon.LoginServer/Arrowgene.Ddon.LoginServer.csproj
@@ -9,6 +9,12 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
       <ProjectReference Include="..\Arrowgene.Ddon.GameServer\Arrowgene.Ddon.GameServer.csproj" />

--- a/Arrowgene.Ddon.Rpc.Web/Arrowgene.Ddon.Rpc.Web.csproj
+++ b/Arrowgene.Ddon.Rpc.Web/Arrowgene.Ddon.Rpc.Web.csproj
@@ -9,12 +9,18 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
-    <Import Project="./../SetSourceRevision.targets"/>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
-        <ProjectReference Include="..\Arrowgene.Ddon.Rpc\Arrowgene.Ddon.Rpc.csproj"/>
-        <ProjectReference Include="..\Arrowgene.Ddon.WebServer\Arrowgene.Ddon.WebServer.csproj"/>
+        <ProjectReference Include="..\Arrowgene.Ddon.Rpc\Arrowgene.Ddon.Rpc.csproj" />
+        <ProjectReference Include="..\Arrowgene.Ddon.WebServer\Arrowgene.Ddon.WebServer.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Arrowgene.WebServer" Version="1.1.4"/>
+        <PackageReference Include="Arrowgene.WebServer" Version="1.1.4" />
     </ItemGroup>
 </Project>

--- a/Arrowgene.Ddon.Rpc/Arrowgene.Ddon.Rpc.csproj
+++ b/Arrowgene.Ddon.Rpc/Arrowgene.Ddon.Rpc.csproj
@@ -9,6 +9,12 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.GameServer\Arrowgene.Ddon.GameServer.csproj" />

--- a/Arrowgene.Ddon.Server/Arrowgene.Ddon.Server.csproj
+++ b/Arrowgene.Ddon.Server/Arrowgene.Ddon.Server.csproj
@@ -9,6 +9,12 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Arrowgene.Buffers" Version="1.0.2" />

--- a/Arrowgene.Ddon.Shared/Arrowgene.Ddon.Shared.csproj
+++ b/Arrowgene.Ddon.Shared/Arrowgene.Ddon.Shared.csproj
@@ -10,6 +10,14 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Arrowgene.Buffers" Version="1.0.2" />

--- a/Arrowgene.Ddon.Shared/Crypto/BlowFish.cs
+++ b/Arrowgene.Ddon.Shared/Crypto/BlowFish.cs
@@ -1,4 +1,4 @@
-﻿//Blowfish encryption (ECB, CBC and CTR mode) as defined by Bruce Schneier here: http://www.schneier.com/paper-blowfish-fse.html
+//Blowfish encryption (ECB, CBC and CTR mode) as defined by Bruce Schneier here: http://www.schneier.com/paper-blowfish-fse.html
 //Complies with test vectors found here: http://www.schneier.com/code/vectors.txt
 //non-standard mode provided to be usable with the javascript crypto library found here: http://etherhack.co.uk/symmetric/blowfish/blowfish.html
 //By Taylor Hornby, 1/7/1010, 
@@ -621,10 +621,13 @@ namespace Arrowgene.Ddon.Shared.Crypto
         /// <returns></returns>
         private uint round(uint a, uint b, uint n)
         {
-            uint x1 = (bf_s0[wordByte0(b)] + bf_s1[wordByte1(b)]) ^ bf_s2[wordByte2(b)];
-            uint x2 = x1 + bf_s3[this.wordByte3(b)];
-            uint x3 = x2 ^ bf_P[n];
-            return x3 ^ a;
+            unchecked
+            {
+                uint x1 = (bf_s0[wordByte0(b)] + bf_s1[wordByte1(b)]) ^ bf_s2[wordByte2(b)];
+                uint x2 = x1 + bf_s3[this.wordByte3(b)];
+                uint x3 = x2 ^ bf_P[n];
+                return x3 ^ a;
+            }
         }
 
         #endregion

--- a/Arrowgene.Ddon.Shared/Crypto/Camellia.cs
+++ b/Arrowgene.Ddon.Shared/Crypto/Camellia.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Arrowgene.Ddon.Shared.Crypto
 {
@@ -343,17 +343,26 @@ namespace Arrowgene.Ddon.Shared.Crypto
 
         private byte s2(int x)
         {
-            return (byte) ((S[x] << 1) + (S[x] >> 7));
+            unchecked
+            {
+                return (byte)((S[x] << 1) + (S[x] >> 7));
+            }
         }
 
         private byte s3(int x)
         {
-            return (byte) ((S[x] << 7) + (S[x] >> 1));
+            unchecked
+            {
+                return (byte)((S[x] << 7) + (S[x] >> 1));
+            }
         }
 
         private byte s4(int x)
         {
-            return S[(byte) (x << 1) + (x >> 7)];
+            unchecked
+            {
+                return S[(byte)(x << 1) + (x >> 7)];
+            }
         }
 
         /* dst[] <- src1[] ^ src2[] */
@@ -404,14 +413,17 @@ namespace Arrowgene.Ddon.Shared.Crypto
         /* x[] <<<= 1 */
         private void rot1(int nOctets, Span<byte> x)
         {
-            byte x0 = x[0];
-            nOctets--;
-            for (int i = 0; i < nOctets; i++)
+            unchecked
             {
-                x[i] = (byte) ((x[i] << 1) ^ (x[i + 1] >> 7));
-            }
+                byte x0 = x[0];
+                nOctets--;
+                for (int i = 0; i < nOctets; i++)
+                {
+                    x[i] = (byte)((x[i] << 1) ^ (x[i + 1] >> 7));
+                }
 
-            x[nOctets] = (byte) ((x[nOctets] << 1) ^ (x0 >> 7));
+                x[nOctets] = (byte)((x[nOctets] << 1) ^ (x0 >> 7));
+            }
         }
 
         /* rotate 128-bit data to the left by 16 bits */
@@ -433,17 +445,20 @@ namespace Arrowgene.Ddon.Shared.Crypto
         /* rotate 128-bit data to the left by 15 bits */
         private void rot15(Span<byte> x)
         {
-            byte x15;
-            int i;
-
-            rot16(x);
-            x15 = x[15];
-            for (i = 15; i >= 1; i--)
+            unchecked
             {
-                x[i] = (byte) ((x[i] >> 1) ^ (x[i - 1] << 7));
-            }
+                byte x15;
+                int i;
 
-            x[0] = (byte) ((x[0] >> 1) ^ (x15 << 7));
+                rot16(x);
+                x15 = x[15];
+                for (i = 15; i >= 1; i--)
+                {
+                    x[i] = (byte)((x[i] >> 1) ^ (x[i - 1] << 7));
+                }
+
+                x[0] = (byte)((x[0] >> 1) ^ (x15 << 7));
+            }
         }
 
         /* rotate 128-bit data to the left by 17 bits */

--- a/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
+++ b/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
@@ -10,6 +10,12 @@
         <IsPackable>false</IsPackable>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />

--- a/Arrowgene.Ddon.WebServer/Arrowgene.Ddon.WebServer.csproj
+++ b/Arrowgene.Ddon.WebServer/Arrowgene.Ddon.WebServer.csproj
@@ -9,6 +9,12 @@
         <Copyright>Copyright © 2019-2022 DDON Team</Copyright>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />


### PR DESCRIPTION
Enabled the build flag which detects underflow and overflow by default. Marked certain functions as unchecked in the networking library as they are depending on this behavior for certain operations.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
