### PR TITLE
Fix: Skills don't do damage after leveling it up 

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -233,6 +233,25 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     SkillId = skillId,
                     SkillLv = skillLv
                 });
+
+                //Find on the palletes (if any) where the skill is set and notify party. Can occur at two locations (Main + Secondary) for players.
+                List<CustomSkill?> equippedCustomSkillList = character.EquippedCustomSkillsDictionary[job];
+                var slotIndices = Enumerable.Range(0, equippedCustomSkillList.Count)
+                    .Where(i => equippedCustomSkillList[i] != null && equippedCustomSkillList[i].SkillId == skillId)
+                    .ToList();
+                foreach (int slotIndex in slotIndices)
+                {
+                    client.Party.SendToAll(new S2CSkillCustomSkillSetNtc()
+                    {
+                        CharacterId = ((Character)character).CharacterId,
+                        ContextAcquirementData = new CDataContextAcquirementData()
+                        {
+                            SlotNo = (byte)(slotIndex + 1),
+                            AcquirementNo = skillId,
+                            AcquirementLv = skillLv
+                        }
+                    });
+                }       
             }
             else if (character is Pawn)
             {
@@ -244,6 +263,25 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     SkillId = skillId,
                     SkillLv = skillLv
                 });
+
+                //Find on the palletes (if any) where the skill is set. 
+                List<CustomSkill?> equippedCustomSkillList = character.EquippedCustomSkillsDictionary[job];
+                var slotIndices = Enumerable.Range(0, equippedCustomSkillList.Count)
+                    .Where(i => equippedCustomSkillList[i] != null && equippedCustomSkillList[i].SkillId == skillId)
+                    .ToList();
+                foreach (int slotIndex in slotIndices)
+                {
+                    client.Party.SendToAll(new S2CSkillPawnCustomSkillSetNtc()
+                    {
+                        PawnId = ((Pawn)character).PawnId,
+                        ContextAcquirementData = new CDataContextAcquirementData()
+                        {
+                            SlotNo = (byte)(slotIndex + 1),
+                            AcquirementNo = skillId,
+                            AcquirementLv = skillLv
+                        }
+                    });
+                }
             }
         }
 

--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -438,6 +438,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     SkillIndex = skillIndex,
                     NewJobPoint = characterJobData.JobPoint,
                 });
+
+                //Notify other members of the new skill.
+                client.Party.SendToAll(new S2CSkillNormalSkillLearnNtc()
+                {
+                    CharacterId = ((Character)character).CharacterId,
+                    NormalSkillData = new CDataContextNormalSkillData()
+                    {
+                        SkillIndex = (byte)skillIndex
+                    }
+                });
             }
             else
             {
@@ -448,12 +458,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     SkillIndex = skillIndex,
                     NewJobPoint = characterJobData.JobPoint,
                 });
-            }
 
-            // TODO: Send data to rest of party
-            // TODO: S2C_NORMAL_SKILL_LEARN_NTC currently not defined
-            // TODO: Need to investigate ID and layout
-            // Client.Party.SendToAll(S2C_NORMAL_SKILL_LEARN_NTC)
+                //Notify other members of the new skill.
+                client.Party.SendToAll(new S2CSkillPawnNormalSkillLearnNtc()
+                {
+                    PawnId = ((Pawn)character).PawnId,
+                    NormalSkillData = new CDataContextNormalSkillData()
+                    {
+                        SkillIndex = (byte)skillIndex
+                    }
+                });
+            }
         }
 
         public void UnlockAbility(IDatabase database, GameClient client, CharacterCommon character, JobId job, uint abilityId, byte abilityLv)

--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -431,27 +431,23 @@ namespace Arrowgene.Ddon.GameServer.Characters
             database.UpdateCharacterJobData(character.CommonId, characterJobData);
 
             if (character is Character)
