### PR TITLE
Database migrator proposal

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
@@ -1,0 +1,95 @@
+using Arrowgene.Ddon.Database;
+using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Shared;
+using Arrowgene.Logging;
+using System;
+using System.IO;
+
+namespace Arrowgene.Ddon.Cli.Command
+{
+    public class DbMigrationCommand : ICommand
+    {
+        private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(ServerCommand));
+
+        public string Key => "dbmigration";
+
+        public string Description => $"Commandline tool to update the database\n\n" +
+                                     $"usage:\n" +
+                                     $"{Key} <previous version>\n" +
+                                     $"The previous version argument is required only when using sqlite as the database engine.";
+
+        public CommandResultType Run(CommandParameter parameter)
+        {
+           
+            string settingPath = Path.Combine(Util.ExecutingDirectory(), "Files/Arrowgene.Ddon.config.json");
+            Setting settings = Setting.Load(settingPath);
+            if (settings == null)
+            {
+                return CommandResultType.Exit;
+            }
+
+            DatabaseSetting dbSettings = settings.DatabaseSetting;
+            if (dbSettings == null)
+            {
+                return CommandResultType.Exit;
+            }
+
+            Enum.TryParse(dbSettings.Type, true, out DatabaseType dbType);
+            if (dbType == DatabaseType.SQLite)
+            {
+                if (parameter.Arguments.Count < 1)
+                {
+                    Logger.Error("The previous version argument is required when using sqlite as the database engine.");
+                    return CommandResultType.Exit;
+                }
+
+                if(!uint.TryParse(parameter.Arguments[0], out uint previousVersion))
+                {
+                    Logger.Error($"Failed to parse the version value '{parameter.Arguments[1]}'.");
+                    return CommandResultType.Exit;
+                }
+
+                string oldSqlitePath = DdonDatabaseBuilder.BuildSqLitePath(dbSettings.DatabaseFolder, previousVersion);
+                if (!File.Exists(oldSqlitePath))
+                {
+                    Logger.Error($"The previous version database file '{oldSqlitePath}' does not exist.");
+                    return CommandResultType.Exit;
+                }
+
+                string newSqlitePath = DdonDatabaseBuilder.BuildSqLitePath(dbSettings.DatabaseFolder, DdonDatabaseBuilder.Version);
+                if (File.Exists(newSqlitePath))
+                {
+                    Logger.Error($"Cannot migrate the database, the file '{newSqlitePath}' already exists.");
+                    return CommandResultType.Exit;
+                }
+
+                File.Copy(oldSqlitePath, newSqlitePath);
+            }
+
+            IDatabase database = DdonDatabaseBuilder.Build(dbSettings);
+            if (database == null)
+            {
+                return CommandResultType.Exit;
+            }
+
+            // TODO: Warn that migration is destructive
+            bool result = database.MigrateDatabase(DdonDatabaseBuilder.Version);
+
+            // TODO: Better logging
+            if(result)
+            {
+                Logger.Info($"Successfully migrated the database to version '{DdonDatabaseBuilder.Version}'.");
+            }
+            else
+            {
+                Logger.Error("Failed to migrate the database.");
+            }
+
+            return CommandResultType.Exit;
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+}

--- a/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
@@ -1,9 +1,12 @@
 using Arrowgene.Ddon.Database;
-using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Database.Sql.Core.Migration;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Logging;
-using System;
+using System.Linq;
 using System.IO;
+using System.Reflection;
+using System;
+using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.Cli.Command
 {
@@ -15,8 +18,7 @@ namespace Arrowgene.Ddon.Cli.Command
 
         public string Description => $"Commandline tool to update the database\n\n" +
                                      $"usage:\n" +
-                                     $"{Key} <previous version>\n" +
-                                     $"The previous version argument is required only when using sqlite as the database engine.";
+                                     $"{Key}\n";
 
         public CommandResultType Run(CommandParameter parameter)
         {
@@ -32,38 +34,6 @@ namespace Arrowgene.Ddon.Cli.Command
             if (dbSettings == null)
             {
                 return CommandResultType.Exit;
-            }
-
-            Enum.TryParse(dbSettings.Type, true, out DatabaseType dbType);
-            if (dbType == DatabaseType.SQLite)
-            {
-                if (parameter.Arguments.Count < 1)
-                {
-                    Logger.Error("The previous version argument is required when using sqlite as the database engine.");
-                    return CommandResultType.Exit;
-                }
-
-                if(!uint.TryParse(parameter.Arguments[0], out uint previousVersion))
-                {
-                    Logger.Error($"Failed to parse the version value '{parameter.Arguments[1]}'.");
-                    return CommandResultType.Exit;
-                }
-
-                string oldSqlitePath = DdonDatabaseBuilder.BuildSqLitePath(dbSettings.DatabaseFolder, previousVersion);
-                if (!File.Exists(oldSqlitePath))
-                {
-                    Logger.Error($"The previous version database file '{oldSqlitePath}' does not exist.");
-                    return CommandResultType.Exit;
-                }
-
-                string newSqlitePath = DdonDatabaseBuilder.BuildSqLitePath(dbSettings.DatabaseFolder, DdonDatabaseBuilder.Version);
-                if (File.Exists(newSqlitePath))
-                {
-                    Logger.Error($"Cannot migrate the database, the file '{newSqlitePath}' already exists.");
-                    return CommandResultType.Exit;
-                }
-
-                File.Copy(oldSqlitePath, newSqlitePath);
             }
 
             IDatabase database = DdonDatabaseBuilder.Build(dbSettings);

--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -94,6 +94,7 @@ namespace Arrowgene.Ddon.Cli
             AddCommand(new HelpCommand(_commands));
             AddCommand(new ClientCommand());
             AddCommand(new PacketCommand());
+            AddCommand(new DbMigrationCommand());
         }
 
         private void RunArguments(string[] arguments)

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -16,7 +16,7 @@ namespace Arrowgene.Ddon.Database
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-        public const uint Version = 1;
+        public const uint Version = 2;
 
         public static IDatabase Build(DatabaseSetting settings)
         {
@@ -31,6 +31,7 @@ namespace Arrowgene.Ddon.Database
 
             database.Migrator = new DatabaseMigrator(new List<IMigrationStrategy>()
             {
+                new MailMigration(settings)
             });
 
             database.CreateMeta(new DatabaseMeta()

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -53,14 +53,14 @@ namespace Arrowgene.Ddon.Database
             return database;
         }
 
-        public static string BuildSqLitePath(string databaseFolder, uint version)
+        public static string BuildSqLitePath(string databaseFolder)
         {
-            return Path.Combine(databaseFolder, $"db.v{version}.sqlite");
+            return Path.Combine(databaseFolder, $"db.sqlite");
         }
 
         public static DdonSqLiteDb BuildSqLite(string databaseFolder, bool wipeOnStartup)
         {
-            string sqLitePath = BuildSqLitePath(databaseFolder, Version);
+            string sqLitePath = BuildSqLitePath(databaseFolder);
             DdonSqLiteDb db = new DdonSqLiteDb(sqLitePath, wipeOnStartup);
             if (db.CreateDatabase())
             {

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -52,9 +52,14 @@ namespace Arrowgene.Ddon.Database
             return database;
         }
 
+        public static string BuildSqLitePath(string databaseFolder, uint version)
+        {
+            return Path.Combine(databaseFolder, $"db.v{version}.sqlite");
+        }
+
         public static DdonSqLiteDb BuildSqLite(string databaseFolder, bool wipeOnStartup)
         {
-            string sqLitePath = Path.Combine(databaseFolder, $"db.v{DdonSqLiteDb.Version}.sqlite");
+            string sqLitePath = BuildSqLitePath(databaseFolder, Version);
             DdonSqLiteDb db = new DdonSqLiteDb(sqLitePath, wipeOnStartup);
             if (db.CreateDatabase())
             {

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Database.Sql;
+using Arrowgene.Ddon.Database.Sql.Core.Migration;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Logging;
 
@@ -15,7 +16,7 @@ namespace Arrowgene.Ddon.Database
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-        public const uint Version = 2;
+        public const uint Version = 1;
 
         public static IDatabase Build(DatabaseSetting settings)
         {
@@ -27,6 +28,10 @@ namespace Arrowgene.Ddon.Database
                 DatabaseType.MariaDb => BuildMariaDB(settings.DatabaseFolder, settings.Host, settings.User, settings.Password, settings.Database, settings.WipeOnStartup),
                 _ => throw new ArgumentOutOfRangeException($"Unknown database type '{settings.Type}' encountered!")
             };
+
+            database.Migrator = new DatabaseMigrator(new List<IMigrationStrategy>()
+            {
+            });
 
             database.CreateMeta(new DatabaseMeta()
             {

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -53,6 +53,35 @@ namespace Arrowgene.Ddon.Database
             return database;
         }
 
+        public static string AdaptSQLiteSchemaToPostgreSQL(string schema)
+        {
+            schema = Regex.Replace(schema, "(\\s)DATETIME(\\s|,)", "$1TIMESTAMP WITH TIME ZONE$2");
+            schema = Regex.Replace(schema, "(\\s)INTEGER PRIMARY KEY AUTOINCREMENT(\\s|,)", "$1SERIAL PRIMARY KEY$2");
+            schema = Regex.Replace(schema, "(\\s)BLOB(\\s|,)", "$1BYTEA$2");
+            return schema;
+        }
+
+        public static string AdaptSQLiteSchemaToMariaDB(string schema)
+        {
+            schema = Regex.Replace(schema, "(\\s)AUTOINCREMENT(\\s|,)", "$1AUTO_INCREMENT$2");
+            return schema;
+        }
+
+        public static string AdaptSQLiteSchemaTo(DatabaseType databaseType, string schema)
+        {
+            switch (databaseType)
+            {
+                case DatabaseType.SQLite:
+                    return schema;
+                case DatabaseType.PostgreSQL:
+                    return AdaptSQLiteSchemaToPostgreSQL(schema);
+                case DatabaseType.MariaDb:
+                    return AdaptSQLiteSchemaToMariaDB(schema);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         public static string BuildSqLitePath(string databaseFolder)
         {
             return Path.Combine(databaseFolder, $"db.sqlite");
@@ -82,9 +111,7 @@ namespace Arrowgene.Ddon.Database
             {
                 string schemaFilePath = Path.Combine(databaseFolder, DefaultSchemaFile);
                 String schema = File.ReadAllText(schemaFilePath, Encoding.UTF8);
-                schema = Regex.Replace(schema, "(\\s)DATETIME(\\s|,)", "$1TIMESTAMP WITH TIME ZONE$2");
-                schema = Regex.Replace(schema, "(\\s)INTEGER PRIMARY KEY AUTOINCREMENT(\\s|,)", "$1SERIAL PRIMARY KEY$2");
-                schema = Regex.Replace(schema, "(\\s)BLOB(\\s|,)", "$1BYTEA$2");
+                schema = AdaptSQLiteSchemaToPostgreSQL(schema);
                 
                 db.Execute(schema);
             }
@@ -99,8 +126,7 @@ namespace Arrowgene.Ddon.Database
             {
                 string schemaFilePath = Path.Combine(databaseFolder, DefaultSchemaFile);
                 String schema = File.ReadAllText(schemaFilePath, Encoding.UTF8);
-                schema = Regex.Replace(schema, "(\\s)AUTOINCREMENT(\\s|,)", "$1AUTO_INCREMENT$2");
-                
+                schema = AdaptSQLiteSchemaToMariaDB(schema);
                 db.Execute(schema);
             }
 

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -28,6 +28,11 @@ namespace Arrowgene.Ddon.Database
                 _ => throw new ArgumentOutOfRangeException($"Unknown database type '{settings.Type}' encountered!")
             };
 
+            database.CreateMeta(new DatabaseMeta()
+            {
+                DatabaseVersion = Version
+            });
+
             if (database == null)
             {
                 Logger.Error("Database could not be created, exiting...");

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Database.Sql;
+using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.Database
@@ -12,6 +14,8 @@ namespace Arrowgene.Ddon.Database
     {
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
+
+        public const uint Version = 2;
 
         public static IDatabase Build(DatabaseSetting settings)
         {
@@ -48,6 +52,8 @@ namespace Arrowgene.Ddon.Database
                 String schema = File.ReadAllText(schemaFilePath, Encoding.UTF8);
                 
                 db.Execute(schema);
+
+                Logger.Info($"Created new v{Version} database");
             }
 
             return db;

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Database.Sql;
-using Arrowgene.Ddon.Database.Sql.Core.Migration;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Logging;
 
@@ -28,11 +26,6 @@ namespace Arrowgene.Ddon.Database
                 DatabaseType.MariaDb => BuildMariaDB(settings.DatabaseFolder, settings.Host, settings.User, settings.Password, settings.Database, settings.WipeOnStartup),
                 _ => throw new ArgumentOutOfRangeException($"Unknown database type '{settings.Type}' encountered!")
             };
-
-            database.Migrator = new DatabaseMigrator(new List<IMigrationStrategy>()
-            {
-                new MailMigration(settings)
-            });
 
             database.CreateMeta(new DatabaseMeta()
             {

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_mail_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_mail_sqlite.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "ddon_system_mail" (
+	"message_id"	INTEGER NOT NULL,
+	"character_id"	INTEGER NOT NULL,
+	"message_state"	INTEGER NOT NULL,
+	"sender_name"	VARCHAR(256) NOT NULL DEFAULT "",
+	"message_title"	VARCHAR(256) NOT NULL DEFAULT "",
+	"message_body"	VARCHAR(2048) NOT NULL DEFAULT "",
+	"send_date"	INTEGER NOT NULL DEFAULT 0,
+	FOREIGN KEY("character_id") REFERENCES "ddon_character"("character_id") ON DELETE CASCADE,
+	PRIMARY KEY("message_id" AUTOINCREMENT)
+);
+
+CREATE TABLE IF NOT EXISTS "ddon_system_mail_attachment" (
+	"message_id"	INTEGER NOT NULL,
+	"attachment_id"	INTEGER NOT NULL,
+	"attachment_type"	INTEGER NOT NULL,
+	"is_received"	INTEGER NOT NULL DEFAULT 0,
+	"param0"	VARCHAR(256) NOT NULL DEFAULT "",
+	"param1"	INTEGER NOT NULL DEFAULT 0,
+	"param2"	INTEGER NOT NULL DEFAULT 0,
+	"param3"	INTEGER NOT NULL DEFAULT 0,
+	FOREIGN KEY("message_id") REFERENCES "ddon_system_mail"("message_id") ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_mail_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_mail_sqlite.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "ddon_system_mail" (
+CREATE TABLE "ddon_system_mail" (
 	"message_id"	INTEGER NOT NULL,
 	"character_id"	INTEGER NOT NULL,
 	"message_state"	INTEGER NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS "ddon_system_mail" (
 	PRIMARY KEY("message_id" AUTOINCREMENT)
 );
 
-CREATE TABLE IF NOT EXISTS "ddon_system_mail_attachment" (
+CREATE TABLE "ddon_system_mail_attachment" (
 	"message_id"	INTEGER NOT NULL,
 	"attachment_id"	INTEGER NOT NULL,
 	"attachment_type"	INTEGER NOT NULL,

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -1,4 +1,9 @@
-﻿CREATE TABLE IF NOT EXISTS setting
+CREATE TABLE IF NOT EXISTS meta
+(
+    "db_version" INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS setting
 (
     "key"   VARCHAR(32) NOT NULL,
     "value" TEXT        NOT NULL,

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS meta
+﻿CREATE TABLE IF NOT EXISTS meta
 (
     "db_version" INTEGER NOT NULL
 );

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -1,5 +1,6 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.Structure;
@@ -11,6 +12,8 @@ namespace Arrowgene.Ddon.Database
     public interface IDatabase
     {
         void Execute(string sql);
+        void Execute(DbConnection conn, string sql);
+        bool ExecuteInTransaction(Action<DbConnection> action);
 
         /// <summary>
         /// Return true if database was created, or false if not.

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -19,6 +19,7 @@ namespace Arrowgene.Ddon.Database
         /// Return true if database was created, or false if not.
         /// </summary>
         bool CreateDatabase();
+        bool MigrateDatabase(uint toVersion);
 
         // Meta
         bool CreateMeta(DatabaseMeta meta);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -12,8 +12,6 @@ namespace Arrowgene.Ddon.Database
 {
     public interface IDatabase
     {
-        DatabaseMigrator Migrator { get; set; }
-
         void Execute(string sql);
         void Execute(DbConnection conn, string sql);
         bool ExecuteInTransaction(Action<DbConnection> action);
@@ -22,7 +20,7 @@ namespace Arrowgene.Ddon.Database
         /// Return true if database was created, or false if not.
         /// </summary>
         bool CreateDatabase();
-        bool MigrateDatabase(uint toVersion);
+        bool MigrateDatabase(DatabaseMigrator migrator, uint toVersion);
 
         // Meta
         bool CreateMeta(DatabaseMeta meta);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
@@ -15,6 +16,11 @@ namespace Arrowgene.Ddon.Database
         /// Return true if database was created, or false if not.
         /// </summary>
         bool CreateDatabase();
+
+        // Meta
+        bool CreateMeta(DatabaseMeta meta);
+        bool SetMeta(DatabaseMeta meta);
+        DatabaseMeta GetMeta();
 
         // Account
         Account CreateAccount(string name, string mail, string hash);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Database.Sql.Core.Migration;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
@@ -11,6 +12,8 @@ namespace Arrowgene.Ddon.Database
 {
     public interface IDatabase
     {
+        DatabaseMigrator Migrator { get; set; }
+
         void Execute(string sql);
         void Execute(DbConnection conn, string sql);
         bool ExecuteInTransaction(Action<DbConnection> action);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Text;
+using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.Database.Sql.Core
@@ -8,7 +9,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     /// <summary>
     /// Implementation of Ddon database operations.
     /// </summary>
-    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>, IDatabase
         where TCon : DbConnection
         where TCom : DbCommand
         where TReader : DbDataReader
@@ -97,6 +98,18 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             }
 
             return sb.ToString();
+        }
+        
+        public abstract bool CreateDatabase();
+
+        public void Execute(DbConnection conn, string sql)
+        {
+            base.Execute((TCon) conn, sql);
+        }
+
+        public bool ExecuteInTransaction(Action<DbConnection> action)
+        {
+            return base.ExecuteInTransaction((conn) => action.Invoke(conn));
         }
 
         protected override void Exception(Exception ex, string query)

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -112,6 +112,11 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return base.ExecuteInTransaction((conn) => action.Invoke(conn));
         }
 
+        public bool MigrateDatabase(uint toVersion)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void Exception(Exception ex, string query)
         {
             Logger.Exception(ex);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -17,8 +17,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     {
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonSqlDb<TCon, TCom, TReader>));
 
-        public DatabaseMigrator Migrator { get; set; }
-
         public DdonSqlDb()
         {
         }
@@ -115,15 +113,10 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return base.ExecuteInTransaction((conn) => action.Invoke(conn));
         }
 
-        public bool MigrateDatabase(uint toVersion)
+        public bool MigrateDatabase(DatabaseMigrator migrator, uint toVersion)
         {
-            if(Migrator == null)
-            {
-                return false;
-            }
-
             uint currentVersion = GetMeta().DatabaseVersion;
-            bool result = Migrator.MigrateDatabase(this, currentVersion, toVersion);
+            bool result = migrator.MigrateDatabase(this, currentVersion, toVersion);
             if (result)
             {
                 SetMeta(new DatabaseMeta()

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Data.Common;
 using System.Text;
+using Arrowgene.Ddon.Database.Sql.Core.Migration;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Logging;
 
@@ -15,6 +16,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         where TReader : DbDataReader
     {
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonSqlDb<TCon, TCom, TReader>));
+
+        public DatabaseMigrator Migrator { get; set; }
 
         public DdonSqlDb()
         {
@@ -114,7 +117,21 @@ namespace Arrowgene.Ddon.Database.Sql.Core
 
         public bool MigrateDatabase(uint toVersion)
         {
-            throw new NotImplementedException();
+            if(Migrator == null)
+            {
+                return false;
+            }
+
+            uint currentVersion = GetMeta().DatabaseVersion;
+            bool result = Migrator.MigrateDatabase(this, currentVersion, toVersion);
+            if (result)
+            {
+                SetMeta(new DatabaseMeta()
+                {
+                    DatabaseVersion = DdonDatabaseBuilder.Version
+                });
+            }
+            return result;
         }
 
         protected override void Exception(Exception ex, string query)

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbMeta.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbMeta.cs
@@ -1,0 +1,54 @@
+using System.Data.Common;
+using Arrowgene.Ddon.Shared.Entity;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        protected static readonly string[] MetaFields = new string[]
+        {
+            "db_version"
+        };
+
+        private static readonly string SqlInsertOrIgnoreMeta = $"INSERT INTO \"meta\" ({BuildQueryField(MetaFields)}) SELECT ({BuildQueryInsert(MetaFields)}) WHERE NOT EXISTS (SELECT 1 FROM \"meta\" LIMIT 1);";
+        private static readonly string SqlUpdateMeta = $"UPDATE \"meta\" SET {BuildQueryUpdate(MetaFields)};";
+        private static readonly string SqlSelectMeta = $"SELECT {BuildQueryField(MetaFields)} FROM \"meta\" LIMIT 1;";
+        
+
+        public bool CreateMeta(DatabaseMeta meta)
+        {
+            int rowsAffected = ExecuteNonQuery(SqlInsertOrIgnoreMeta, command =>
+            {
+                AddParameter(command, "@db_version", meta.DatabaseVersion);
+            });
+
+            return rowsAffected > NoRowsAffected;
+        }
+
+        public bool SetMeta(DatabaseMeta meta)
+        {
+            int rowsAffected = ExecuteNonQuery(SqlUpdateMeta, command =>
+            {
+                AddParameter(command, "@db_version", meta.DatabaseVersion);
+            });
+
+            return rowsAffected > NoRowsAffected;
+        }
+
+        public DatabaseMeta GetMeta()
+        {
+            DatabaseMeta meta = new DatabaseMeta();
+            ExecuteReader(SqlSelectMeta, command => {}, reader =>
+            {
+                if(reader.Read())
+                {
+                    meta.DatabaseVersion = GetUInt32(reader, "db_version");
+                }
+            });
+            return meta;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbUnlockedSecretAbility.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbUnlockedSecretAbility.cs
@@ -1,10 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Reflection.Metadata.Ecma335;
-using System.Text.RegularExpressions;
-using Arrowgene.Ddon.Database.Model;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Database.Sql.Core

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/DatabaseMigrator.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/DatabaseMigrator.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class DatabaseMigrator
+    {
+        private readonly List<IMigrationStrategy> MigrationStrategies;
+
+        public DatabaseMigrator(List<IMigrationStrategy> strategies)
+        {
+            MigrationStrategies = strategies;
+        }
+
+        public bool MigrateDatabase(IDatabase db, uint fromVersion, uint toVersion)
+        {
+            return db.ExecuteInTransaction((conn) => {
+                foreach (var strategy in FindStrategies(fromVersion, toVersion))
+                {
+                    strategy.Migrate(db, conn);
+                }
+            });
+        }
+
+        private List<IMigrationStrategy> FindStrategies(uint fromVersion, uint toVersion)
+        {
+            return FindStrategies(fromVersion, toVersion, out bool _);
+        }
+
+        // Recursively find a list of strategies to ugprade the database from fromVersion to toVersion
+        private List<IMigrationStrategy> FindStrategies(uint fromVersion, uint toVersion, out bool done)
+        {
+            if(fromVersion == toVersion)
+            {
+                done = true;
+                return new List<IMigrationStrategy>();
+            }
+
+            // Get all strategies that upgrade from fromVersion to toVersion
+            IEnumerable<IMigrationStrategy> strategiesFromVersion = MigrationStrategies
+                .Where(strategy => strategy.From == fromVersion);
+
+            List<IMigrationStrategy>? candidateStrategies = null;
+            foreach (var strategy in strategiesFromVersion)
+            {
+                List<IMigrationStrategy> nextStrategies = FindStrategies(strategy.To, toVersion, out bool nextDone);
+                if(nextDone && (candidateStrategies == null || (nextStrategies.Count+1) < candidateStrategies.Count))
+                {
+                    candidateStrategies = new List<IMigrationStrategy>() { strategy }.Concat(nextStrategies).ToList();;
+                }
+            }
+
+            if (candidateStrategies != null)
+            {
+                done = true;
+                return candidateStrategies;
+            }
+            else
+            {
+                done = false;
+                return new List<IMigrationStrategy>();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/IMigrationStrategy.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/IMigrationStrategy.cs
@@ -1,0 +1,11 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public interface IMigrationStrategy
+    {
+        uint From { get; }
+        uint To { get; }
+        bool Migrate(IDatabase db, DbConnection conn);
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/MailMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/MailMigration.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Data.Common;
 using System.IO;
 using System.Text;
+using Arrowgene.Ddon.Database.Model;
 
 namespace Arrowgene.Ddon.Database.Sql.Core.Migration
 {
@@ -20,7 +22,9 @@ namespace Arrowgene.Ddon.Database.Sql.Core.Migration
         {
             string schemaFilePath = Path.Combine(DatabaseSetting.DatabaseFolder, "Script/migration_mail_sqlite.sql");
             string schema = File.ReadAllText(schemaFilePath, Encoding.UTF8);
-            db.Execute(conn, schema);
+            DatabaseType databaseType = (DatabaseType) Enum.Parse(typeof(DatabaseType), DatabaseSetting.Type, true);
+            string adaptedSchema = DdonDatabaseBuilder.AdaptSQLiteSchemaTo(databaseType, schema);
+            db.Execute(conn, adaptedSchema);
             return true;
         }
     }

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/MailMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/MailMigration.cs
@@ -1,0 +1,27 @@
+using System.Data.Common;
+using System.IO;
+using System.Text;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class MailMigration : IMigrationStrategy
+    {
+        public uint From => 1;
+        public uint To => 2;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public MailMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string schemaFilePath = Path.Combine(DatabaseSetting.DatabaseFolder, "Script/migration_mail_sqlite.sql");
+            string schema = File.ReadAllText(schemaFilePath, Encoding.UTF8);
+            db.Execute(conn, schema);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/DdonMariaDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonMariaDb.cs
@@ -20,7 +20,7 @@ namespace Arrowgene.Ddon.Database.Sql
             }
         }
 
-        public bool CreateDatabase()
+        public override bool CreateDatabase()
         {
             if (_connectionString == null)
             {

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -22,7 +22,7 @@ namespace Arrowgene.Ddon.Database.Sql
             }
         }
 
-        public bool CreateDatabase()
+        public override bool CreateDatabase()
         {
             if (_connectionString == null)
             {

--- a/Arrowgene.Ddon.Database/Sql/DdonSqLiteDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonSqLiteDb.cs
@@ -12,7 +12,6 @@ namespace Arrowgene.Ddon.Database.Sql
 
 
         public const string MemoryDatabasePath = ":memory:";
-        public const int Version = 1;
 
         private readonly string _databasePath;
         private string _connectionString;
@@ -36,7 +35,7 @@ namespace Arrowgene.Ddon.Database.Sql
             }
         }
 
-        public bool CreateDatabase()
+        public override bool CreateDatabase()
         {
             _connectionString = BuildConnectionString(_databasePath);
             if (_connectionString == null)
@@ -60,7 +59,6 @@ namespace Arrowgene.Ddon.Database.Sql
                 FileStream fs = File.Create(_databasePath);
                 fs.Close();
                 fs.Dispose();
-                Logger.Info($"Created new v{Version} database");
                 return true;
             }
 

--- a/Arrowgene.Ddon.Shared/Entity/DatabaseMeta.cs
+++ b/Arrowgene.Ddon.Shared/Entity/DatabaseMeta.cs
@@ -1,0 +1,7 @@
+namespace Arrowgene.Ddon.Shared.Entity
+{
+    public class DatabaseMeta
+    {
+        public uint DatabaseVersion { get; set; }
+    }
+}

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -34,7 +34,9 @@ namespace Arrowgene.Ddon.Test.Database
                 from2to3
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 0, 3);
+            bool result = migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.True(result);
 
             Assert.True(from0to1.Called);
             Assert.True(from0to1.CallOrder == 0);
@@ -59,7 +61,9 @@ namespace Arrowgene.Ddon.Test.Database
                 from0to3,
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 0, 3);
+            bool result = migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.True(result);
 
             Assert.False(from0to1.Called);
             Assert.False(from1to2.Called);
@@ -81,7 +85,9 @@ namespace Arrowgene.Ddon.Test.Database
                 from0to2,
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 0, 3);
+            bool result = migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.True(result);
 
             Assert.True(from0to2.Called);
             Assert.True(from0to2.CallOrder == 0);
@@ -108,7 +114,9 @@ namespace Arrowgene.Ddon.Test.Database
                 from0to1
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 0, 4);
+            bool result = migrator.MigrateDatabase(db, 0, 4);
+
+            Assert.True(result);
 
             Assert.True(from0to1.Called);
             Assert.True(from0to1.CallOrder == 0);
@@ -132,7 +140,8 @@ namespace Arrowgene.Ddon.Test.Database
                 from2to3
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 0, 4);
+
+            Assert.Throws<Exception>(() => migrator.MigrateDatabase(db, 0, 4));
 
             Assert.False(from0to1.Called);
             Assert.False(from1to2.Called);
@@ -152,7 +161,9 @@ namespace Arrowgene.Ddon.Test.Database
                 from2to3
             };
             var migrator = new DatabaseMigrator(strategies);
-            migrator.MigrateDatabase(db, 3, 3);
+            bool result = migrator.MigrateDatabase(db, 3, 3);
+
+            Assert.True(result);
 
             Assert.False(from0to1.Called);
             Assert.False(from1to2.Called);
@@ -162,8 +173,6 @@ namespace Arrowgene.Ddon.Test.Database
 
     class MockDatabase : IDatabase
     {
-        public DatabaseMigrator Migrator { get; set; }
-
         public bool ExecuteInTransaction(Action<DbConnection> action) { 
             action.Invoke(null); return true; 
         }
@@ -302,7 +311,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool UpdateStatusInfo(CharacterCommon character) { return true; }
         public bool UpdateStorage(uint characterId, StorageType storageType, Storage storage) { return true; }
         public bool UpdateWalletPoint(uint characterId, CDataWalletPoint updatedWalletPoint) { return true; }
-        public bool MigrateDatabase(uint toVersion) { return true; }
+        public bool MigrateDatabase(DatabaseMigrator migrator, uint toVersion) { return true; }
     }
 
     class MockMigrationStrategy : IMigrationStrategy

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Arrowgene.Ddon.Database;
+using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.Database.Sql.Core.Migration;
+using Arrowgene.Ddon.Shared.Entity;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arrowgene.Ddon.Test.Database
+{
+    public class DatabaseMigratorTest : TestBase
+    {
+        private IDatabase db = new MockDatabase();
+
+        public DatabaseMigratorTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void TestStraightforwardMigration()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to1 = new MockMigrationStrategy() { From = 0, To = 1 };
+            var from1to2 = new MockMigrationStrategy() { From = 1, To = 2 };
+            var from2to3 = new MockMigrationStrategy() { From = 2, To = 3 };
+            var strategies = new List<IMigrationStrategy>() {
+                from0to1,
+                from1to2,
+                from2to3
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.True(from0to1.Called);
+            Assert.True(from0to1.CallOrder == 0);
+            Assert.True(from1to2.Called);
+            Assert.True(from1to2.CallOrder == 1);
+            Assert.True(from2to3.Called);
+            Assert.True(from2to3.CallOrder == 2);
+        }
+
+        [Fact]
+        public void TestShortestMigrationPath()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to1 = new MockMigrationStrategy() { From = 0, To = 1 };
+            var from1to2 = new MockMigrationStrategy() { From = 1, To = 2 };
+            var from2to3 = new MockMigrationStrategy() { From = 2, To = 3 };
+            var from0to3 = new MockMigrationStrategy() { From = 0, To = 3 };
+            var strategies = new List<IMigrationStrategy>() {
+                from0to1,
+                from1to2,
+                from2to3,
+                from0to3,
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.False(from0to1.Called);
+            Assert.False(from1to2.Called);
+            Assert.False(from2to3.Called);
+            Assert.True(from0to3.Called);
+            Assert.True(from2to3.CallOrder == 0);
+        }
+
+        [Fact]
+        public void TestConvolutedMigrationPath()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to2 = new MockMigrationStrategy() { From = 0, To = 2 };
+            var from2to1 = new MockMigrationStrategy() { From = 2, To = 1 };
+            var from1to3 = new MockMigrationStrategy() { From = 1, To = 3 };
+            var strategies = new List<IMigrationStrategy>() {
+                from1to3,
+                from2to1,
+                from0to2,
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 0, 3);
+
+            Assert.True(from0to2.Called);
+            Assert.True(from0to2.CallOrder == 0);
+            Assert.True(from2to1.Called);
+            Assert.True(from2to1.CallOrder == 1);
+            Assert.True(from1to3.Called);
+            Assert.True(from1to3.CallOrder == 2);
+        }
+
+        [Fact]
+        public void TestShortestConvolutedMigrationPath()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to2 = new MockMigrationStrategy() { From = 0, To = 2 };
+            var from2to3 = new MockMigrationStrategy() { From = 2, To = 3 };
+            var from3to1 = new MockMigrationStrategy() { From = 3, To = 1 };
+            var from1to4 = new MockMigrationStrategy() { From = 1, To = 4 };
+            var from0to1 = new MockMigrationStrategy() { From  = 0, To  = 1 };
+            var strategies = new List<IMigrationStrategy>() {
+                from0to2,
+                from2to3,
+                from3to1,
+                from1to4,
+                from0to1
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 0, 4);
+
+            Assert.True(from0to1.Called);
+            Assert.True(from0to1.CallOrder == 0);
+            Assert.True(from1to4.Called);
+            Assert.True(from1to4.CallOrder == 1);
+            Assert.False(from0to2.Called);
+            Assert.False(from2to3.Called);
+            Assert.False(from3to1.Called);
+        }
+
+        [Fact]
+        public void TestNoMigrationPath()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to1 = new MockMigrationStrategy() { From = 0, To = 1 };
+            var from1to2 = new MockMigrationStrategy() { From = 1, To = 2 };
+            var from2to3 = new MockMigrationStrategy() { From = 2, To = 3 };
+            var strategies = new List<IMigrationStrategy>() {
+                from0to1,
+                from1to2,
+                from2to3
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 0, 4);
+
+            Assert.False(from0to1.Called);
+            Assert.False(from1to2.Called);
+            Assert.False(from2to3.Called);
+        }
+
+        [Fact]
+        public void TestNoMigrationNeeded()
+        {
+            MockMigrationStrategy.CALL_COUNT = 0;
+            var from0to1 = new MockMigrationStrategy() { From = 0, To = 1 };
+            var from1to2 = new MockMigrationStrategy() { From = 1, To = 2 };
+            var from2to3 = new MockMigrationStrategy() { From = 2, To = 3 };
+            var strategies = new List<IMigrationStrategy>() {
+                from0to1,
+                from1to2,
+                from2to3
+            };
+            var migrator = new DatabaseMigrator(strategies);
+            migrator.MigrateDatabase(db, 3, 3);
+
+            Assert.False(from0to1.Called);
+            Assert.False(from1to2.Called);
+            Assert.False(from2to3.Called);
+        }
+    }
+
+    class MockDatabase : IDatabase
+    {
+        public DatabaseMigrator Migrator { get; set; }
+
+        public bool ExecuteInTransaction(Action<DbConnection> action) { 
+            action.Invoke(null); return true; 
+        }
+
+        public Account CreateAccount(string name, string mail, string hash) { return new Account(); }
+        public bool CreateCharacter(Character character) { return true; }
+        public bool CreateDatabase() { return true; }
+        public bool CreatePawn(Pawn pawn) { return true; }
+        public bool DeleteAccount(int accountId) { return true; }
+        public int DeleteBazaarExhibition(ulong bazaarId) { return 1; }
+        public bool DeleteBoxRewardItem(uint commonId, uint uniqId) { return true; }
+        public bool DeleteCharacter(uint characterId) { return true; }
+        public bool DeleteCommunicationShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
+        public bool DeleteConnection(int serverId, int accountId) { return true; }
+        public bool DeleteConnectionsByAccountId(int accountId) { return true; }
+        public bool DeleteConnectionsByServerId(int serverId) { return true; }
+        public int DeleteContact(uint requestingCharacterId, uint requestedCharacterId) { return 1; }
+        public int DeleteContactById(uint id) { return 1; }
+        public bool DeleteEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId) { return true; }
+        public bool DeleteEquipJobItem(uint commonId, JobId job, ushort slotNo) { return true; }
+        public bool DeleteEquippedAbilities(uint commonId, JobId equippedToJob) { return true; }
+        public bool DeleteEquippedAbility(uint commonId, JobId equippedToJob, byte slotNo) { return true; }
+        public bool DeleteEquippedCustomSkill(uint commonId, JobId job, byte slotNo) { return true; }
+        public bool DeleteNormalSkillParam(uint commonId, JobId job, uint skillNo) { return true; }
+        public bool DeletePawn(uint pawnId) { return true; }
+        public bool DeletePriorityQuest(uint characterCommonId, QuestId questId) { return true; }
+        public bool DeleteReleasedWarpPoint(uint characterId, uint warpPointId) { return true; }
+        public bool DeleteShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
+        public bool DeleteSpSkill(uint pawnId, JobId job, byte spSkillId) { return true; }
+        public bool DeleteStorage(uint characterId, StorageType storageType) { return true; }
+        public bool DeleteStorageItem(uint characterId, StorageType storageType, ushort slotNo) { return true; }
+        public bool DeleteToken(string token) { return true; }
+        public bool DeleteTokenByAccountId(int accountId) { return true; }
+        public bool DeleteWalletPoint(uint characterId, WalletType type) { return true; }
+        public void Execute(string sql) {}
+        public void Execute(DbConnection conn, string sql) {}
+        public List<BazaarExhibition> FetchCharacterBazaarExhibitions(uint characterId) { return new List<BazaarExhibition>(); }
+        public CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId) { return new CompletedQuest(); }
+        public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType) { return new List<CompletedQuest>(); }
+        public bool CreateMeta(DatabaseMeta meta) { return true; }
+        public DatabaseMeta GetMeta() { return new DatabaseMeta(); }
+        public List<QuestId> GetPriorityQuests(uint characterCommonId) { return new List<QuestId>(); }
+        public QuestProgress GetQuestProgressById(uint characterCommonId, QuestId questId) { return new QuestProgress(); }
+        public List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType) { return new List<QuestProgress>(); }
+        public ulong InsertBazaarExhibition(BazaarExhibition exhibition) { return 1; }
+        public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards) { return true; }
+        public bool InsertCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut) { return true; }
+        public bool InsertConnection(Connection connection) { return true; }
+        public int InsertContact(uint requestingCharacterId, uint requestedCharacterId, ContactListStatus status, ContactListType type, bool requesterFavorite, bool requestedFavorite) { return 1; }
+        public bool InsertEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId) { return true; }
+        public bool InsertEquipJobItem(string itemUId, uint commonId, JobId job, ushort slotNo) { return true; }
+        public bool InsertEquippedAbility(uint commonId, JobId equipptedToJob, byte slotNo, Ability ability) { return true; }
+        public bool InsertEquippedCustomSkill(uint commonId, byte slotNo, CustomSkill skill) { return true; }
+        public bool InsertGainExtendParam(uint commonId, CDataOrbGainExtendParam Param) { return true; }
+        public bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType) { return true; }
+        public bool InsertIfNotExistsDragonForceAugmentation(uint commonId, uint elementId, uint pageNo, uint groupNo, uint indexNo) { return true; }
+        public bool InsertIfNotExistsNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
+        public bool InsertIfNotExistsPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool InsertIfNotExistsReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
+        public bool InsertIfNotExistsReleasedWarpPoints(uint characterId, List<ReleasedWarpPoint> ReleasedWarpPoint) { return true; }
+        public bool InsertItem(Item item) { return true; }
+        public bool InsertLearnedAbility(uint commonId, Ability ability) { return true; }
+        public bool InsertLearnedCustomSkill(uint commonId, CustomSkill skill) { return true; }
+        public bool InsertNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
+        public bool InsertPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool InsertPriorityQuest(uint characterCommonId, QuestId questId) { return true; }
+        public bool InsertQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step) { return true; }
+        public bool InsertReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
+        public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility) { return true; }
+        public bool InsertShortcut(uint characterId, CDataShortCut shortcut) { return true; }
+        public bool InsertSpSkill(uint pawnId, JobId job, CDataSpSkill spSkill) { return true; }
+        public bool InsertStorage(uint characterId, StorageType storageType, Storage storage) { return true; }
+        public bool InsertStorageItem(uint characterId, StorageType storageType, ushort slotNo, string itemUId, uint itemNum) { return true; }
+        public bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
+        public bool RemoveQuestProgress(uint characterCommonId, QuestId questId, QuestType questType) { return true; }
+        public bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData) { return true; }
+        public bool ReplaceCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut) { return true; }
+        public bool ReplaceEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId) { return true; }
+        public bool ReplaceEquipJobItem(string itemUId, uint commonId, JobId job, ushort slotNo) { return true; }
+        public bool ReplaceEquippedAbilities(uint commonId, JobId equippedToJob, List<Ability> abilities) { return true; }
+        public bool ReplaceEquippedAbility(uint commonId, JobId equipptedToJob, byte slotNo, Ability ability) { return true; }
+        public bool ReplaceEquippedCustomSkill(uint commonId, byte slotNo, CustomSkill skill) { return true; }
+        public bool ReplaceNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
+        public bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool ReplaceReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
+        public bool ReplaceShortcut(uint characterId, CDataShortCut shortcut) { return true; }
+        public bool ReplaceStorageItem(uint characterId, StorageType storageType, ushort slotNo, string itemUId, uint itemNum) { return true; }
+        public bool ReplaceWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
+        public Account SelectAccountById(int accountId) { return new Account(); }
+        public Account SelectAccountByLoginToken(string loginToken) { return new Account(); }
+        public Account SelectAccountByName(string accountName) { return new Account(); }
+        public List<BazaarExhibition> SelectActiveBazaarExhibitionsByItemIdExcludingOwn(uint itemId, uint excludedCharacterId) { return new List<BazaarExhibition>(); }
+        public List<BazaarExhibition> SelectActiveBazaarExhibitionsByItemIdsExcludingOwn(List<uint> itemIds, uint excludedCharacterId) { return new List<BazaarExhibition>(); }
+        public List<SecretAbility> SelectAllUnlockedSecretAbilities(uint commonId) { return new List<SecretAbility>(); }
+        public BazaarExhibition SelectBazaarExhibitionByBazaarId(ulong bazaarId) { return new BazaarExhibition(); }
+        public List<QuestBoxRewards> SelectBoxRewardItems(uint commonId) { return new List<QuestBoxRewards>(); }
+        public Character SelectCharacter(uint characterId) { return new Character(); }
+        public List<Character> SelectCharactersByAccountId(int accountId) { return new List<Character>(); }
+        public List<Connection> SelectConnectionsByAccountId(int accountId) { return new List<Connection>(); }
+        public ContactListEntity SelectContactListById(uint id) { return new ContactListEntity(); }
+        public List<ContactListEntity> SelectContactsByCharacterId(uint characterId) { return new List<ContactListEntity>(); }
+        public ContactListEntity SelectContactsByCharacterId(uint characterId1, uint characterId2) { return new ContactListEntity(); }
+        public Item SelectItem(string uid) { return new Item(); }
+        public List<CDataNormalSkillParam> SelectNormalSkillParam(uint commonId, JobId job) { return new List<CDataNormalSkillParam>(); }
+        public CDataOrbGainExtendParam SelectOrbGainExtendParam(uint commonId) { return new CDataOrbGainExtendParam(); }
+        public List<CDataReleaseOrbElement> SelectOrbReleaseElementFromDragonForceAugmentation(uint commonId) { return new List<CDataReleaseOrbElement>(); }
+        public Pawn SelectPawn(uint pawnId) { return new Pawn(); }
+        public List<Pawn> SelectPawnsByCharacterId(uint characterId) { return new List<Pawn>(); }
+        public List<ReleasedWarpPoint> SelectReleasedWarpPoints(uint characterId) { return new List<ReleasedWarpPoint>(); }
+        public GameToken SelectToken(string tokenStr) { return new GameToken(); }
+        public GameToken SelectTokenByAccountId(int accountId) { return new GameToken(); }
+        public bool SetMeta(DatabaseMeta meta) { return true; }
+        public bool SetToken(GameToken token) { return true; }
+        public bool UpdateAccount(Account account) { return true; }
+        public int UpdateBazaarExhibiton(BazaarExhibition exhibition) { return 1; }
+        public bool UpdateCharacterArisenProfile(Character character) { return true; }
+        public bool UpdateCharacterBaseInfo(Character character) { return true; }
+        public bool UpdateCharacterCommonBaseInfo(CharacterCommon common) { return true; }
+        public bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData) { return true; }
+        public bool UpdateCharacterMatchingProfile(Character character) { return true; }
+        public bool UpdateCommunicationShortcut(uint characterId, uint oldPageNo, uint oldButtonNo, CDataCommunicationShortCut updatedCommunicationShortcut) { return true; }
+        public int UpdateContact(uint requestingCharacterId, uint requestedCharacterId, ContactListStatus status, ContactListType type, bool requesterFavorite, bool requestedFavorite) { return 1; }
+        public bool UpdateEditInfo(CharacterCommon character) { return true; }
+        public bool UpdateEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId) { return true; }
+        public bool UpdateEquippedAbility(uint commonId, JobId oldEquippedToJob, byte oldSlotNo, JobId equipptedToJob, byte slotNo, Ability ability) { return true; }
+        public bool UpdateEquippedCustomSkill(uint commonId, JobId oldJob, byte oldSlotNo, byte slotNo, CustomSkill skill) { return true; }
+        public bool UpdateLearnedAbility(uint commonId, Ability ability) { return true; }
+        public bool UpdateLearnedCustomSkill(uint commonId, CustomSkill updatedSkill) { return true; }
+        public bool UpdateNormalSkillParam(uint commonId, JobId job, uint skillNo, CDataNormalSkillParam normalSkillParam) { return true; }
+        public bool UpdateOrbGainExtendParam(uint commonId, CDataOrbGainExtendParam Param) { return true; }
+        public bool UpdatePawnBaseInfo(Pawn pawn) { return true; }
+        public bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool UpdateQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step) { return true; }
+        public bool UpdateReleasedWarpPoint(uint characterId, ReleasedWarpPoint updatedReleasedWarpPoint) { return true; }
+        public bool UpdateShortcut(uint characterId, uint oldPageNo, uint oldButtonNo, CDataShortCut updatedShortcut) { return true; }
+        public bool UpdateStatusInfo(CharacterCommon character) { return true; }
+        public bool UpdateStorage(uint characterId, StorageType storageType, Storage storage) { return true; }
+        public bool UpdateWalletPoint(uint characterId, CDataWalletPoint updatedWalletPoint) { return true; }
+        public bool MigrateDatabase(uint toVersion) { return true; }
+    }
+
+    class MockMigrationStrategy : IMigrationStrategy
+    {
+        public static uint CALL_COUNT = 0;
+
+        public uint From { get; set; }
+
+        public uint To { get; set; }
+
+        public bool Called { get; private set; } = false;
+        public uint CallOrder { get; private set; }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            Called = true;
+            CallOrder = CALL_COUNT++;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Addresses #93 and #102 

Implement a simple database migrator CLI command that will read the current database version and figure out which strategies to run to upgrade to the target database version.

The migrator will have a list of IMigrationStrategy objects, each with a From and To properties and a Migrate method. The migrator will figure out the shortest path to upgrade from one version to another.

For example, if the database is in version 1 and the target version is 4, it'll try running the least number of migrations to reach version 4:
If there's strategies to migrate from version 1 to 2, 2 to 3, 3 to 4, but also, there's a strategy to migrate from 1 to 4 directly, it'll favour the later.

These strategies are regular C# code, meaning you can call SQL but also perform complex logic if needed in C#.

Ironically this PR requires the following SQL script to be run
```sql
CREATE TABLE IF NOT EXISTS meta
(
    "db_version" INTEGER NOT NULL
);
INSERT INTO meta (db_version) VALUES (1);
```

To migrate a database, first, supply a database in version 1 (db.v1.sqlite) in the Database directory, and then run the following command:
```dotnet run dbmigration 1```
This will tell the server to read the v1 database and upgrade it to whatever database version the server requires (In this case, version 2). A v2 database will be created (db.v2.sqlite) after running the scripts and code in the strategies.

The previous version argument is required only when using sqlite, as each different database version will be stored in a different file. It won't be needed when migrating a MySQL or Postgres database.

It has been tested with SQLite, althought it should work fine with MySQL or Postgres i haven't tested it.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
