### PR TITLE
Fix: You cant receive bazaar proceeds when the total sum is 0 

### DIFF
--- a/Arrowgene.Ddon.GameServer/BazaarManager.cs
+++ b/Arrowgene.Ddon.GameServer/BazaarManager.cs
@@ -212,7 +212,9 @@ namespace Arrowgene.Ddon.GameServer
         {
             uint totalPrice = itemBaseInfo.Num*itemBaseInfo.Price;
             uint taxDeduction = (uint)(totalPrice * TAXES);
-            return Math.Clamp(totalPrice - taxDeduction, 0, uint.MaxValue);
+
+            //Minimum proceeds are 1 because the client UI won't let the player receive them if the total proceeds are less than 1.
+            return Math.Clamp(totalPrice - taxDeduction, 1, uint.MaxValue); 
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/BazaarManager.cs
+++ b/Arrowgene.Ddon.GameServer/BazaarManager.cs
@@ -145,7 +145,7 @@ namespace Arrowgene.Ddon.GameServer
         public uint ReceiveProceeds(GameClient client)
         {
             List<BazaarExhibition> exhibitionsToReceive = GetSoldExhibitionsByCharacter(client.Character);
-            
+
             uint totalProceeds = (uint) exhibitionsToReceive.Sum(exhibition => exhibition.Info.Proceeds);
             Server.WalletManager.AddToWalletNtc(client, client.Character, WalletType.Gold, totalProceeds);
 
@@ -211,7 +211,8 @@ namespace Arrowgene.Ddon.GameServer
         private uint calculateProceeds(CDataBazaarItemBaseInfo itemBaseInfo)
         {
             uint totalPrice = itemBaseInfo.Num*itemBaseInfo.Price;
-            return (uint)Math.Clamp(totalPrice - totalPrice*TAXES, 0, uint.MaxValue);
+            uint taxDeduction = (uint)(totalPrice * TAXES);
+            return Math.Clamp(totalPrice - taxDeduction, 0, uint.MaxValue);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/BazaarGetItemPriceLimitHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/BazaarGetItemPriceLimitHandler.cs
@@ -15,12 +15,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CBazaarGetItemPriceLimitRes Handle(GameClient client, C2SBazaarGetItemPriceLimitReq request)
         {
             // TODO: Take values from itemlist.csv?
+            // New values from the JP Wiki.
             return new S2CBazaarGetItemPriceLimitRes()
             {
                 ItemId = request.ItemId,
-                Low = uint.MinValue,
-                High = int.MaxValue, // Has to be int, apparently the client understands this field as an int, a number too high is seen as negative
-                Num = ushort.MaxValue // I recall it being 10 in most of the cases
+                Low = 1,
+                High = 99999, // Has to be int, apparently the client understands this field as an int, a number too high is seen as negative
+                Num = 20 // I recall it being 10 in most of the cases
             };
         }
     }


### PR DESCRIPTION
Addresses issue #357.

Tweaks the tax algorithm to match the UI; there should be no tax on sales of **up to** 20 GP, because tax is floored before its subtracted from the total sale price. The minimum/maximum price and max stack are also set to what was apparently on the live server, although those min/max prices were also seemingly item dependent.

Old:
> Min = 0, Max = ushort.MaxValue, Stack = 99

New:
> Min = 1, Max = 99,999, Stack = 10

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