-                {
-                var result = new S2CSkillLearnNormalSkillRes()
+            {
+                client.Send(new S2CSkillLearnNormalSkillRes()
                 {
                     Job = job,
                     SkillIndex = skillIndex,
                     NewJobPoint = characterJobData.JobPoint,
-                };
-
-                client.Send(result);
+                });
             }
             else
             {
-                var result = new S2CSkillLearnPawnNormalSkillRes()
+                client.Send(new S2CSkillLearnPawnNormalSkillRes()
                 {
                     PawnId = ((Pawn)character).PawnId,
                     Job = job,
                     SkillIndex = skillIndex,
                     NewJobPoint = characterJobData.JobPoint,
-                };
-
-                client.Send(result);
+                });
             }
 
             // TODO: Send data to rest of party

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -810,8 +810,10 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CSkillLearnPawnNormalSkillRes.Serializer());
             Create(new S2CSkillLearnPawnSkillRes.Serializer());
             Create(new S2CSkillLearnSkillRes.Serializer());
+            Create(new S2CSkillNormalSkillLearnNtc.Serializer());
             Create(new S2CSkillPawnAbilitySetNtc.Serializer());
             Create(new S2CSkillPawnCustomSkillSetNtc.Serializer());
+            Create(new S2CSkillPawnNormalSkillLearnNtc.Serializer());
             Create(new S2CSkillSetAbilityRes.Serializer());
             Create(new S2CSkillSetOffAbilityRes.Serializer());
             Create(new S2CSkillSetOffPawnAbilityRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillNormalSkillLearnNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillNormalSkillLearnNtc.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CSkillNormalSkillLearnNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_SKILL_NORMAL_SKILL_LEARN_NTC;
+
+        public uint CharacterId { get; set; }
+        public CDataContextNormalSkillData NormalSkillData { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CSkillNormalSkillLearnNtc>
+        {
+            public override void Write(IBuffer buffer, S2CSkillNormalSkillLearnNtc obj)
+            {
+                WriteUInt32(buffer, obj.CharacterId);
+                WriteEntity<CDataContextNormalSkillData>(buffer, obj.NormalSkillData);
+            }
+
+            public override S2CSkillNormalSkillLearnNtc Read(IBuffer buffer)
+            {
+                S2CSkillNormalSkillLearnNtc obj = new S2CSkillNormalSkillLearnNtc();
+                obj.CharacterId = ReadUInt32(buffer);
+                obj.NormalSkillData = ReadEntity<CDataContextNormalSkillData>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillPawnNormalSkillLearnNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillPawnNormalSkillLearnNtc.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CSkillPawnNormalSkillLearnNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC;
+
+        public uint PawnId { get; set; }
+        public CDataContextNormalSkillData NormalSkillData { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CSkillPawnNormalSkillLearnNtc>
+        {
+            public override void Write(IBuffer buffer, S2CSkillPawnNormalSkillLearnNtc obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteEntity<CDataContextNormalSkillData>(buffer, obj.NormalSkillData);
+            }
+
+            public override S2CSkillPawnNormalSkillLearnNtc Read(IBuffer buffer)
+            {
+                S2CSkillPawnNormalSkillLearnNtc obj = new S2CSkillPawnNormalSkillLearnNtc();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.NormalSkillData = ReadEntity<CDataContextNormalSkillData>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -1032,10 +1032,10 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_SKILL_GET_CURRENT_SET_SKILL_LIST_RES = new PacketId(19, 28, 2, "S2C_SKILL_GET_CURRENT_SET_SKILL_LIST_RES", ServerType.Game, PacketSource.Server); // 装備中スキルリスト取得に
         public static readonly PacketId C2S_SKILL_GET_CURRENT_SET_ABILITY_LIST_REQ = new PacketId(19, 29, 1, "C2S_SKILL_GET_CURRENT_SET_ABILITY_LIST_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_SKILL_GET_CURRENT_SET_ABILITY_LIST_RES = new PacketId(19, 29, 2, "S2C_SKILL_GET_CURRENT_SET_ABILITY_LIST_RES", ServerType.Game, PacketSource.Server); // 装備中アビリティリスト取得に
-        public static readonly PacketId C2S_SKILL_19_30_1_REQ = new PacketId(19, 30, 1, "C2S_SKILL_19_30_1_REQ", ServerType.Game, PacketSource.Client);
-        public static readonly PacketId S2C_SKILL_19_30_2_RES = new PacketId(19, 30, 2, "S2C_SKILL_19_30_2_RES", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId C2S_SKILL_19_31_1_REQ = new PacketId(19, 31, 1, "C2S_SKILL_19_31_1_REQ", ServerType.Game, PacketSource.Client);
-        public static readonly PacketId S2C_SKILL_19_31_2_RES = new PacketId(19, 31, 2, "S2C_SKILL_19_31_2_RES", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId C2S_SKILL_19_30_1_REQ = new PacketId(19, 30, 1, "C2S_SKILL_19_30_1_REQ", ServerType.Game, PacketSource.Client); //Likely C2S_SKILL_GET_PAWN_CURRENT_SET_SKILL_LIST_REQ
+        public static readonly PacketId S2C_SKILL_19_30_2_RES = new PacketId(19, 30, 2, "S2C_SKILL_19_30_2_RES", ServerType.Game, PacketSource.Server); //Likely S2C_SKILL_GET_PAWN_CURRENT_SET_SKILL_LIST_RES
+        public static readonly PacketId C2S_SKILL_19_31_1_REQ = new PacketId(19, 31, 1, "C2S_SKILL_19_31_1_REQ", ServerType.Game, PacketSource.Client); //Likely C2S_SKILL_GET_PAWN_CURRENT_SET_ABILITY_LIST_REQ
+        public static readonly PacketId S2C_SKILL_19_31_2_RES = new PacketId(19, 31, 2, "S2C_SKILL_19_31_2_RES", ServerType.Game, PacketSource.Server); //Likely S2C_SKILL_GET_PAWN_CURRENT_SET_ABILITY_LIST_RES
         public static readonly PacketId C2S_SKILL_GET_RELEASE_SKILL_LIST_REQ = new PacketId(19, 32, 1, "C2S_SKILL_GET_RELEASE_SKILL_LIST_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_SKILL_GET_RELEASE_SKILL_LIST_RES = new PacketId(19, 32, 2, "S2C_SKILL_GET_RELEASE_SKILL_LIST_RES", ServerType.Game, PacketSource.Server); // 解放済みスキルリストの取得に
         public static readonly PacketId C2S_SKILL_GET_RELEASE_ABILITY_LIST_REQ = new PacketId(19, 33, 1, "C2S_SKILL_GET_RELEASE_ABILITY_LIST_REQ", ServerType.Game, PacketSource.Client);
@@ -1054,11 +1054,11 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_SKILL_GET_ABILITY_COST_RES = new PacketId(19, 39, 2, "S2C_SKILL_GET_ABILITY_COST_RES", ServerType.Game, PacketSource.Server); // アビリティセット用コストの取得に
         public static readonly PacketId C2S_SKILL_GET_PAWN_ABILITY_COST_REQ = new PacketId(19, 40, 1, "C2S_SKILL_GET_PAWN_ABILITY_COST_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_SKILL_GET_PAWN_ABILITY_COST_RES = new PacketId(19, 40, 2, "S2C_SKILL_GET_PAWN_ABILITY_COST_RES", ServerType.Game, PacketSource.Server); // ポーンアビリティセット用コストの取得に
-        public static readonly PacketId S2C_SKILL_19_41_16_NTC = new PacketId(19, 41, 16, "S2C_SKILL_19_41_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_SKILL_19_42_16_NTC = new PacketId(19, 42, 16, "S2C_SKILL_19_42_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_SKILL_ACQUIREMENT_LEARN_NTC = new PacketId(19, 41, 16, "S2C_SKILL_ACQUIREMENT_LEARN_NTC", ServerType.Game, PacketSource.Server); //Probably, based on order in debug symbols.
+        public static readonly PacketId S2C_SKILL_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 42, 16, "S2C_SKILL_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_CUSTOM_SKILL_SET_NTC = new PacketId(19, 43, 16, "S2C_SKILL_CUSTOM_SKILL_SET_NTC", ServerType.Game, PacketSource.Server, "S2C_SKILL_19_43_16_NTC");
         public static readonly PacketId S2C_SKILL_19_44_16_NTC = new PacketId(19, 44, 16, "S2C_SKILL_19_44_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_SKILL_19_45_16_NTC = new PacketId(19, 45, 16, "S2C_SKILL_19_45_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 45, 16, "S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_ABILITY_SET_NTC = new PacketId(19, 46, 16, "S2C_SKILL_19_46_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_19_47_16_NTC = new PacketId(19, 47, 16, "S2C_SKILL_19_47_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_19_48_16_NTC = new PacketId(19, 48, 16, "S2C_SKILL_19_48_16_NTC", ServerType.Game, PacketSource.Server);
@@ -2965,11 +2965,11 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_SKILL_GET_ABILITY_COST_RES);
             AddPacketIdEntry(packetIds, C2S_SKILL_GET_PAWN_ABILITY_COST_REQ);
             AddPacketIdEntry(packetIds, S2C_SKILL_GET_PAWN_ABILITY_COST_RES);
-            AddPacketIdEntry(packetIds, S2C_SKILL_19_41_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_SKILL_19_42_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_SKILL_ACQUIREMENT_LEARN_NTC);
+            AddPacketIdEntry(packetIds, S2C_SKILL_NORMAL_SKILL_LEARN_NTC);
             AddPacketIdEntry(packetIds, S2C_SKILL_CUSTOM_SKILL_SET_NTC);
             AddPacketIdEntry(packetIds, S2C_SKILL_19_44_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_SKILL_19_45_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC);
             AddPacketIdEntry(packetIds, S2C_SKILL_ABILITY_SET_NTC);
             AddPacketIdEntry(packetIds, S2C_SKILL_19_47_16_NTC);
             AddPacketIdEntry(packetIds, S2C_SKILL_19_48_16_NTC);

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -1054,11 +1054,11 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_SKILL_GET_ABILITY_COST_RES = new PacketId(19, 39, 2, "S2C_SKILL_GET_ABILITY_COST_RES", ServerType.Game, PacketSource.Server); // アビリティセット用コストの取得に
         public static readonly PacketId C2S_SKILL_GET_PAWN_ABILITY_COST_REQ = new PacketId(19, 40, 1, "C2S_SKILL_GET_PAWN_ABILITY_COST_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_SKILL_GET_PAWN_ABILITY_COST_RES = new PacketId(19, 40, 2, "S2C_SKILL_GET_PAWN_ABILITY_COST_RES", ServerType.Game, PacketSource.Server); // ポーンアビリティセット用コストの取得に
-        public static readonly PacketId S2C_SKILL_ACQUIREMENT_LEARN_NTC = new PacketId(19, 41, 16, "S2C_SKILL_ACQUIREMENT_LEARN_NTC", ServerType.Game, PacketSource.Server); //Probably, based on order in debug symbols.
-        public static readonly PacketId S2C_SKILL_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 42, 16, "S2C_SKILL_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_SKILL_ACQUIREMENT_LEARN_NTC = new PacketId(19, 41, 16, "S2C_SKILL_ACQUIREMENT_LEARN_NTC", ServerType.Game, PacketSource.Server, "S2C_SKILL_19_41_16_NTC "); //Probably, based on order in debug symbols.
+        public static readonly PacketId S2C_SKILL_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 42, 16, "S2C_SKILL_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server, "S2C_SKILL_19_42_16_NTC ");
         public static readonly PacketId S2C_SKILL_CUSTOM_SKILL_SET_NTC = new PacketId(19, 43, 16, "S2C_SKILL_CUSTOM_SKILL_SET_NTC", ServerType.Game, PacketSource.Server, "S2C_SKILL_19_43_16_NTC");
         public static readonly PacketId S2C_SKILL_19_44_16_NTC = new PacketId(19, 44, 16, "S2C_SKILL_19_44_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 45, 16, "S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC = new PacketId(19, 45, 16, "S2C_SKILL_PAWN_NORMAL_SKILL_LEARN_NTC", ServerType.Game, PacketSource.Server, "S2C_SKILL_19_45_16_NTC ");
         public static readonly PacketId S2C_SKILL_ABILITY_SET_NTC = new PacketId(19, 46, 16, "S2C_SKILL_19_46_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_19_47_16_NTC = new PacketId(19, 47, 16, "S2C_SKILL_19_47_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_SKILL_19_48_16_NTC = new PacketId(19, 48, 16, "S2C_SKILL_19_48_16_NTC", ServerType.Game, PacketSource.Server);


### PR DESCRIPTION
Alert all party members with an NTC when a player or pawn ranks up a custom skill.

Addresses issue #359.

New to C# so the pallet search is probably wonky.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
