### PR TITLE
Hotfix: ClientItemInfo and itemlist.csv errors

### DIFF
--- a/Arrowgene.Ddon.Shared/Csv/ClientItemInfoCsv.cs
+++ b/Arrowgene.Ddon.Shared/Csv/ClientItemInfoCsv.cs
@@ -1,4 +1,6 @@
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+using System;
 
 namespace Arrowgene.Ddon.Shared.Csv
 {
@@ -14,16 +16,18 @@ namespace Arrowgene.Ddon.Shared.Csv
             if (!byte.TryParse(properties[3], out byte stackLimit)) return null;
             if (!byte.TryParse(properties[4], out byte rank)) return null;
 
-            string name = properties[6];
+            string name = properties[5];
 
             //Optional properties
 
-            ushort? subcategory = byte.TryParse(properties[5], out byte tmp0) ? (byte?)tmp0 : null;
+            ushort? subcategory = ushort.TryParse(properties[6], out ushort tmp0) ? (ushort?)tmp0 : null;
             byte? level = byte.TryParse(properties[7], out byte tmp1) ? (byte?)tmp1 : null;
             byte? jobs = byte.TryParse(properties[8], out byte tmp2) ? (byte?)tmp2 : null;
             byte? crestSlots = byte.TryParse(properties[9], out byte tmp3) ? (byte?)tmp3 : null;
             byte? quality = byte.TryParse(properties[10], out byte tmp4) ? (byte?)tmp4 : null;
             byte? gender = byte.TryParse(properties[11], out byte tmp5) ? (byte?)tmp5 : null;
+
+            if (subcategory != null && !Enum.IsDefined(typeof(ItemSubCategory), subcategory)) return null;
 
             return new ClientItemInfo
             {

--- a/Arrowgene.Ddon.Shared/Files/Assets/itemlist.csv
+++ b/Arrowgene.Ddon.Shared/Files/Assets/itemlist.csv
@@ -117,9 +117,9 @@
 11052,1,0,99,0,Net Cafe Privilege,1,,,,,
 11261,1,1,255,0,Currency for JP reset,1,,,,,
 11262,1,1,255,0,Currency for resetting craft P,1,,,,,
-11407,1,500,10,9,Corruption Cure,1,,,,,
+11407,1,500,10,25,Corruption Cure,1,,,,,
 11408,1,250,50,15,Anti-Corruption Medicine,1,,,,,
-11510,1,500,50,4,Superior Anti-Corruption Medicine,1,,,,,
+11510,1,500,50,20,Superior Anti-Corruption Medicine,1,,,,,
 13328,1,10,255,0,AP (Hidell Plains),1,,,,,
 13329,1,10,255,0,AP (Breya Coast),1,,,,,
 13330,1,10,255,0,AP (Mysree Forest),1,,,,,
@@ -292,10 +292,10 @@
 13969,1,0,99,0,Skill acquisition_Tactile Magic Arrow,1,,,,,
 13970,1,0,99,0,Skill Acquisition_Alchem Burst,1,,,,,
 13971,1,0,99,0,Skill acquisition_Dorus Aeris,1,,,,,
-14189,1,950,99,14,Key of Dragon Force,8,,,,,
-14190,1,950,99,14,Key of Gemstones,8,,,,,
-14191,1,950,99,14,Key of Treasures,8,,,,,
-14192,1,950,99,14,Key of Jewelry,8,,,,,
+14189,1,950,99,30,Key of Dragon Force,8,,,,,
+14190,1,950,99,30,Key of Gemstones,8,,,,,
+14191,1,950,99,30,Key of Treasures,8,,,,,
+14192,1,950,99,30,Key of Jewelry,8,,,,,
 16100,1,0,99,1,Book of Acquisition (Companion Healing),1,,,,,
 16101,1,0,99,1,Book of Acquisition (Heavy Steps: Light),1,,,,,
 16102,1,0,99,1,Book of Acquisition (Deft Footing: Light),1,,,,,
@@ -328,12 +328,12 @@
 16831,1,10000,255,1,Experience Crystal,1,,,,,
 17106,1,10,50,1,Handpicked Cacao,1,,,,,
 17107,1,80,10,1,Special Chocolate,1,,,,,
-17923,1,100,99,0,Bonus Dungeon Ticket (XP),8,,,,,
-17924,1,100,99,0,Bonus Dungeon Ticket (R),8,,,,,
-17925,1,100,99,0,Bonus Dungeon Ticket (BO),8,,,,,
-17926,1,100,99,0,Bonus Dungeon Ticket (G),8,,,,,
-18640,1,500,99,0,Carrie's Special Sandwich,1,,,,,
-18641,1,800,99,5,Carrie's Special Lunchbox,1,,,,,
+17923,1,100,99,80,Bonus Dungeon Ticket (XP),8,,,,,
+17924,1,100,99,80,Bonus Dungeon Ticket (R),8,,,,,
+17925,1,100,99,80,Bonus Dungeon Ticket (BO),8,,,,,
+17926,1,100,99,80,Bonus Dungeon Ticket (G),8,,,,,
+18640,1,500,99,80,Carrie's Special Sandwich,1,,,,,
+18641,1,800,99,85,Carrie's Special Lunchbox,1,,,,,
 18643,1,1,99,1,Dominion Point,1,,,,,
 18644,1,10,99,2,Dominion Point,1,,,,,
 18645,1,100,99,3,Dominion Point,1,,,,,
@@ -427,7 +427,7 @@
 19233,1,0,99,1,Book of Acquisition (Reduce Magick Defense Down),1,,,,,
 19234,1,0,99,1,Book of Acquisition (Reduce Petrify),1,,,,,
 19235,1,0,99,1,Book of Acquisition (Reduce Goldify),1,,,,,
-19367,1,0,99,0,Custom-Made Service Ticket,1,,,,,
+19367,1,0,99,80,Custom-Made Service Ticket,1,,,,,
 19382,1,150,99,10,Fresh Sangria,1,,,,,
 19383,1,150,99,10,Spicy Radish Marinade,1,,,,,
 19384,1,150,99,10,Beach Grilled Meat Skewers,1,,,,,
@@ -524,27 +524,27 @@
 23121,1,100,255,1,Red Dragon Mark,1,,,,,
 23122,1,1,255,1,Bitterblack Maze Reset Ticket,1,,,,,
 23123,1,0,1,1,Orb of Growth (LV.80),1,,,,,
-23365,1,0,99,0,Event Ticket (White Day),8,,,,,
-23366,1,0,99,0,Event Ticket (3rd Anniversary),8,,,,,
-23367,1,0,99,0,Event Ticket (Golden Palace),8,,,,,
-23368,1,0,99,0,Event Ticket,8,,,,,
-23369,1,0,99,0,Event Ticket,8,,,,,
-23370,1,0,99,0,Event Ticket,8,,,,,
-23371,1,0,99,0,Event Ticket,8,,,,,
-23372,1,0,99,0,Event Ticket,8,,,,,
-23373,1,0,99,0,Event Ticket,8,,,,,
-23374,1,0,99,0,Event Ticket,8,,,,,
-23375,1,0,99,0,Bonus Dungeon Ticket (SP),8,,,,,
-23411,1,100,99,0,Bonus Dungeon Ticket (JP),8,,,,,
-23412,1,100,99,0,Bonus Dungeon Ticket (HO),8,,,,,
+23365,1,0,99,80,Event Ticket (White Day),8,,,,,
+23366,1,0,99,80,Event Ticket (3rd Anniversary),8,,,,,
+23367,1,0,99,80,Event Ticket (Golden Palace),8,,,,,
+23368,1,0,99,80,Event Ticket,8,,,,,
+23369,1,0,99,80,Event Ticket,8,,,,,
+23370,1,0,99,80,Event Ticket,8,,,,,
+23371,1,0,99,80,Event Ticket,8,,,,,
+23372,1,0,99,80,Event Ticket,8,,,,,
+23373,1,0,99,80,Event Ticket,8,,,,,
+23374,1,0,99,80,Event Ticket,8,,,,,
+23375,1,0,99,80,Bonus Dungeon Ticket (SP),8,,,,,
+23411,1,100,99,80,Bonus Dungeon Ticket (JP),8,,,,,
+23412,1,100,99,80,Bonus Dungeon Ticket (HO),8,,,,,
 23413,1,0,255,1,Job Point,1,,,,,
 23545,1,10,99,1,Halloween Petit Muffin,1,,,,,
 23546,1,10,99,1,Angelic Wafer,1,,,,,
 23547,1,10,99,1,Devil's Nougat,1,,,,,
 23548,1,10,99,1,Sparkling Snow Large Crystal,1,,,,,
 24722,1,500,10,15,Dispelling Holy Water,1,,,,,
-24742,1,100,10,2,Dragon Fighting Talisman,1,,,,,
-24743,1,100,10,2,Dragon Protection Talisman,1,,,,,
+24742,1,100,10,130,Dragon Fighting Talisman,1,,,,,
+24743,1,100,10,130,Dragon Protection Talisman,1,,,,,
 24786,1,0,1,1,Become LV.100 Orb (Fighter),1,,,,,
 24787,1,0,1,1,Become LV.100 Orb (Shield Sage),1,,,,,
 24788,1,0,1,1,Become LV.100 Orb (Hunter),1,,,,,
@@ -566,10 +566,10 @@
 25651,1,0,255,1,Play Point,1,,,,,
 25652,1,0,255,1,Play Point,1,,,,,
 25653,1,0,255,1,Play Point,1,,,,,
-1053,2,5,99,1,Weight Reduction,134,,,,,
-1054,2,5,99,1,Low Level XP Up,135,,,,,
-1074,2,5,99,1,Beast-Steak,136,,,,,
-1316,2,50,99,4,Glowworm,137,,,,,
+1053,2,5,99,1,Weight Reduction,125,,,,,
+1054,2,5,99,1,Low Level XP Up,125,,,,,
+1074,2,5,99,1,Beast-Steak,122,,,,,
+1316,2,50,99,4,Glowworm,123,,,,,
 5723,2,0,1,0,Promotion exam A,123,,,,,
 1359,2,0,1,0,Promotion Exam B,123,,,,,
 7551,2,85,99,5,Large Beast-Steak,122,,,,,
@@ -1139,56 +1139,56 @@
 11747,2,100,99,12,Crest of Light Warding+,125,,,,,
 11748,2,100,99,12,Crest of Gloom Warding+,125,,,,,
 11759,2,100,99,15,Unappraised Moon Trinket (Soldier),129,,,,,
-11764,2,300,99,4,Grimoire Scrap,130,,,,,
-11765,2,600,99,4,Foreign Scroll,130,,,,,
-11766,2,300,99,4,Silver Moss,130,,,,,
-11767,2,600,99,4,Luminescent Silver Moss,130,,,,,
-11768,2,300,99,4,Ash Quartz,130,,,,,
-11769,2,600,99,4,Vision Quartz,130,,,,,
-11770,2,300,99,4,Volden Quality Coal,130,,,,,
-11771,2,600,99,4,Voldic Diamond,130,,,,,
-11772,2,300,99,4,Tomb Gravel,130,,,,,
-11773,2,600,99,4,Broken Stone Manacles,130,,,,,
-11774,2,952,99,4,Corroded Giant Eyeball,122,,,,,
-11775,2,300,99,9,Stalactite Tip,130,,,,,
-11776,2,600,99,9,Luminescent Stalactite,130,,,,,
-11777,2,952,99,9,Discolored Hard Horn,110,,,,,
-11778,2,952,99,9,Frost Metal,101,,,,,
-11779,2,1000,99,9,Reconnaissance Medal,123,,,,,
-11780,2,952,99,14,Rare Meteorite Crystal,123,,,,,
-11781,2,952,99,14,Dragon Beard,123,,,,,
-11782,2,952,99,14,Long Dragon Beard,123,,,,,
-11783,2,988,99,14,Blessed Long Dragon Beard,123,,,,,
+11764,2,300,99,20,Grimoire Scrap,130,,,,,
+11765,2,600,99,20,Foreign Scroll,130,,,,,
+11766,2,300,99,20,Silver Moss,130,,,,,
+11767,2,600,99,20,Luminescent Silver Moss,130,,,,,
+11768,2,300,99,20,Ash Quartz,130,,,,,
+11769,2,600,99,20,Vision Quartz,130,,,,,
+11770,2,300,99,20,Volden Quality Coal,130,,,,,
+11771,2,600,99,20,Voldic Diamond,130,,,,,
+11772,2,300,99,20,Tomb Gravel,130,,,,,
+11773,2,600,99,20,Broken Stone Manacles,130,,,,,
+11774,2,952,99,20,Corroded Giant Eyeball,122,,,,,
+11775,2,300,99,25,Stalactite Tip,130,,,,,
+11776,2,600,99,25,Luminescent Stalactite,130,,,,,
+11777,2,952,99,25,Discolored Hard Horn,110,,,,,
+11778,2,952,99,25,Frost Metal,101,,,,,
+11779,2,1000,99,25,Reconnaissance Medal,123,,,,,
+11780,2,952,99,30,Rare Meteorite Crystal,123,,,,,
+11781,2,952,99,30,Dragon Beard,123,,,,,
+11782,2,952,99,30,Long Dragon Beard,123,,,,,
+11783,2,988,99,30,Blessed Long Dragon Beard,123,,,,,
 11784,2,100,99,12,Refined Paraffin,123,,,,,
-11789,2,300,99,14,Pebble Bud,130,,,,,
-11790,2,600,99,14,Stone Bouquet,130,,,,,
-11791,2,300,99,14,Cave Silkworm,130,,,,,
-11792,2,600,99,14,Strong Silk Thread,130,,,,,
-11793,2,300,99,14,Ancient Beast Pelt,130,,,,,
-11794,2,600,99,14,Bristly Felt,130,,,,,
-11795,2,300,99,3,Phyton Liquid,130,,,,,
-11796,2,600,99,3,Phindymian Resin,130,,,,,
-11797,2,300,99,3,Ball Moss,130,,,,,
-11798,2,600,99,3,Light Green Moss Paper,130,,,,,
-11799,2,300,99,3,Soft Tectrix,130,,,,,
-11800,2,600,99,3,Feather Chiffon,130,,,,,
-11801,2,300,99,3,Viscous Meat,130,,,,,
-11802,2,600,99,3,Strong Adhesive Paste,130,,,,,
-11803,2,300,99,3,Gold-Stained Animal Fur,130,,,,,
-11804,2,600,99,3,Glitter Mohair,130,,,,,
-11805,2,1014,99,3,Manticore's Scorpion Tail,122,,,,,
-11806,2,300,99,8,Slimy Hide,130,,,,,
-11807,2,600,99,8,High Quality Slimy Leather,130,,,,,
-11808,2,1014,99,8,Prism Crystal,123,,,,,
-11809,2,1014,99,8,Mirage Crystal,123,,,,,
-11810,2,1014,99,13,Rare Vortex Crystal,123,,,,,
-11811,2,1014,99,13,Droplets of Ruin,123,,,,,
-11812,2,1014,99,13,Water of Ruin,123,,,,,
-11813,2,1056,99,13,Abyssal Ice of Ruin,123,,,,,
-11819,2,1000,99,14,White Knights Medal,123,,,,,
-12784,2,1000,99,14,Arisen Corps Medal,123,,,,,
-13223,2,952,99,4,Discolored Spore-covered Feather,112,,,,,
-13224,2,1014,99,3,Medusa's Serpent Hair,106,,,,,
+11789,2,300,99,30,Pebble Bud,130,,,,,
+11790,2,600,99,30,Stone Bouquet,130,,,,,
+11791,2,300,99,30,Cave Silkworm,130,,,,,
+11792,2,600,99,30,Strong Silk Thread,130,,,,,
+11793,2,300,99,30,Ancient Beast Pelt,130,,,,,
+11794,2,600,99,30,Bristly Felt,130,,,,,
+11795,2,300,99,35,Phyton Liquid,130,,,,,
+11796,2,600,99,35,Phindymian Resin,130,,,,,
+11797,2,300,99,35,Ball Moss,130,,,,,
+11798,2,600,99,35,Light Green Moss Paper,130,,,,,
+11799,2,300,99,35,Soft Tectrix,130,,,,,
+11800,2,600,99,35,Feather Chiffon,130,,,,,
+11801,2,300,99,35,Viscous Meat,130,,,,,
+11802,2,600,99,35,Strong Adhesive Paste,130,,,,,
+11803,2,300,99,35,Gold-Stained Animal Fur,130,,,,,
+11804,2,600,99,35,Glitter Mohair,130,,,,,
+11805,2,1014,99,35,Manticore's Scorpion Tail,122,,,,,
+11806,2,300,99,40,Slimy Hide,130,,,,,
+11807,2,600,99,40,High Quality Slimy Leather,130,,,,,
+11808,2,1014,99,40,Prism Crystal,123,,,,,
+11809,2,1014,99,40,Mirage Crystal,123,,,,,
+11810,2,1014,99,45,Rare Vortex Crystal,123,,,,,
+11811,2,1014,99,45,Droplets of Ruin,123,,,,,
+11812,2,1014,99,45,Water of Ruin,123,,,,,
+11813,2,1056,99,45,Abyssal Ice of Ruin,123,,,,,
+11819,2,1000,99,30,White Knights Medal,123,,,,,
+12784,2,1000,99,30,Arisen Corps Medal,123,,,,,
+13223,2,952,99,20,Discolored Spore-covered Feather,112,,,,,
+13224,2,1014,99,35,Medusa's Serpent Hair,106,,,,,
 13371,2,0,99,1,Fire Affinity LV.1,125,,,,,
 13372,2,0,99,1,Fire Affinity LV.2,125,,,,,
 13373,2,0,99,1,Fire Affinity LV.3,125,,,,,
@@ -1294,21 +1294,21 @@
 13473,2,0,99,1,Tough Skin LV.1,125,,,,,
 13474,2,0,99,1,Tough Skin LV.2,125,,,,,
 13475,2,0,99,1,Tough Skin LV.3,125,,,,,
-13476,2,100,99,4,Unappraised Moon Trinket (General),129,,,,,
-13477,2,100,99,9,Unappraised Moon Trinket (King),129,,,,,
-13478,2,100,99,14,Unappraised Moon Trinket (Emperor),129,,,,,
+13476,2,100,99,20,Unappraised Moon Trinket (General),129,,,,,
+13477,2,100,99,25,Unappraised Moon Trinket (King),129,,,,,
+13478,2,100,99,30,Unappraised Moon Trinket (Emperor),129,,,,,
 13479,2,100,99,15,Unappraised Star Trinket (Soldier),129,,,,,
-13480,2,100,99,4,Unappraised Star Trinket (General),129,,,,,
-13481,2,100,99,9,Unappraised Star Trinket (King),129,,,,,
-13482,2,100,99,14,Unappraised Star Trinket (Emperor),129,,,,,
+13480,2,100,99,20,Unappraised Star Trinket (General),129,,,,,
+13481,2,100,99,25,Unappraised Star Trinket (King),129,,,,,
+13482,2,100,99,30,Unappraised Star Trinket (Emperor),129,,,,,
 13483,2,100,99,15,Unappraised Flower Trinket (Soldier),129,,,,,
-13484,2,100,99,4,Unappraised Flower Trinket (General),129,,,,,
-13485,2,100,99,9,Unappraised Flower Trinket (King),129,,,,,
-13486,2,100,99,14,Unappraised Flower Trinket (Emperor),129,,,,,
+13484,2,100,99,20,Unappraised Flower Trinket (General),129,,,,,
+13485,2,100,99,25,Unappraised Flower Trinket (King),129,,,,,
+13486,2,100,99,30,Unappraised Flower Trinket (Emperor),129,,,,,
 13487,2,100,99,15,Unappraised Wind Trinket (Soldier),129,,,,,
-13488,2,100,99,4,Unappraised Wind Trinket (General),129,,,,,
-13489,2,100,99,9,Unappraised Wind Trinket (King),129,,,,,
-13490,2,100,99,14,Unappraised Wind Trinket (Emperor),129,,,,,
+13488,2,100,99,20,Unappraised Wind Trinket (General),129,,,,,
+13489,2,100,99,25,Unappraised Wind Trinket (King),129,,,,,
+13490,2,100,99,30,Unappraised Wind Trinket (Emperor),129,,,,,
 13491,2,500,99,12,Authentication Orb (Rathalos),123,,,,,
 13492,2,500,99,12,Authentication Orb (Rathian),123,,,,,
 13653,2,100,99,15,Crest of Burning+,124,,,,,
@@ -1394,181 +1394,181 @@
 14186,2,100,99,15,Crest of Greater Protection+,125,,,,,
 14187,2,100,99,15,Crest of Greater Intelligence+,125,,,,,
 14188,2,100,99,15,Crest of Fortitude+,125,,,,,
-15913,2,300,99,13,Carved Potsherd,130,,,,,
-15914,2,600,99,13,Pottery Charm,130,,,,,
-15915,2,300,99,13,Purple Petals,130,,,,,
-15916,2,600,99,13,Purple Algae Seed,130,,,,,
-15917,2,300,99,13,Ancient Iron Ore,130,,,,,
-15918,2,600,99,13,Ancient Iron Ingot,130,,,,,
-15919,2,300,99,2,Twisted Iron Scrap,130,,,,,
-15920,2,600,99,2,Ancient General's Chainmail,130,,,,,
-15921,2,300,99,2,Shrieking Mushroom,130,,,,,
-15922,2,600,99,2,Cursed Shrieking Mushroom,130,,,,,
-15923,2,300,99,2,Icon Fragment,130,,,,,
-15924,2,600,99,2,Foreign Goddess Idol,130,,,,,
-15925,2,300,99,2,Scarlet Plume,130,,,,,
-15926,2,300,99,2,Demon Scraps,130,,,,,
-15927,2,1200,99,2,Infected Giant Ulna,108,,,,,
-15928,2,1200,99,2,Rainbow-Colored Claw,109,,,,,
-15929,2,300,99,7,Mysterious Shell Fragment,130,,,,,
-15930,2,600,99,7,Giant Carapace,130,,,,,
-15931,2,300,99,7,Ancient Manuscript Scrap,130,,,,,
-15932,2,600,99,7,Phindym Manuscript,130,,,,,
-15933,2,300,99,7,Giant Scale,130,,,,,
-15934,2,1200,99,7,Tarasque Shell,123,,,,,
-15935,2,1200,99,7,Platinum Blood,119,,,,,
-15936,2,1000,99,7,Farana Medal,123,,,,,
-15937,2,1000,99,7,Elan Medal,123,,,,,
-15938,2,1000,99,7,Morrow Medal,123,,,,,
-15939,2,1000,99,7,Kingal Medal,123,,,,,
-15940,2,1200,99,12,Rare Green Tree Crystal,123,,,,,
-15941,2,952,99,12,Ancient Knight's Letter,123,,,,,
-15942,2,952,99,12,Ancient Knight's Book,123,,,,,
-15943,2,988,99,12,Ancient Knight's Scripture,123,,,,,
-15944,2,100,99,13,Farana Mint,114,,,,,
-15945,2,100,99,13,Sparkling Water,119,,,,,
-15946,2,200,99,2,White Bone Rock,102,,,,,
-15947,2,100,99,13,Old Geranium,114,,,,,
-15948,2,100,99,13,Premium Fragrant Wood,118,,,,,
-15949,2,200,99,2,Elana Water,119,,,,,
-15950,2,100,99,13,Rotten Tree,118,,,,,
-15951,2,100,99,13,Crab Brittlegill,117,,,,,
-15952,2,200,99,2,Wijnruit,114,,,,,
-15953,2,100,99,13,Ringing Ore,102,,,,,
-15954,2,100,99,13,Valley Spring Water,119,,,,,
-15955,2,200,99,2,Kingalite,113,,,,,
-15956,2,100,99,13,Bright Titanium,101,,,,,
-15957,2,100,99,13,Spider Mesh,104,,,,,
-15958,2,200,99,13,Scroll of Dream and Reality,120,,,,,
-15959,2,235,99,13,Pixie Mock Wing,112,,,,,
-15960,2,235,99,13,Demon Wolf's Sinewy Meat,122,,,,,
-15961,2,235,99,13,Stiff Crocodile Skin,107,,,,,
-15962,2,235,99,13,Bronze Tail Feather,112,,,,,
-15963,2,320,99,13,Bloodied Giant Tusk,109,,,,,
-15965,2,800,99,13,Composite Organ,122,,,,,
-15967,2,800,99,13,Dazzling Silver Plume,112,,,,,
-15969,2,800,99,13,Sharp Back Spine,110,,,,,
-15971,2,800,99,13,Murky Dragon Fang,109,,,,,
-15973,2,800,99,13,Demon Envoy's Horn,110,,,,,
-15974,2,800,99,13,Envoy's Loathsome Tail,122,,,,,
-15975,2,300,99,12,Thick Shell,130,,,,,
-15976,2,600,99,12,Giant Fossil Shell,130,,,,,
-15977,2,300,99,12,Gnarled Branch,130,,,,,
-15978,2,600,99,12,Diseased Wreath,130,,,,,
-15979,2,300,99,12,Illustrated Old Cloth,130,,,,,
-15980,2,600,99,12,Spirit's Tapestry,130,,,,,
-15981,2,300,99,1,Ancient Sago Palm,130,,,,,
-15982,2,600,99,1,Aged Green Leaves,130,,,,,
-15983,2,300,99,1,Transparent Coarse Sand,130,,,,,
-15984,2,600,99,1,Clear Fine Sand,130,,,,,
-15985,2,300,99,1,Malformed Nut,130,,,,,
-15986,2,600,99,1,Strange Sprout,130,,,,,
-15987,2,300,99,1,Jet Black Fur,130,,,,,
-15988,2,300,99,1,Infected Demon Bone Fragment,130,,,,,
-15989,2,1200,99,1,Pixie Crown,123,,,,,
-15990,2,1200,99,1,Sancto Sap,119,,,,,
-15991,2,300,99,6,Dubious Animal Pelt,130,,,,,
-15992,2,600,99,6,Fleshed Animal Pelt,130,,,,,
-15993,2,300,99,6,Crystallized Sap,130,,,,,
-15994,2,300,99,6,Corrupted Small Feathers,130,,,,,
-15995,2,1200,99,6,Griffin Spinel,113,,,,,
-15996,2,1200,99,6,Black Claw of Misfortune,109,,,,,
-15997,2,952,99,11,Ocean Crystal,123,,,,,
-15998,2,988,99,11,Blue Opal,123,,,,,
-15999,2,988,99,11,Blue Skies Blue Opal,123,,,,,
-16000,2,988,99,11,Sky Dragon's Blue Opal,123,,,,,
-16001,2,250,99,1,Ashen Flower Rock,102,,,,,
-16002,2,250,99,1,Smooth White Mud,103,,,,,
-16003,2,250,99,1,Morrow Lauan Wood,118,,,,,
-16004,2,250,99,1,Adamas Ore,102,,,,,
-16005,2,980,99,1,Silvery Snow Steel Ingot,101,,,,,
-16006,2,980,99,1,Elemental Lace,104,,,,,
-16007,2,980,99,1,Scroll of True Shadow,120,,,,,
-16008,2,800,99,12,Fine Femur,108,,,,,
-16009,2,800,99,12,Protected Beast's Green Fur,106,,,,,
-16010,2,800,99,12,Still-Beating Heart,122,,,,,
-16011,2,800,99,12,Seabird Syrinx,122,,,,,
-16012,2,800,99,12,Thousand-Year Moss,117,,,,,
-16013,2,800,99,12,Deformed Horn of Misfortune,110,,,,,
-16014,2,800,99,12,Eagle's Damaged Talon,109,,,,,
-16017,2,100,99,13,Soldier's Loyalty,123,,,,,
-16018,2,100,99,13,Abrasive,123,,,,,
-16019,2,100,99,13,Rusty Iron Lump,123,,,,,
-16020,2,100,99,13,Superior Abrasive,123,,,,,
-16030,2,100,99,4,Crest of Herculean Power (Burning),124,,,,,
-16031,2,100,99,4,Crest of Herculean Power (Freezing),124,,,,,
-16032,2,100,99,4,Crest of Herculean Power (Shock),124,,,,,
-16033,2,100,99,4,Crest of Herculean Power (Holy Drain),124,,,,,
-16034,2,100,99,4,Crest of Herculean Power (Blinding),124,,,,,
-16035,2,100,99,4,Crest of Superior Magick (Burning),124,,,,,
-16036,2,100,99,4,Crest of Superior Magick (Freezing),124,,,,,
-16040,2,100,99,4,Crest of Superior Magick (Shock),124,,,,,
-16041,2,100,99,4,Crest of Superior Magick (Holy Drain),124,,,,,
-16042,2,100,99,4,Crest of Superior Magick (Blinding),124,,,,,
-16043,2,100,99,4,Crest of Herculean Power (Blow Power),124,,,,,
-16044,2,100,99,4,Crest of Herculean Power (Stun),124,,,,,
-16045,2,100,99,4,Crest of Herculean Power (Poison),124,,,,,
-16046,2,100,99,4,Crest of Herculean Power (Torpor),124,,,,,
-16047,2,100,99,4,Crest of Herculean Power (Sleep),124,,,,,
-16048,2,100,99,4,Crest of Herculean Power (Petrification),124,,,,,
-16049,2,100,99,4,Crest of Herculean Power (Gilding),124,,,,,
-16050,2,100,99,4,Crest of Herculean Power (Lowered Defense),124,,,,,
-16051,2,100,99,4,Crest of Superior Magick (Blow Power),124,,,,,
-16052,2,100,99,4,Crest of Superior Magick (Stun),124,,,,,
-16053,2,100,99,4,Crest of Superior Magick (Poison),124,,,,,
-16054,2,100,99,4,Crest of Superior Magick (Torpor),124,,,,,
-16055,2,100,99,4,Crest of Superior Magick (Sleep),124,,,,,
-16056,2,100,99,4,Crest of Superior Magick (Petrification),124,,,,,
-16057,2,100,99,4,Crest of Superior Magick (Gilding),124,,,,,
-16058,2,100,99,4,Crest of Superior Magick (Lowered Magick Defense),124,,,,,
-16059,2,100,99,4,Crest of Herculean Power (Lightness),124,,,,,
-16060,2,100,99,4,Crest of Superior Magick (Lightness),124,,,,,
-16061,2,100,99,4,Crest of Incineration (Decreased Fire Resist),124,,,,,
-16062,2,100,99,4,Crest of Permafrost (Decreased Ice Resist),124,,,,,
-16063,2,100,99,4,Crest of Electrocution (Decreased Lightning Resist),124,,,,,
-16064,2,100,99,4,Crest of Sanctity (Decreased Holy Resist),124,,,,,
-16065,2,100,99,4,Crest of Twilight (Decreased Dark Resist),124,,,,,
-16066,2,100,99,4,Crest of Strong Health,125,,,,,
-16067,2,100,99,4,Crest of Health,125,,,,,
-16068,2,100,99,4,Crest of Strong Stamina,125,,,,,
-16069,2,100,99,4,Crest of Stamina,125,,,,,
-16070,2,100,99,4,Crest of Firm Protection (Health),125,,,,,
-16071,2,100,99,4,Crest of Firm Protection (Endurance),125,,,,,
-16072,2,100,99,4,Crest of Firm Protection (Vitality),125,,,,,
-16073,2,100,99,4,Crest of Firm Protection (Lightness),125,,,,,
-16074,2,100,99,4,Crest of Wisdom (Health),125,,,,,
-16075,2,100,99,4,Crest of Wisdom (Endurance),125,,,,,
-16076,2,100,99,4,Crest of Wisdom (Vitality),125,,,,,
-16077,2,100,99,4,Crest of Wisdom (Lightness),125,,,,,
-16078,2,100,99,4,Crest of Unwavering,125,,,,,
-16079,2,100,99,4,Crest of Vigor,125,,,,,
-16080,2,100,99,4,Crest of Fire Barrier,125,,,,,
-16081,2,100,99,4,Crest of Ice Barrier,125,,,,,
-16082,2,100,99,4,Crest of Lightning Barrier,125,,,,,
-16083,2,100,99,4,Crest of Holy Barrier,125,,,,,
-16084,2,100,99,4,Crest of Dark Barrier,125,,,,,
-16085,2,100,99,4,Crest of Double Resist (Poison/Torpor),125,,,,,
-16086,2,100,99,4,Crest of Double Resist (Sleep/Stun),125,,,,,
-16087,2,100,99,4,Crest of Double Resist (Petrify/Gild),125,,,,,
-16088,2,100,99,4,Crest of Double Resist (Curse/Stifle),125,,,,,
-16089,2,100,99,4,Crest of Double Resist (Lowered Strength/Defense),125,,,,,
-16090,2,100,99,4,Crest of Double Resist (Lowered Magick/Magick Defense),125,,,,,
-16091,2,100,99,4,Crest of Fire Protection,125,,,,,
-16092,2,100,99,4,Crest of Ice Protection,125,,,,,
-16093,2,100,99,4,Crest of Lightning Protection,125,,,,,
-16094,2,100,99,4,Crest of Holy Protection,125,,,,,
-16095,2,100,99,4,Crest of Dark Protection,125,,,,,
-16096,2,100,99,4,Crest of Triple Resist (Sleep/Poison/Slow),125,,,,,
-16097,2,100,99,4,Crest of Triple Resist (Stun/Curse/Stifle),125,,,,,
-16098,2,100,99,4,Crest of Triple Resist (Petrify/Gild/Frail),125,,,,,
-16099,2,100,99,4,Crest of Stature Protection,125,,,,,
-16115,2,600,99,2,Rainbow Feather,130,,,,,
-16116,2,600,99,2,Discolored Organs,130,,,,,
-16117,2,600,99,7,Armored Scale,130,,,,,
-16118,2,600,99,1,Jet Black Pelt,130,,,,,
-16119,2,600,99,1,Corroded Spine,130,,,,,
-16120,2,600,99,6,Crystal-Encrusted Twig,130,,,,,
-16121,2,600,99,6,Corrupted Griffin Blood,130,,,,,
+15913,2,300,99,45,Carved Potsherd,130,,,,,
+15914,2,600,99,45,Pottery Charm,130,,,,,
+15915,2,300,99,45,Purple Petals,130,,,,,
+15916,2,600,99,45,Purple Algae Seed,130,,,,,
+15917,2,300,99,45,Ancient Iron Ore,130,,,,,
+15918,2,600,99,45,Ancient Iron Ingot,130,,,,,
+15919,2,300,99,50,Twisted Iron Scrap,130,,,,,
+15920,2,600,99,50,Ancient General's Chainmail,130,,,,,
+15921,2,300,99,50,Shrieking Mushroom,130,,,,,
+15922,2,600,99,50,Cursed Shrieking Mushroom,130,,,,,
+15923,2,300,99,50,Icon Fragment,130,,,,,
+15924,2,600,99,50,Foreign Goddess Idol,130,,,,,
+15925,2,300,99,50,Scarlet Plume,130,,,,,
+15926,2,300,99,50,Demon Scraps,130,,,,,
+15927,2,1200,99,50,Infected Giant Ulna,108,,,,,
+15928,2,1200,99,50,Rainbow-Colored Claw,109,,,,,
+15929,2,300,99,55,Mysterious Shell Fragment,130,,,,,
+15930,2,600,99,55,Giant Carapace,130,,,,,
+15931,2,300,99,55,Ancient Manuscript Scrap,130,,,,,
+15932,2,600,99,55,Phindym Manuscript,130,,,,,
+15933,2,300,99,55,Giant Scale,130,,,,,
+15934,2,1200,99,55,Tarasque Shell,123,,,,,
+15935,2,1200,99,55,Platinum Blood,119,,,,,
+15936,2,1000,99,55,Farana Medal,123,,,,,
+15937,2,1000,99,55,Elan Medal,123,,,,,
+15938,2,1000,99,55,Morrow Medal,123,,,,,
+15939,2,1000,99,55,Kingal Medal,123,,,,,
+15940,2,1200,99,60,Rare Green Tree Crystal,123,,,,,
+15941,2,952,99,60,Ancient Knight's Letter,123,,,,,
+15942,2,952,99,60,Ancient Knight's Book,123,,,,,
+15943,2,988,99,60,Ancient Knight's Scripture,123,,,,,
+15944,2,100,99,45,Farana Mint,114,,,,,
+15945,2,100,99,45,Sparkling Water,119,,,,,
+15946,2,200,99,50,White Bone Rock,102,,,,,
+15947,2,100,99,45,Old Geranium,114,,,,,
+15948,2,100,99,45,Premium Fragrant Wood,118,,,,,
+15949,2,200,99,50,Elana Water,119,,,,,
+15950,2,100,99,45,Rotten Tree,118,,,,,
+15951,2,100,99,45,Crab Brittlegill,117,,,,,
+15952,2,200,99,50,Wijnruit,114,,,,,
+15953,2,100,99,45,Ringing Ore,102,,,,,
+15954,2,100,99,45,Valley Spring Water,119,,,,,
+15955,2,200,99,50,Kingalite,113,,,,,
+15956,2,100,99,45,Bright Titanium,101,,,,,
+15957,2,100,99,45,Spider Mesh,104,,,,,
+15958,2,200,99,45,Scroll of Dream and Reality,120,,,,,
+15959,2,235,99,45,Pixie Mock Wing,112,,,,,
+15960,2,235,99,45,Demon Wolf's Sinewy Meat,122,,,,,
+15961,2,235,99,45,Stiff Crocodile Skin,107,,,,,
+15962,2,235,99,45,Bronze Tail Feather,112,,,,,
+15963,2,320,99,45,Bloodied Giant Tusk,109,,,,,
+15965,2,800,99,45,Composite Organ,122,,,,,
+15967,2,800,99,45,Dazzling Silver Plume,112,,,,,
+15969,2,800,99,45,Sharp Back Spine,110,,,,,
+15971,2,800,99,45,Murky Dragon Fang,109,,,,,
+15973,2,800,99,45,Demon Envoy's Horn,110,,,,,
+15974,2,800,99,45,Envoy's Loathsome Tail,122,,,,,
+15975,2,300,99,60,Thick Shell,130,,,,,
+15976,2,600,99,60,Giant Fossil Shell,130,,,,,
+15977,2,300,99,60,Gnarled Branch,130,,,,,
+15978,2,600,99,60,Diseased Wreath,130,,,,,
+15979,2,300,99,60,Illustrated Old Cloth,130,,,,,
+15980,2,600,99,60,Spirit's Tapestry,130,,,,,
+15981,2,300,99,65,Ancient Sago Palm,130,,,,,
+15982,2,600,99,65,Aged Green Leaves,130,,,,,
+15983,2,300,99,65,Transparent Coarse Sand,130,,,,,
+15984,2,600,99,65,Clear Fine Sand,130,,,,,
+15985,2,300,99,65,Malformed Nut,130,,,,,
+15986,2,600,99,65,Strange Sprout,130,,,,,
+15987,2,300,99,65,Jet Black Fur,130,,,,,
+15988,2,300,99,65,Infected Demon Bone Fragment,130,,,,,
+15989,2,1200,99,65,Pixie Crown,123,,,,,
+15990,2,1200,99,65,Sancto Sap,119,,,,,
+15991,2,300,99,70,Dubious Animal Pelt,130,,,,,
+15992,2,600,99,70,Fleshed Animal Pelt,130,,,,,
+15993,2,300,99,70,Crystallized Sap,130,,,,,
+15994,2,300,99,70,Corrupted Small Feathers,130,,,,,
+15995,2,1200,99,70,Griffin Spinel,113,,,,,
+15996,2,1200,99,70,Black Claw of Misfortune,109,,,,,
+15997,2,952,99,75,Ocean Crystal,123,,,,,
+15998,2,988,99,75,Blue Opal,123,,,,,
+15999,2,988,99,75,Blue Skies Blue Opal,123,,,,,
+16000,2,988,99,75,Sky Dragon's Blue Opal,123,,,,,
+16001,2,250,99,65,Ashen Flower Rock,102,,,,,
+16002,2,250,99,65,Smooth White Mud,103,,,,,
+16003,2,250,99,65,Morrow Lauan Wood,118,,,,,
+16004,2,250,99,65,Adamas Ore,102,,,,,
+16005,2,980,99,65,Silvery Snow Steel Ingot,101,,,,,
+16006,2,980,99,65,Elemental Lace,104,,,,,
+16007,2,980,99,65,Scroll of True Shadow,120,,,,,
+16008,2,800,99,60,Fine Femur,108,,,,,
+16009,2,800,99,60,Protected Beast's Green Fur,106,,,,,
+16010,2,800,99,60,Still-Beating Heart,122,,,,,
+16011,2,800,99,60,Seabird Syrinx,122,,,,,
+16012,2,800,99,60,Thousand-Year Moss,117,,,,,
+16013,2,800,99,60,Deformed Horn of Misfortune,110,,,,,
+16014,2,800,99,60,Eagle's Damaged Talon,109,,,,,
+16017,2,100,99,45,Soldier's Loyalty,123,,,,,
+16018,2,100,99,45,Abrasive,123,,,,,
+16019,2,100,99,45,Rusty Iron Lump,123,,,,,
+16020,2,100,99,45,Superior Abrasive,123,,,,,
+16030,2,100,99,20,Crest of Herculean Power (Burning),124,,,,,
+16031,2,100,99,20,Crest of Herculean Power (Freezing),124,,,,,
+16032,2,100,99,20,Crest of Herculean Power (Shock),124,,,,,
+16033,2,100,99,20,Crest of Herculean Power (Holy Drain),124,,,,,
+16034,2,100,99,20,Crest of Herculean Power (Blinding),124,,,,,
+16035,2,100,99,20,Crest of Superior Magick (Burning),124,,,,,
+16036,2,100,99,20,Crest of Superior Magick (Freezing),124,,,,,
+16040,2,100,99,20,Crest of Superior Magick (Shock),124,,,,,
+16041,2,100,99,20,Crest of Superior Magick (Holy Drain),124,,,,,
+16042,2,100,99,20,Crest of Superior Magick (Blinding),124,,,,,
+16043,2,100,99,20,Crest of Herculean Power (Blow Power),124,,,,,
+16044,2,100,99,20,Crest of Herculean Power (Stun),124,,,,,
+16045,2,100,99,20,Crest of Herculean Power (Poison),124,,,,,
+16046,2,100,99,20,Crest of Herculean Power (Torpor),124,,,,,
+16047,2,100,99,20,Crest of Herculean Power (Sleep),124,,,,,
+16048,2,100,99,20,Crest of Herculean Power (Petrification),124,,,,,
+16049,2,100,99,20,Crest of Herculean Power (Gilding),124,,,,,
+16050,2,100,99,20,Crest of Herculean Power (Lowered Defense),124,,,,,
+16051,2,100,99,20,Crest of Superior Magick (Blow Power),124,,,,,
+16052,2,100,99,20,Crest of Superior Magick (Stun),124,,,,,
+16053,2,100,99,20,Crest of Superior Magick (Poison),124,,,,,
+16054,2,100,99,20,Crest of Superior Magick (Torpor),124,,,,,
+16055,2,100,99,20,Crest of Superior Magick (Sleep),124,,,,,
+16056,2,100,99,20,Crest of Superior Magick (Petrification),124,,,,,
+16057,2,100,99,20,Crest of Superior Magick (Gilding),124,,,,,
+16058,2,100,99,20,Crest of Superior Magick (Lowered Magick Defense),124,,,,,
+16059,2,100,99,20,Crest of Herculean Power (Lightness),124,,,,,
+16060,2,100,99,20,Crest of Superior Magick (Lightness),124,,,,,
+16061,2,100,99,20,Crest of Incineration (Decreased Fire Resist),124,,,,,
+16062,2,100,99,20,Crest of Permafrost (Decreased Ice Resist),124,,,,,
+16063,2,100,99,20,Crest of Electrocution (Decreased Lightning Resist),124,,,,,
+16064,2,100,99,20,Crest of Sanctity (Decreased Holy Resist),124,,,,,
+16065,2,100,99,20,Crest of Twilight (Decreased Dark Resist),124,,,,,
+16066,2,100,99,20,Crest of Strong Health,125,,,,,
+16067,2,100,99,20,Crest of Health,125,,,,,
+16068,2,100,99,20,Crest of Strong Stamina,125,,,,,
+16069,2,100,99,20,Crest of Stamina,125,,,,,
+16070,2,100,99,20,Crest of Firm Protection (Health),125,,,,,
+16071,2,100,99,20,Crest of Firm Protection (Endurance),125,,,,,
+16072,2,100,99,20,Crest of Firm Protection (Vitality),125,,,,,
+16073,2,100,99,20,Crest of Firm Protection (Lightness),125,,,,,
+16074,2,100,99,20,Crest of Wisdom (Health),125,,,,,
+16075,2,100,99,20,Crest of Wisdom (Endurance),125,,,,,
+16076,2,100,99,20,Crest of Wisdom (Vitality),125,,,,,
+16077,2,100,99,20,Crest of Wisdom (Lightness),125,,,,,
+16078,2,100,99,20,Crest of Unwavering,125,,,,,
+16079,2,100,99,20,Crest of Vigor,125,,,,,
+16080,2,100,99,20,Crest of Fire Barrier,125,,,,,
+16081,2,100,99,20,Crest of Ice Barrier,125,,,,,
+16082,2,100,99,20,Crest of Lightning Barrier,125,,,,,
+16083,2,100,99,20,Crest of Holy Barrier,125,,,,,
+16084,2,100,99,20,Crest of Dark Barrier,125,,,,,
+16085,2,100,99,20,Crest of Double Resist (Poison/Torpor),125,,,,,
+16086,2,100,99,20,Crest of Double Resist (Sleep/Stun),125,,,,,
+16087,2,100,99,20,Crest of Double Resist (Petrify/Gild),125,,,,,
+16088,2,100,99,20,Crest of Double Resist (Curse/Stifle),125,,,,,
+16089,2,100,99,20,Crest of Double Resist (Lowered Strength/Defense),125,,,,,
+16090,2,100,99,20,Crest of Double Resist (Lowered Magick/Magick Defense),125,,,,,
+16091,2,100,99,20,Crest of Fire Protection,125,,,,,
+16092,2,100,99,20,Crest of Ice Protection,125,,,,,
+16093,2,100,99,20,Crest of Lightning Protection,125,,,,,
+16094,2,100,99,20,Crest of Holy Protection,125,,,,,
+16095,2,100,99,20,Crest of Dark Protection,125,,,,,
+16096,2,100,99,20,Crest of Triple Resist (Sleep/Poison/Slow),125,,,,,
+16097,2,100,99,20,Crest of Triple Resist (Stun/Curse/Stifle),125,,,,,
+16098,2,100,99,20,Crest of Triple Resist (Petrify/Gild/Frail),125,,,,,
+16099,2,100,99,20,Crest of Stature Protection,125,,,,,
+16115,2,600,99,50,Rainbow Feather,130,,,,,
+16116,2,600,99,50,Discolored Organs,130,,,,,
+16117,2,600,99,55,Armored Scale,130,,,,,
+16118,2,600,99,65,Jet Black Pelt,130,,,,,
+16119,2,600,99,65,Corroded Spine,130,,,,,
+16120,2,600,99,70,Crystal-Encrusted Twig,130,,,,,
+16121,2,600,99,70,Corrupted Griffin Blood,130,,,,,
 16239,2,0,99,1,Agile Motion LV.3,125,,,,,
 16240,2,0,99,1,Agile Motion LV.4,125,,,,,
 16241,2,0,99,1,Agile Motion LV.5,125,,,,,
@@ -1704,15 +1704,15 @@
 16371,2,0,99,1,Lively Romp LV.3,125,,,,,
 16372,2,0,99,1,Lively Romp LV.4,125,,,,,
 16373,2,0,99,1,Lively Romp LV.5,125,,,,,
-16374,2,100,99,2,Unidentified Dragon Trinket (Fighter),129,,,,,
-16375,2,100,99,2,Unidentified Dragon Trinket (Seeker),129,,,,,
-16376,2,100,99,2,Unidentified Dragon Trinket (Hunter),129,,,,,
-16377,2,100,99,2,Unidentified Dragon Trinket (Priest),129,,,,,
-16378,2,100,99,2,Unidentified Dragon Trinket (Shield Sage),129,,,,,
-16379,2,100,99,2,Unidentified Dragon Trinket (Sorcerer),129,,,,,
-16380,2,100,99,2,Unidentified Dragon Trinket (Warrior),129,,,,,
-16381,2,100,99,2,Unidentified Dragon Trinket (Element Archer),129,,,,,
-16382,2,100,99,2,Unidentified Dragon Trinket (Alchemist),129,,,,,
+16374,2,100,99,50,Unidentified Dragon Trinket (Fighter),129,,,,,
+16375,2,100,99,50,Unidentified Dragon Trinket (Seeker),129,,,,,
+16376,2,100,99,50,Unidentified Dragon Trinket (Hunter),129,,,,,
+16377,2,100,99,50,Unidentified Dragon Trinket (Priest),129,,,,,
+16378,2,100,99,50,Unidentified Dragon Trinket (Shield Sage),129,,,,,
+16379,2,100,99,50,Unidentified Dragon Trinket (Sorcerer),129,,,,,
+16380,2,100,99,50,Unidentified Dragon Trinket (Warrior),129,,,,,
+16381,2,100,99,50,Unidentified Dragon Trinket (Element Archer),129,,,,,
+16382,2,100,99,50,Unidentified Dragon Trinket (Alchemist),129,,,,,
 16392,2,0,99,1,Agile Motion LV.6,125,,,,,
 16393,2,0,99,1,Dire Gouge LV.6,125,,,,,
 16394,2,0,99,1,Crush Receive LV.6,125,,,,,
@@ -1758,14 +1758,14 @@
 16434,2,0,99,1,Prolonged Lure LV.6,125,,,,,
 16435,2,0,99,1,Well-Practiced LV.6,125,,,,,
 16436,2,0,99,1,Lively Romp LV.6,125,,,,,
-16522,2,100,99,13,Spiritual Flame,123,,,,,
+16522,2,100,99,45,Spiritual Flame,123,,,,,
 16626,2,0,99,1,Fire Engraving,124,,,,,
 16627,2,0,99,1,Ice Engraving,124,,,,,
 16628,2,0,99,1,Lightning Engraving,124,,,,,
 16629,2,0,99,1,Heaven Engraving,124,,,,,
 16630,2,0,99,1,Dark Engraving,124,,,,,
 16632,2,0,99,1,No Engraving,124,,,,,
-16698,2,960,99,11,Black Knight's Thoughts,123,,,,,
+16698,2,960,99,75,Black Knight's Thoughts,123,,,,,
 16699,2,0,99,1,Extension LV.3,125,,,,,
 16700,2,0,99,1,Extension LV.4,125,,,,,
 16701,2,0,99,1,Extension LV.5,125,,,,,
@@ -1786,126 +1786,126 @@
 16716,2,0,99,1,Evasive Spirit LV.4,125,,,,,
 16720,2,0,99,1,Evasive Spirit LV.5,125,,,,,
 16721,2,0,99,1,Evasive Spirit LV.6,125,,,,,
-16725,2,100,99,2,Unidentified Dragon Trinket (Spirit Lancer),129,,,,,
+16725,2,100,99,50,Unidentified Dragon Trinket (Spirit Lancer),129,,,,,
 16800,2,500,99,1,2017 New Year Jumbo Draw Ticket,123,,,,,
-16833,2,500,99,2,Silver Authentication Orb,123,,,,,
-16834,2,500,99,2,Gold Authentication Orb,123,,,,,
-17856,2,2500,99,5,Stone-Curser's Tears,119,,,,,
-17857,2,1500,99,5,Demonic Beast Snakeskin,107,,,,,
-17858,2,1500,99,5,Giant's Molar,109,,,,,
-17859,2,500,99,0,Mark of Brute Courage,123,,,,,
-17860,2,1500,99,5,Mark of A Hundred Battles,123,,,,,
-17861,2,350,99,0,Black Blade Fragment,102,,,,,
-17863,2,2500,99,4,Evil Eye Lens,123,,,,,
-17864,2,1500,99,4,Magickal Giant Bones,108,,,,,
-17865,2,1500,99,4,Ogre's Horn,110,,,,,
-17866,2,1500,99,5,Manticore Raw Pelt,107,,,,,
-17867,2,350,99,0,Goblin's Spellstaff,123,,,,,
-17868,2,350,99,15,Blood Drinking Vessel,123,,,,,
-17869,2,350,99,15,Undead Wolf's Fang,109,,,,,
-17870,2,350,99,0,Rock Leather,107,,,,,
-17871,2,1500,99,5,Rock-Cutter,109,,,,,
-17872,2,350,99,5,Giant Apophyllite,113,,,,,
-17873,2,350,99,5,Undead Nail Shaving,109,,,,,
-17875,2,2500,99,5,Dragonkin Stone,131,,,,,
-17876,2,500,99,0,Battle Armor Fragment,123,,,,,
-17877,2,250,99,0,Dragonkin Stone Shard,123,,,,,
-17878,2,1500,99,5,Cursed Letter,120,,,,,
-17879,2,2000,99,5,Dragon's Inverse Scale,107,,,,,
-17880,2,350,99,0,Highly Viscous Slime Liquid,119,,,,,
-17881,2,15000,99,5,Bone Pearl,113,,,,,
-17882,2,250,99,0,Brittle Sandstone,102,,,,,
-17883,2,1000,99,5,Pyroclastic Rock,102,,,,,
-17884,2,250,99,0,Ashen Grass,114,,,,,
-17885,2,1000,99,5,Blaze Grass,114,,,,,
-17886,2,500,99,0,Plankton Liquid,119,,,,,
-17888,2,350,99,0,Dragon Head Tile Fragment,123,,,,,
-17889,2,350,99,0,Dragon Tail Tile Fragment,123,,,,,
-17891,2,3000,99,5,Ribbon of Rich Bounty,104,,,,,
-17892,2,3000,99,5,Cobalt Alloy Ingot,101,,,,,
-17893,2,3000,99,4,Scroll of the Starry Sky,120,,,,,
-17894,2,3000,99,4,Bright Purple Steel Ingot,101,,,,,
-17897,2,2500,99,5,Gusty Winds Stone,131,,,,,
-17898,2,2500,99,5,Victorious Chance Stone,131,,,,,
-17899,2,2500,99,5,Fallen Soldier Stone,131,,,,,
-17900,2,2500,99,5,Animal Hunter Stone,131,,,,,
-17901,2,2500,99,5,Demihuman Cutter Stone,131,,,,,
-17902,2,2500,99,5,Demonic Slasher Stone,131,,,,,
-17903,2,2500,99,5,Skeleton Smasher Stone,131,,,,,
-17904,2,2500,99,5,Undead Destroyer Stone,131,,,,,
-17905,2,2500,99,5,Giant Killer Stone,131,,,,,
-17907,2,200,99,5,Dried Test Sample,130,,,,,
-17908,2,900,99,5,Monster Tissue Sample,130,,,,,
-17909,2,200,99,10,Flesh-Eating Snail,130,,,,,
-17910,2,900,99,10,Blood-Colored Spiral Shell,130,,,,,
-17911,2,200,99,0,Delicate Intaglio,130,,,,,
-17912,2,900,99,0,Acre Royal Family Intaglio,130,,,,,
-17915,2,900,99,15,Underworld Drop,119,,,,,
-17916,2,900,99,15,Misleading Twig,118,,,,,
-17917,2,900,99,15,Feryana Sweet Mushroom,117,,,,,
-17927,2,1500,99,4,Goremanticore's White Beard,106,,,,,
-17928,2,350,99,0,Harpy Breast Meat,122,,,,,
-17929,2,350,99,15,Fluttering Rags,104,,,,,
-17930,2,1500,99,5,Winged Beast's Heart,122,,,,,
-17959,2,123,99,0,Soft Soil,103,,,,,
-18141,2,900,99,15,Warm Mud,103,,,,,
-18142,2,900,99,15,Blazing Ore,102,,,,,
-18507,2,250,99,0,Rathnite Local Hardwood,118,,,,,
-18508,2,1000,99,5,Natural Charcoal,118,,,,,
-18513,2,0,99,5,Merit Medal (Peafowl),123,,,,,
-18514,2,0,99,5,Merit Medal (Large Bear),123,,,,,
-18611,2,5,99,6,Myrmidon Ring Plate,123,,,,,
-18612,2,5,99,6,Inquiry Ring Plate,123,,,,,
-18613,2,5,99,6,Purge Ring Plate,123,,,,,
-18614,2,5,99,6,Night Emperor Ring Plate,123,,,,,
-18615,2,5,99,1,Supreme Merit Medal,123,,,,,
+16833,2,500,99,50,Silver Authentication Orb,123,,,,,
+16834,2,500,99,50,Gold Authentication Orb,123,,,,,
+17856,2,2500,99,85,Stone-Curser's Tears,119,,,,,
+17857,2,1500,99,85,Demonic Beast Snakeskin,107,,,,,
+17858,2,1500,99,85,Giant's Molar,109,,,,,
+17859,2,500,99,80,Mark of Brute Courage,123,,,,,
+17860,2,1500,99,85,Mark of A Hundred Battles,123,,,,,
+17861,2,350,99,80,Black Blade Fragment,102,,,,,
+17863,2,2500,99,100,Evil Eye Lens,123,,,,,
+17864,2,1500,99,100,Magickal Giant Bones,108,,,,,
+17865,2,1500,99,100,Ogre's Horn,110,,,,,
+17866,2,1500,99,85,Manticore Raw Pelt,107,,,,,
+17867,2,350,99,80,Goblin's Spellstaff,123,,,,,
+17868,2,350,99,95,Blood Drinking Vessel,123,,,,,
+17869,2,350,99,95,Undead Wolf's Fang,109,,,,,
+17870,2,350,99,80,Rock Leather,107,,,,,
+17871,2,1500,99,85,Rock-Cutter,109,,,,,
+17872,2,350,99,85,Giant Apophyllite,113,,,,,
+17873,2,350,99,85,Undead Nail Shaving,109,,,,,
+17875,2,2500,99,85,Dragonkin Stone,131,,,,,
+17876,2,500,99,80,Battle Armor Fragment,123,,,,,
+17877,2,250,99,80,Dragonkin Stone Shard,123,,,,,
+17878,2,1500,99,85,Cursed Letter,120,,,,,
+17879,2,2000,99,85,Dragon's Inverse Scale,107,,,,,
+17880,2,350,99,80,Highly Viscous Slime Liquid,119,,,,,
+17881,2,15000,99,85,Bone Pearl,113,,,,,
+17882,2,250,99,80,Brittle Sandstone,102,,,,,
+17883,2,1000,99,85,Pyroclastic Rock,102,,,,,
+17884,2,250,99,80,Ashen Grass,114,,,,,
+17885,2,1000,99,85,Blaze Grass,114,,,,,
+17886,2,500,99,80,Plankton Liquid,119,,,,,
+17888,2,350,99,80,Dragon Head Tile Fragment,123,,,,,
+17889,2,350,99,80,Dragon Tail Tile Fragment,123,,,,,
+17891,2,3000,99,85,Ribbon of Rich Bounty,104,,,,,
+17892,2,3000,99,85,Cobalt Alloy Ingot,101,,,,,
+17893,2,3000,99,100,Scroll of the Starry Sky,120,,,,,
+17894,2,3000,99,100,Bright Purple Steel Ingot,101,,,,,
+17897,2,2500,99,85,Gusty Winds Stone,131,,,,,
+17898,2,2500,99,85,Victorious Chance Stone,131,,,,,
+17899,2,2500,99,85,Fallen Soldier Stone,131,,,,,
+17900,2,2500,99,85,Animal Hunter Stone,131,,,,,
+17901,2,2500,99,85,Demihuman Cutter Stone,131,,,,,
+17902,2,2500,99,85,Demonic Slasher Stone,131,,,,,
+17903,2,2500,99,85,Skeleton Smasher Stone,131,,,,,
+17904,2,2500,99,85,Undead Destroyer Stone,131,,,,,
+17905,2,2500,99,85,Giant Killer Stone,131,,,,,
+17907,2,200,99,85,Dried Test Sample,130,,,,,
+17908,2,900,99,85,Monster Tissue Sample,130,,,,,
+17909,2,200,99,90,Flesh-Eating Snail,130,,,,,
+17910,2,900,99,90,Blood-Colored Spiral Shell,130,,,,,
+17911,2,200,99,80,Delicate Intaglio,130,,,,,
+17912,2,900,99,80,Acre Royal Family Intaglio,130,,,,,
+17915,2,900,99,95,Underworld Drop,119,,,,,
+17916,2,900,99,95,Misleading Twig,118,,,,,
+17917,2,900,99,95,Feryana Sweet Mushroom,117,,,,,
+17927,2,1500,99,100,Goremanticore's White Beard,106,,,,,
+17928,2,350,99,80,Harpy Breast Meat,122,,,,,
+17929,2,350,99,95,Fluttering Rags,104,,,,,
+17930,2,1500,99,85,Winged Beast's Heart,122,,,,,
+17959,2,123,99,80,Soft Soil,103,,,,,
+18141,2,900,99,95,Warm Mud,103,,,,,
+18142,2,900,99,95,Blazing Ore,102,,,,,
+18507,2,250,99,80,Rathnite Local Hardwood,118,,,,,
+18508,2,1000,99,85,Natural Charcoal,118,,,,,
+18513,2,0,99,85,Merit Medal (Peafowl),123,,,,,
+18514,2,0,99,85,Merit Medal (Large Bear),123,,,,,
+18611,2,5,99,70,Myrmidon Ring Plate,123,,,,,
+18612,2,5,99,70,Inquiry Ring Plate,123,,,,,
+18613,2,5,99,70,Purge Ring Plate,123,,,,,
+18614,2,5,99,70,Night Emperor Ring Plate,123,,,,,
+18615,2,5,99,65,Supreme Merit Medal,123,,,,,
 18616,2,0,99,1,Myrmidon,125,,,,,
 18617,2,0,99,1,Inquiry,125,,,,,
 18618,2,0,99,1,Purge,125,,,,,
 18619,2,0,99,1,Night Emperor,125,,,,,
-18646,2,500,99,0,Toadstool Sitter,117,,,,,
-18647,2,500,99,5,Mandragora Mushroom,117,,,,,
-18648,2,250,99,0,Volcanic Sand,103,,,,,
-18649,2,1000,99,5,Volcanic Glass,103,,,,,
-18650,2,500,99,5,Red Garnet,113,,,,,
-18655,2,350,99,0,Demon Beast's Liver,122,,,,,
-18656,2,50,99,5,Guardsman's Spirit,123,,,,,
-18658,2,50,99,15,Courtier's Spirit,123,,,,,
-18659,2,50,99,9,Executor's Spirit,123,,,,,
-18660,2,50,99,3,Retainer's Spirit,123,,,,,
-18661,2,500,99,0,Beast-Luring Meat,122,,,,,
-18662,2,900,99,15,Cursed Withered Grass,114,,,,,
-18663,2,500,99,5,Mandragora Leaf,114,,,,,
-18664,2,500,99,5,Mandragora Twig,118,,,,,
+18646,2,500,99,80,Toadstool Sitter,117,,,,,
+18647,2,500,99,85,Mandragora Mushroom,117,,,,,
+18648,2,250,99,80,Volcanic Sand,103,,,,,
+18649,2,1000,99,85,Volcanic Glass,103,,,,,
+18650,2,500,99,85,Red Garnet,113,,,,,
+18655,2,350,99,80,Demon Beast's Liver,122,,,,,
+18656,2,50,99,85,Guardsman's Spirit,123,,,,,
+18658,2,50,99,95,Courtier's Spirit,123,,,,,
+18659,2,50,99,105,Executor's Spirit,123,,,,,
+18660,2,50,99,115,Retainer's Spirit,123,,,,,
+18661,2,500,99,80,Beast-Luring Meat,122,,,,,
+18662,2,900,99,95,Cursed Withered Grass,114,,,,,
+18663,2,500,99,85,Mandragora Leaf,114,,,,,
+18664,2,500,99,85,Mandragora Twig,118,,,,,
 18725,2,0,99,1,Dull Blue Pearl,113,,,,,
-18726,2,350,99,15,Scarred Lizardscale Pelt,107,,,,,
-18729,2,2500,99,0,Campaign Battle Armor,123,,,,,
-18730,2,100,99,11,Unappraised Snow Trinket (Soldier),129,,,,,
-18731,2,100,99,0,Unappraised Snow Trinket (General),129,,,,,
-18732,2,100,99,5,Unappraised Snow Trinket (King),129,,,,,
-18733,2,100,99,10,Unappraised Snow Trinket (Emperor),129,,,,,
-18735,2,2000,99,5,Steel Featherwork,112,,,,,
-18738,2,100,99,0,Eye Ore,102,,,,,
-18815,2,1000,99,5,Royal Crest Medal (Rathnite District),123,,,,,
-18819,2,1000,99,4,Royal Crest Medal (Feryana District),123,,,,,
-18820,2,1000,99,3,Royal Crest Medal (Megadosys District),123,,,,,
-18821,2,100,99,5,Unappraised Flight Trinket (Soldier),129,,,,,
-18822,2,100,99,10,Unappraised Flight Trinket (General),129,,,,,
-18823,2,100,99,15,Unappraised Flight Trinket (King),129,,,,,
-18824,2,100,99,4,Unappraised Flight Trinket (Emperor),129,,,,,
-18826,2,1000,99,8,Royal Crest Medal (Urteca District),123,,,,,
-18835,2,104,99,6,Survey Corps Token,123,,,,,
-18876,2,250,99,0,Gusty Winds Stone Shard,123,,,,,
-18877,2,250,99,0,Victorious Chance Stone Shard,123,,,,,
-18878,2,250,99,0,Fallen Soldier Stone Shard,123,,,,,
-18879,2,250,99,0,Animal Hunter Stone Shard,123,,,,,
-18880,2,250,99,0,Demihuman Cutter Stone Shard,123,,,,,
-18881,2,250,99,0,Demonic Slasher Stone Shard,123,,,,,
-18882,2,250,99,0,Skeleton Smasher Stone Shard,123,,,,,
-18883,2,250,99,0,Undead Destroyer Stone Shard,123,,,,,
-18884,2,250,99,0,Giant Killer Stone Shard,123,,,,,
-18893,2,100,99,6,Golden Palm Fiber,105,,,,,
-19147,2,1000,99,6,Central Tree Drop,123,,,,,
+18726,2,350,99,95,Scarred Lizardscale Pelt,107,,,,,
+18729,2,2500,99,80,Campaign Battle Armor,123,,,,,
+18730,2,100,99,75,Unappraised Snow Trinket (Soldier),129,,,,,
+18731,2,100,99,80,Unappraised Snow Trinket (General),129,,,,,
+18732,2,100,99,85,Unappraised Snow Trinket (King),129,,,,,
+18733,2,100,99,90,Unappraised Snow Trinket (Emperor),129,,,,,
+18735,2,2000,99,85,Steel Featherwork,112,,,,,
+18738,2,100,99,80,Eye Ore,102,,,,,
+18815,2,1000,99,85,Royal Crest Medal (Rathnite District),123,,,,,
+18819,2,1000,99,100,Royal Crest Medal (Feryana District),123,,,,,
+18820,2,1000,99,115,Royal Crest Medal (Megadosys District),123,,,,,
+18821,2,100,99,85,Unappraised Flight Trinket (Soldier),129,,,,,
+18822,2,100,99,90,Unappraised Flight Trinket (General),129,,,,,
+18823,2,100,99,95,Unappraised Flight Trinket (King),129,,,,,
+18824,2,100,99,100,Unappraised Flight Trinket (Emperor),129,,,,,
+18826,2,1000,99,120,Royal Crest Medal (Urteca District),123,,,,,
+18835,2,104,99,70,Survey Corps Token,123,,,,,
+18876,2,250,99,80,Gusty Winds Stone Shard,123,,,,,
+18877,2,250,99,80,Victorious Chance Stone Shard,123,,,,,
+18878,2,250,99,80,Fallen Soldier Stone Shard,123,,,,,
+18879,2,250,99,80,Animal Hunter Stone Shard,123,,,,,
+18880,2,250,99,80,Demihuman Cutter Stone Shard,123,,,,,
+18881,2,250,99,80,Demonic Slasher Stone Shard,123,,,,,
+18882,2,250,99,80,Skeleton Smasher Stone Shard,123,,,,,
+18883,2,250,99,80,Undead Destroyer Stone Shard,123,,,,,
+18884,2,250,99,80,Giant Killer Stone Shard,123,,,,,
+18893,2,100,99,70,Golden Palm Fiber,105,,,,,
+19147,2,1000,99,70,Central Tree Drop,123,,,,,
 19258,2,0,99,1,Fire Affinity LV.4,125,,,,,
 19259,2,0,99,1,Dark Attack LV.4,125,,,,,
 19260,2,0,99,1,Holy Affinity LV.4,125,,,,,
@@ -1941,8 +1941,8 @@
 19290,2,0,99,1,Unyielding Posture LV.4,125,,,,,
 19291,2,0,99,1,Efficacy LV.4,125,,,,,
 19292,2,0,99,1,Tough Skin LV.4,125,,,,,
-19293,2,300,99,1,Cloth of Fighting Spirit,104,,,,,
-19294,2,300,99,1,Cloth of Ambition,104,,,,,
+19293,2,300,99,65,Cloth of Fighting Spirit,104,,,,,
+19294,2,300,99,65,Cloth of Ambition,104,,,,,
 19319,2,0,99,15,Relief Coin (Sappanwood),123,,,,,
 19320,2,0,99,15,Relief Coin (Gold Copper),123,,,,,
 19321,2,0,99,15,Relief Coin (Mint),123,,,,,
@@ -1968,12 +1968,12 @@
 19341,2,0,99,15,Relief Coin (Brown II),123,,,,,
 19343,2,0,99,15,Relief Coin (Brown III),123,,,,,
 19344,2,0,99,15,Relief Coin (Brown IV),123,,,,,
-19345,2,50000,99,2,Battlefield Ring Plate (Blue),123,,,,,
-19346,2,50000,99,2,Battlefield Ring Plate (Purple),123,,,,,
-19347,2,50000,99,2,Battlefield Ring Plate (Green),123,,,,,
-19348,2,50000,99,2,Battlefield Ring Plate (Black),123,,,,,
-19349,2,50000,99,2,Battlefield Ring Plate (Blue-green),123,,,,,
-19350,2,50000,99,2,Battlefield Ring Plate (Yellow),123,,,,,
+19345,2,50000,99,50,Battlefield Ring Plate (Blue),123,,,,,
+19346,2,50000,99,50,Battlefield Ring Plate (Purple),123,,,,,
+19347,2,50000,99,50,Battlefield Ring Plate (Green),123,,,,,
+19348,2,50000,99,50,Battlefield Ring Plate (Black),123,,,,,
+19349,2,50000,99,50,Battlefield Ring Plate (Blue-green),123,,,,,
+19350,2,50000,99,50,Battlefield Ring Plate (Yellow),123,,,,,
 19357,2,0,99,1,Relaxedness LV.4,125,,,,,
 19358,2,0,99,1,Herculean Strength LV.4,125,,,,,
 19359,2,0,99,1,Unyielding Posture LV.4,125,,,,,
@@ -1982,8 +1982,8 @@
 19362,2,0,99,1,Divine Protection LV.4,125,,,,,
 19363,2,100,99,10,Crest of War-Ready Break I,124,,,,,
 19364,2,100,99,15,Crest of War-Ready Break II,124,,,,,
-19365,2,100,99,4,Crest of War-Ready Break III,124,,,,,
-19366,2,100,99,9,Crest of War-Ready Break IV,124,,,,,
+19365,2,100,99,20,Crest of War-Ready Break III,124,,,,,
+19366,2,100,99,25,Crest of War-Ready Break IV,124,,,,,
 19376,2,0,99,1,Extreme Dash ST Consumption Reduced,123,,,,,
 19377,2,0,99,1,Extreme Climb Speed Up,123,,,,,
 19378,2,0,99,1,Extreme Jump Height Up,123,,,,,
@@ -1992,106 +1992,106 @@
 19386,2,100,99,1,Extreme Palm Fragment,123,,,,,
 19387,2,100,99,1,Extreme Wind-Wrought Fragment,123,,,,,
 19388,2,100,99,1,Extreme Weightless Fragment,123,,,,,
-19644,2,250,99,0,Demon Expeller Stone Shard,123,,,,,
-19645,2,2500,99,5,Demon Expeller Stone,131,,,,,
-19646,2,200,99,10,Giant Husk,130,,,,,
-19647,2,900,99,10,Scorpion Tail's Husk,130,,,,,
-19648,2,200,99,15,Smelted Ore Stone,130,,,,,
-19649,2,900,99,15,Red Hot Smelted Ore,130,,,,,
-19650,2,200,99,4,Cursed Bone Fragment,130,,,,,
-19651,2,900,99,4,Cursed Spine,130,,,,,
-19652,2,100,99,10,Silver Eye Ore,102,,,,,
-19653,2,2000,99,4,Groaning Skull,108,,,,,
-19654,2,500,99,15,Unrefined Alloy Lump,101,,,,,
-19655,2,2000,99,15,Reinforced Battle Armor,123,,,,,
-21184,2,2000,99,4,Mark of Tyranny,123,,,,,
-21196,2,0,99,14,Gem of Devastation,123,,,,,
-21213,2,350,99,4,Waterweed,114,,,,,
-21214,2,350,99,4,Rose Megadosys,114,,,,,
-21215,2,350,99,4,Giant Caterpillar,118,,,,,
-21216,2,350,99,4,Phlogopite,102,,,,,
-21217,2,350,99,4,Highland Akadama,103,,,,,
-21218,2,350,99,4,Flame Mushroom,117,,,,,
-21219,2,350,99,4,War Demon's Ancestor Nasal Cartilage,108,,,,,
-21221,2,350,99,4,Strong Acid Sac,122,,,,,
-21222,2,350,99,4,Cracked Amulet,123,,,,,
-21223,2,350,99,9,Strong Heat-Resistant Scale,107,,,,,
-21224,2,1500,99,9,War Dancing Large Feather,112,,,,,
-21225,2,1500,99,9,War Demon Ancestor's Large Tusk,109,,,,,
-21226,2,1500,99,9,Large Demon's Striped Pelt,107,,,,,
-21227,2,2000,99,9,Low-Grade Reinforced Armor,123,,,,,
-21229,2,3000,99,9,Padding,104,,,,,
-21230,2,3000,99,9,Fireproof Cord,105,,,,,
-21231,2,2500,99,9,Burning Magma Lump,123,,,,,
-21232,2,500,99,4,Giant Animal Skull,130,,,,,
-21233,2,350,99,4,Cave Shrimp,130,,,,,
-21234,2,900,99,4,Cave Shrimp Eggs,130,,,,,
-21235,2,350,99,9,Water Purification Stone Powder,130,,,,,
-21236,2,900,99,9,Simple Purification Crystal,130,,,,,
-21237,2,350,99,14,Scroll of Tribute,130,,,,,
-21238,2,900,99,14,Royal Family Chants Grimoire,130,,,,,
-21239,2,2000,99,14,Void's Heartbeat,123,,,,,
-21240,2,100,99,15,Unappraised Water Trinket (Soldier),129,,,,,
-21241,2,100,99,4,Unappraised Water Trinket (General),129,,,,,
-21242,2,100,99,9,Unappraised Water Trinket (King),129,,,,,
-21243,2,100,99,14,Unappraised Water Trinket (Emperor),129,,,,,
-21244,2,250,99,0,Spirit Purifier Stone Shard,123,,,,,
-21245,2,250,99,0,Cursed Exorciser Stone Shard,123,,,,,
-21246,2,250,99,0,Alchemy Sealer Stone Shard,123,,,,,
-21247,2,250,99,0,Corrupted Sealer Stone Shard,123,,,,,
-21248,2,2500,99,5,Spirit Purifier Stone,131,,,,,
-21249,2,2500,99,5,Cursed Exorciser Stone,131,,,,,
-21250,2,2500,99,5,Alchemy Sealer Stone,131,,,,,
-21251,2,2500,99,5,Corrupted Sealer Stone,131,,,,,
-21252,2,100,99,4,Golden Mistletoe,118,,,,,
-21253,2,2000,99,14,Mark of the Underworld,123,,,,,
-21255,2,350,99,14,Urteca Hot Spring Water,119,,,,,
-21256,2,350,99,14,Belladonna,114,,,,,
-21257,2,350,99,14,Petrified Wood,118,,,,,
-21258,2,350,99,14,Volcanic Tuff,102,,,,,
-21259,2,350,99,14,Volcanic Mountain Ash,103,,,,,
-21260,2,350,99,14,Scorched Mushroom,117,,,,,
-21261,2,350,99,14,Demon Dog Pelt,107,,,,,
-21262,2,350,99,14,Blazing Lizard Pelt,107,,,,,
-21263,2,350,99,14,Small Flame Remains,123,,,,,
-21264,2,1500,99,14,Grotesque Burning Horn,110,,,,,
-21265,2,1500,99,14,Tree Man's Charred Branch,118,,,,,
-21266,2,1500,99,14,Ancient Warrior's Bone,108,,,,,
-21267,2,1500,99,14,Charged Great Vessel,122,,,,,
-21268,2,2000,99,3,Howling Blaze Lump,123,,,,,
-21269,2,3000,99,14,Soul Siphoning Cloth,104,,,,,
-21270,2,3000,99,14,Flicker Gem,101,,,,,
-21271,2,2500,99,3,Evil Dragon's Chin Spike,110,,,,,
-21272,2,500,99,14,Old Brick Material,130,,,,,
-21273,2,350,99,14,Ancient Wheat,130,,,,,
-21274,2,900,99,14,Ancient Wheat Ear,130,,,,,
-21275,2,350,99,3,Dragon Temple's Charm,130,,,,,
-21276,2,900,99,3,Dragon Temple's Blessed Cloth,130,,,,,
-21277,2,350,99,8,Royal Blazing Rock,130,,,,,
-21278,2,900,99,8,Sacred Flame Steel,130,,,,,
-21279,2,2000,99,8,Reddish Dragon Scale,107,,,,,
-21280,2,100,99,9,Unappraised Cloud Trinket (Soldier),129,,,,,
-21281,2,100,99,14,Unappraised Cloud Trinket (General),129,,,,,
-21282,2,100,99,3,Unappraised Cloud Trinket (King),129,,,,,
-21283,2,100,99,8,Unappraised Cloud Trinket (Emperor),129,,,,,
-21284,2,250,99,0,War-Ready Break Stone Shard,123,,,,,
-21285,2,250,99,0,Fragments of the Soft Tissue Erasure Gemstone,123,,,,,
-21286,2,250,99,0,Winged Slayer's Stone Shard,123,,,,,
-21287,2,250,99,0,Magickal Constructs Destruction Shard,123,,,,,
-21288,2,2500,99,5,War-Ready Break Stone,131,,,,,
-21289,2,2500,99,5,Soft Tissue Erasure Gemstone,131,,,,,
-21290,2,2500,99,5,Winged Slayer's Stone,131,,,,,
-21291,2,2500,99,5,Magickal Constructs Destruction Gemstone,131,,,,,
-21292,2,100,99,14,Crystal Glass,103,,,,,
-21293,2,2000,99,8,Bright Fire Wing,123,,,,,
+19644,2,250,99,80,Demon Expeller Stone Shard,123,,,,,
+19645,2,2500,99,85,Demon Expeller Stone,131,,,,,
+19646,2,200,99,90,Giant Husk,130,,,,,
+19647,2,900,99,90,Scorpion Tail's Husk,130,,,,,
+19648,2,200,99,95,Smelted Ore Stone,130,,,,,
+19649,2,900,99,95,Red Hot Smelted Ore,130,,,,,
+19650,2,200,99,100,Cursed Bone Fragment,130,,,,,
+19651,2,900,99,100,Cursed Spine,130,,,,,
+19652,2,100,99,90,Silver Eye Ore,102,,,,,
+19653,2,2000,99,100,Groaning Skull,108,,,,,
+19654,2,500,99,95,Unrefined Alloy Lump,101,,,,,
+19655,2,2000,99,95,Reinforced Battle Armor,123,,,,,
+21184,2,2000,99,100,Mark of Tyranny,123,,,,,
+21196,2,0,99,94,Gem of Devastation,123,,,,,
+21213,2,350,99,100,Waterweed,114,,,,,
+21214,2,350,99,100,Rose Megadosys,114,,,,,
+21215,2,350,99,100,Giant Caterpillar,118,,,,,
+21216,2,350,99,100,Phlogopite,102,,,,,
+21217,2,350,99,100,Highland Akadama,103,,,,,
+21218,2,350,99,100,Flame Mushroom,117,,,,,
+21219,2,350,99,100,War Demon's Ancestor Nasal Cartilage,108,,,,,
+21221,2,350,99,100,Strong Acid Sac,122,,,,,
+21222,2,350,99,100,Cracked Amulet,123,,,,,
+21223,2,350,99,105,Strong Heat-Resistant Scale,107,,,,,
+21224,2,1500,99,105,War Dancing Large Feather,112,,,,,
+21225,2,1500,99,105,War Demon Ancestor's Large Tusk,109,,,,,
+21226,2,1500,99,105,Large Demon's Striped Pelt,107,,,,,
+21227,2,2000,99,105,Low-Grade Reinforced Armor,123,,,,,
+21229,2,3000,99,105,Padding,104,,,,,
+21230,2,3000,99,105,Fireproof Cord,105,,,,,
+21231,2,2500,99,105,Burning Magma Lump,123,,,,,
+21232,2,500,99,100,Giant Animal Skull,130,,,,,
+21233,2,350,99,100,Cave Shrimp,130,,,,,
+21234,2,900,99,100,Cave Shrimp Eggs,130,,,,,
+21235,2,350,99,105,Water Purification Stone Powder,130,,,,,
+21236,2,900,99,105,Simple Purification Crystal,130,,,,,
+21237,2,350,99,110,Scroll of Tribute,130,,,,,
+21238,2,900,99,110,Royal Family Chants Grimoire,130,,,,,
+21239,2,2000,99,110,Void's Heartbeat,123,,,,,
+21240,2,100,99,95,Unappraised Water Trinket (Soldier),129,,,,,
+21241,2,100,99,100,Unappraised Water Trinket (General),129,,,,,
+21242,2,100,99,105,Unappraised Water Trinket (King),129,,,,,
+21243,2,100,99,110,Unappraised Water Trinket (Emperor),129,,,,,
+21244,2,250,99,80,Spirit Purifier Stone Shard,123,,,,,
+21245,2,250,99,80,Cursed Exorciser Stone Shard,123,,,,,
+21246,2,250,99,80,Alchemy Sealer Stone Shard,123,,,,,
+21247,2,250,99,80,Corrupted Sealer Stone Shard,123,,,,,
+21248,2,2500,99,85,Spirit Purifier Stone,131,,,,,
+21249,2,2500,99,85,Cursed Exorciser Stone,131,,,,,
+21250,2,2500,99,85,Alchemy Sealer Stone,131,,,,,
+21251,2,2500,99,85,Corrupted Sealer Stone,131,,,,,
+21252,2,100,99,100,Golden Mistletoe,118,,,,,
+21253,2,2000,99,110,Mark of the Underworld,123,,,,,
+21255,2,350,99,110,Urteca Hot Spring Water,119,,,,,
+21256,2,350,99,110,Belladonna,114,,,,,
+21257,2,350,99,110,Petrified Wood,118,,,,,
+21258,2,350,99,110,Volcanic Tuff,102,,,,,
+21259,2,350,99,110,Volcanic Mountain Ash,103,,,,,
+21260,2,350,99,110,Scorched Mushroom,117,,,,,
+21261,2,350,99,110,Demon Dog Pelt,107,,,,,
+21262,2,350,99,110,Blazing Lizard Pelt,107,,,,,
+21263,2,350,99,110,Small Flame Remains,123,,,,,
+21264,2,1500,99,110,Grotesque Burning Horn,110,,,,,
+21265,2,1500,99,110,Tree Man's Charred Branch,118,,,,,
+21266,2,1500,99,110,Ancient Warrior's Bone,108,,,,,
+21267,2,1500,99,110,Charged Great Vessel,122,,,,,
+21268,2,2000,99,115,Howling Blaze Lump,123,,,,,
+21269,2,3000,99,110,Soul Siphoning Cloth,104,,,,,
+21270,2,3000,99,110,Flicker Gem,101,,,,,
+21271,2,2500,99,115,Evil Dragon's Chin Spike,110,,,,,
+21272,2,500,99,110,Old Brick Material,130,,,,,
+21273,2,350,99,110,Ancient Wheat,130,,,,,
+21274,2,900,99,110,Ancient Wheat Ear,130,,,,,
+21275,2,350,99,115,Dragon Temple's Charm,130,,,,,
+21276,2,900,99,115,Dragon Temple's Blessed Cloth,130,,,,,
+21277,2,350,99,120,Royal Blazing Rock,130,,,,,
+21278,2,900,99,120,Sacred Flame Steel,130,,,,,
+21279,2,2000,99,120,Reddish Dragon Scale,107,,,,,
+21280,2,100,99,105,Unappraised Cloud Trinket (Soldier),129,,,,,
+21281,2,100,99,110,Unappraised Cloud Trinket (General),129,,,,,
+21282,2,100,99,115,Unappraised Cloud Trinket (King),129,,,,,
+21283,2,100,99,120,Unappraised Cloud Trinket (Emperor),129,,,,,
+21284,2,250,99,80,War-Ready Break Stone Shard,123,,,,,
+21285,2,250,99,80,Fragments of the Soft Tissue Erasure Gemstone,123,,,,,
+21286,2,250,99,80,Winged Slayer's Stone Shard,123,,,,,
+21287,2,250,99,80,Magickal Constructs Destruction Shard,123,,,,,
+21288,2,2500,99,85,War-Ready Break Stone,131,,,,,
+21289,2,2500,99,85,Soft Tissue Erasure Gemstone,131,,,,,
+21290,2,2500,99,85,Winged Slayer's Stone,131,,,,,
+21291,2,2500,99,85,Magickal Constructs Destruction Gemstone,131,,,,,
+21292,2,100,99,110,Crystal Glass,103,,,,,
+21293,2,2000,99,120,Bright Fire Wing,123,,,,,
 21330,2,0,99,1,Premium Cocoa Powder,123,,,,,
 21331,2,0,99,1,Lestanian Honey,123,,,,,
-21332,2,0,99,14,Merit Medal (Stag),123,,,,,
-21333,2,0,99,8,Merit Medal (Orangutan),123,,,,,
-21355,2,100,99,2,Unidentified Dragon Trinket II (High Scepter),129,,,,,
+21332,2,0,99,110,Merit Medal (Stag),123,,,,,
+21333,2,0,99,120,Merit Medal (Orangutan),123,,,,,
+21355,2,100,99,50,Unidentified Dragon Trinket II (High Scepter),129,,,,,
 21380,2,100,99,1,Fruit of Inspiration (Harden),132,,,,,
 21381,2,100,99,1,Fruit of Inspiration (Heavy),132,,,,,
-21379,2,0,99,2,Relic Steel (Feryana District),123,,,,,
+21379,2,0,99,98,Relic Steel (Feryana District),123,,,,,
 21382,2,100,99,1,Fruit of Inspiration (Restoration),132,,,,,
 21383,2,100,99,1,Fruit of Inspiration (Protection),132,,,,,
 21384,2,100,99,1,Fruit of Inspiration (Weaken),132,,,,,
@@ -2100,41 +2100,41 @@
 21387,2,100,99,1,Fruit of Inspiration (Concentration),132,,,,,
 21388,2,100,99,1,Fruit of Inspiration (Resurrection),132,,,,,
 21389,2,500,99,1,2018 New Year Jumbo Draw Ticket,123,,,,,
-21390,2,0,99,12,Relic Steel (Megadosys District),123,,,,,
-21391,2,0,99,12,Memento Fiber (Megadosys District),123,,,,,
-21392,2,0,99,6,Relic Steel (Urteca District),123,,,,,
-21393,2,0,99,6,Memento Fiber (Urteca District),123,,,,,
-21606,2,100,99,2,Unidentified Dragon Trinket II (Fighter),129,,,,,
-21607,2,100,99,2,Unidentified Dragon Trinket II (Hunter),129,,,,,
-21608,2,100,99,2,Unidentified Dragon Trinket II (Priest),129,,,,,
-21609,2,100,99,2,Unidentified Dragon Trinket II (Shield Sage),129,,,,,
-21610,2,100,99,2,Unidentified Dragon Trinket II (Seeker),129,,,,,
-21611,2,100,99,2,Unidentified Dragon Trinket II (Sorcerer),129,,,,,
-21612,2,100,99,2,Unidentified Dragon Trinket II (Element Archer),129,,,,,
-21613,2,100,99,2,Unidentified Dragon Trinket II (Warrior),129,,,,,
-21614,2,100,99,2,Unidentified Dragon Trinket II (Alchemist),129,,,,,
-21615,2,100,99,2,Unidentified Dragon Trinket II (Spirit Lancer),129,,,,,
-21616,2,100,99,2,Unidentified Dragon Trinket (High Scepter),129,,,,,
+21390,2,0,99,108,Relic Steel (Megadosys District),123,,,,,
+21391,2,0,99,108,Memento Fiber (Megadosys District),123,,,,,
+21392,2,0,99,118,Relic Steel (Urteca District),123,,,,,
+21393,2,0,99,118,Memento Fiber (Urteca District),123,,,,,
+21606,2,100,99,50,Unidentified Dragon Trinket II (Fighter),129,,,,,
+21607,2,100,99,50,Unidentified Dragon Trinket II (Hunter),129,,,,,
+21608,2,100,99,50,Unidentified Dragon Trinket II (Priest),129,,,,,
+21609,2,100,99,50,Unidentified Dragon Trinket II (Shield Sage),129,,,,,
+21610,2,100,99,50,Unidentified Dragon Trinket II (Seeker),129,,,,,
+21611,2,100,99,50,Unidentified Dragon Trinket II (Sorcerer),129,,,,,
+21612,2,100,99,50,Unidentified Dragon Trinket II (Element Archer),129,,,,,
+21613,2,100,99,50,Unidentified Dragon Trinket II (Warrior),129,,,,,
+21614,2,100,99,50,Unidentified Dragon Trinket II (Alchemist),129,,,,,
+21615,2,100,99,50,Unidentified Dragon Trinket II (Spirit Lancer),129,,,,,
+21616,2,100,99,50,Unidentified Dragon Trinket (High Scepter),129,,,,,
 21617,2,0,99,15,Relief Coin (Brown VII),123,,,,,
 21618,2,0,99,15,Relief Coin (Brown VIII),123,,,,,
-21619,2,2000,99,8,Smoldering Crown Horn,110,,,,,
+21619,2,2000,99,120,Smoldering Crown Horn,110,,,,,
 21620,2,0,99,15,Relief Coin (Brown IX),123,,,,,
 21621,2,0,99,15,Relief Coin (Brown XI),123,,,,,
 21622,2,0,99,15,Relief Coin (Brown X),123,,,,,
-21623,2,0,99,9,Beherit,123,,,,,
+21623,2,0,99,105,Beherit,123,,,,,
 21624,2,0,99,1,Delivery Point,123,,,,,
 21625,2,0,99,1,Delivery Point,123,,,,,
 21626,2,0,99,1,Delivery Point,123,,,,,
-21627,2,2000,99,14,Demon Crystal of Atonement,123,,,,,
+21627,2,2000,99,110,Demon Crystal of Atonement,123,,,,,
 21628,2,0,99,15,Relief Coin (Brown VI),123,,,,,
 21629,2,0,99,15,Relief Coin (Brown V),123,,,,,
-21630,2,100,99,4,Bitterblack Deed Box,129,,,,,
-21668,2,2000,99,12,King Draf Enthronement Commemerotive Coin,123,,,,,
-21777,2,500,99,5,Fluffly Ghost Cloth,104,,,,,
-21778,2,500,99,5,Moth Hard Gem,113,,,,,
-21779,2,500,99,5,Speckled Mood Garnet,113,,,,,
-21669,2,2000,99,6,King Kileek Enthronement Commemerotive Coin,123,,,,,
-21787,2,500,99,14,Crystal of Inspiration,113,,,,,
+21630,2,100,99,100,Bitterblack Deed Box,129,,,,,
+21668,2,2000,99,108,King Draf Enthronement Commemerotive Coin,123,,,,,
+21777,2,500,99,85,Fluffly Ghost Cloth,104,,,,,
+21778,2,500,99,85,Moth Hard Gem,113,,,,,
+21779,2,500,99,85,Speckled Mood Garnet,113,,,,,
+21669,2,2000,99,118,King Kileek Enthronement Commemerotive Coin,123,,,,,
+21787,2,500,99,110,Crystal of Inspiration,113,,,,,
 21816,2,0,99,1,Physical Attack +1,124,,,,,
 21817,2,0,99,1,Physical Attack +2,124,,,,,
 21818,2,0,99,1,Physical Attack +3,124,,,,,
@@ -3617,7 +3617,7 @@
 23354,2,0,99,1,Ordinary Attack LV.5,125,,,,,
 23355,2,0,99,1,Ordinary Attack LV.6,125,,,,,
 23207,2,0,99,1,Healing: Chant LV.6,125,,,,,
-23364,2,100,99,4,Bitterblack Orb,129,,,,,
+23364,2,100,99,100,Bitterblack Orb,129,,,,,
 23437,2,0,99,1,Magickal Charge LV.4,125,,,,,
 23438,2,0,99,1,Magickal Charge LV.5,125,,,,,
 23439,2,0,99,1,Magickal Charge LV.6,125,,,,,
@@ -3633,8 +3633,8 @@
 23449,2,0,99,1,Complement Chant LV.4,125,,,,,
 23450,2,0,99,1,Complement Chant LV.5,125,,,,,
 23451,2,0,99,1,Complement Chant LV.6,125,,,,,
-23549,2,0,99,3,Pure Black Jade,123,,,,,
-23550,2,0,99,3,Gem of Great Evil,123,,,,,
+23549,2,0,99,115,Pure Black Jade,123,,,,,
+23550,2,0,99,115,Gem of Great Evil,123,,,,,
 23606,2,0,99,1,Slash damage for fighters UP,124,,,,,
 23607,2,0,99,1,Fighter Strike Damage UP,124,,,,,
 23608,2,0,99,1,Fighter's shooting attribute damage UP,124,,,,,
@@ -3740,27 +3740,27 @@
 23708,2,0,99,1,The White Dragon,133,,,,,
 23709,2,0,99,1,The Golden Dragon,133,,,,,
 24721,2,0,99,1,Anti-Black Dragon,133,,,,,
-24723,2,100,99,2,Bitterblack Chest of the Farthest End,129,,,,,
-24724,2,350,99,2,Fine mahogany wood,118,,,,,
-24725,2,350,99,2,Lestania Marble,102,,,,,
-24726,2,350,99,2,Craft-grade Small Sparkling Gemstones,113,,,,,
-24727,2,0,99,2,Reward Medal,123,,,,,
-24728,2,0,99,2,Keystone to Ruin,123,,,,,
-24729,2,900,99,2,Tree Core Grass,130,,,,,
-24731,2,900,99,2,Flame Apex Sacred Tree,130,,,,,
-24733,2,900,99,2,The Wise Wizard's Chronicles,130,,,,,
-24735,2,900,99,2,Forbidden Gold Sand,130,,,,,
-24737,2,900,99,2,Otherworldly Drop,123,,,,,
-24738,2,900,99,2,Orichalcum,101,,,,,
-24739,2,900,99,2,Jet-black Dragon Scale,107,,,,,
-24740,2,900,99,2,Dark Clouds Smoky Quartz,113,,,,,
-24814,2,900,99,2,Chaotic Dark Dragonscale,107,,,,,
-24815,2,900,99,2,Transformed black wing membrane,112,,,,,
-24816,2,900,99,2,Darkness-filled Black Claw,109,,,,,
-24818,2,900,99,2,Forbidden Horn of Corruption,110,,,,,
-24819,2,900,99,2,Black and Silver Chaos Metal,101,,,,,
-24820,2,900,99,2,Tinctura,102,,,,,
-24821,2,0,99,2,Premium Shiny Silk,104,,,,,
+24723,2,100,99,130,Bitterblack Chest of the Farthest End,129,,,,,
+24724,2,350,99,130,Fine mahogany wood,118,,,,,
+24725,2,350,99,130,Lestania Marble,102,,,,,
+24726,2,350,99,130,Craft-grade Small Sparkling Gemstones,113,,,,,
+24727,2,0,99,130,Reward Medal,123,,,,,
+24728,2,0,99,130,Keystone to Ruin,123,,,,,
+24729,2,900,99,130,Tree Core Grass,130,,,,,
+24731,2,900,99,130,Flame Apex Sacred Tree,130,,,,,
+24733,2,900,99,130,The Wise Wizard's Chronicles,130,,,,,
+24735,2,900,99,130,Forbidden Gold Sand,130,,,,,
+24737,2,900,99,130,Otherworldly Drop,123,,,,,
+24738,2,900,99,130,Orichalcum,101,,,,,
+24739,2,900,99,130,Jet-black Dragon Scale,107,,,,,
+24740,2,900,99,130,Dark Clouds Smoky Quartz,113,,,,,
+24814,2,900,99,130,Chaotic Dark Dragonscale,107,,,,,
+24815,2,900,99,130,Transformed black wing membrane,112,,,,,
+24816,2,900,99,130,Darkness-filled Black Claw,109,,,,,
+24818,2,900,99,130,Forbidden Horn of Corruption,110,,,,,
+24819,2,900,99,130,Black and Silver Chaos Metal,101,,,,,
+24820,2,900,99,130,Tinctura,102,,,,,
+24821,2,0,99,130,Premium Shiny Silk,104,,,,,
 24822,2,0,99,15,Rare Steel [Red],101,,,,,
 24823,2,0,99,15,Rare Steel [Blue],101,,,,,
 24824,2,0,99,15,Rare Steel [Green],101,,,,,
@@ -3797,129 +3797,129 @@
 25025,2,0,99,1,2019 New Year Jumbo Draw Ticket (Red),123,,,,,
 25026,2,0,99,1,2019 New Year Jumbo Draw Ticket (White),123,,,,,
 25027,2,0,99,1,2019 New Year Jumbo Draw Ticket (Gold),123,,,,,
-25521,2,350,99,12,Madness Amulet,120,,,,,
-25522,2,350,99,1,Dragon Cotton Flower in the Temple Medicinal Garden,114,,,,,
-25523,2,350,99,6,Kunstkette,101,,,,,
-25524,2,350,99,12,Shiny white Bonebiter Beetle,123,,,,,
-25525,2,350,99,1,Demon Leather Tanning Solution,119,,,,,
-25526,2,350,99,6,Elegant Harp Steel Ingot,101,,,,,
-25527,2,350,99,12,Spirit Resonance Mudsand,103,,,,,
-25528,2,350,99,1,Cobalt Heliotrope,114,,,,,
-25529,2,350,99,6,Zircon,113,,,,,
-25654,2,100,99,9,Crest of Sheer Power+,124,,,,,
-25655,2,100,99,14,Crest of Herculean Power+,124,,,,,
-25656,2,100,99,14,Crest of Herculean Power (Burning)+,124,,,,,
-25657,2,100,99,14,Crest of Herculean Power (Freezing)+,124,,,,,
-25658,2,100,99,14,Crest of Herculean Power (Shock)+,124,,,,,
-25659,2,100,99,14,Crest of Herculean Power (Holy Drain)+,124,,,,,
-25660,2,100,99,14,Crest of Herculean Power (Blinding)+,124,,,,,
-25661,2,100,99,14,Crest of Herculean Power (Blow Power)+,124,,,,,
-25662,2,100,99,14,Crest of Herculean Power (Stun)+,124,,,,,
-25663,2,100,99,14,Crest of Herculean Power (Poison)+,124,,,,,
-25664,2,100,99,14,Crest of Herculean Power (Torpor)+,124,,,,,
-25665,2,100,99,14,Crest of Herculean Power (Sleep)+,124,,,,,
-25666,2,100,99,14,Crest of Herculean Power (Petrification)+,124,,,,,
-25668,2,100,99,14,Crest of Herculean Power (Gilding)+,124,,,,,
-25669,2,100,99,14,Crest of Herculean Power (Lowered Defense)+,124,,,,,
-25670,2,100,99,9,Crest of Sheer Magick+,124,,,,,
-25671,2,100,99,14,Crest of Superior Magick+,124,,,,,
-25672,2,100,99,14,Crest of Superior Magick (Burning)+,124,,,,,
-25673,2,100,99,14,Crest of Superior Magick (Shock)+,124,,,,,
-25674,2,100,99,14,Crest of Superior Magick (Holy Drain)+,124,,,,,
-25675,2,100,99,14,Crest of Superior Magick (Blow Power)+,124,,,,,
-25676,2,100,99,14,Crest of Superior Magick (Blinding)+,124,,,,,
-25677,2,100,99,14,Crest of Superior Magick (Stun)+,124,,,,,
-25678,2,100,99,14,Crest of Superior Magick (Poison)+,124,,,,,
-25679,2,100,99,14,Crest of Superior Magick (Torpor)+,124,,,,,
-25680,2,100,99,14,Crest of Superior Magick (Sleep)+,124,,,,,
-25681,2,100,99,14,Crest of Superior Magick (Petrification)+,124,,,,,
-25682,2,100,99,14,Crest of Superior Magick (Gilding)+,124,,,,,
-25683,2,100,99,14,Crest of Superior Magick (Lowered Magick Defense)+,124,,,,,
-25684,2,100,99,14,Crest of Incineration+,124,,,,,
-25685,2,100,99,14,Crest of Incineration (Decreased Fire Resist)+,124,,,,,
-25686,2,100,99,14,Crest of Permafrost+,124,,,,,
-25687,2,100,99,14,Crest of Permafrost (Decreased Ice Resist)+,124,,,,,
-25688,2,100,99,14,Crest of Electrocution+,124,,,,,
-25689,2,100,99,14,Crest of Electrocution (Decreased Lightning Resist)+,124,,,,,
-25690,2,100,99,14,Crest of Sanctity+,124,,,,,
-25691,2,100,99,14,Crest of Sanctity (Decreased Holy Resist)+,124,,,,,
-25692,2,100,99,14,Crest of Twilight+,124,,,,,
-25693,2,100,99,14,Crest of Twilight (Decreased Dark Resist)+,124,,,,,
-25694,2,100,99,14,Crest of Depleted Defense+,124,,,,,
-25695,2,100,99,14,Crest of Depleted Magick Defense+,124,,,,,
-25696,2,100,99,9,Crest of Dazzling+,124,,,,,
-25697,2,100,99,14,Crest of Sidesplitting Laughter+,124,,,,,
-25698,2,100,99,14,Crest of Fatal Poison+,124,,,,,
-25699,2,100,99,9,Crest of Sleep+,124,,,,,
-25700,2,100,99,14,Crest of Deeper Sleep+,124,,,,,
-25701,2,100,99,9,Crest of Gilding+,124,,,,,
-25702,2,100,99,14,Crest of Glittering Gold+,124,,,,,
-25703,2,100,99,9,Crest of Petrification+,124,,,,,
-25704,2,100,99,14,Crest of Crystallization+,124,,,,,
-25705,2,100,99,9,Crest of Frailness+,124,,,,,
-25706,2,100,99,14,Crest of Fragility+,124,,,,,
-25707,2,100,99,9,Crest of Stifling+,124,,,,,
-25708,2,100,99,14,Crest of Sealing+,124,,,,,
-25709,2,100,99,9,Crest of Drenching+,124,,,,,
-25710,2,100,99,14,Crest of Drowning+,124,,,,,
-25711,2,100,99,9,Crest of Tarring+,124,,,,,
-25712,2,100,99,14,Crest of Greater Tarring+,124,,,,,
-25713,2,100,99,14,Crest of Greater Torpor+,124,,,,,
-25714,2,100,99,9,Crest of Increased Attack+,124,,,,,
-25715,2,100,99,14,Crest of Amplified Attack+,124,,,,,
-25716,2,100,99,9,Crest of Sheer Protection+,125,,,,,
-25717,2,100,99,14,Crest of Firm Protection (Health)+,125,,,,,
-25718,2,100,99,14,Crest of Firm Protection (Endurance)+,125,,,,,
-25719,2,100,99,14,Crest of Firm Protection (Vitality)+,125,,,,,
-25720,2,100,99,14,Crest of Firm Protection (Lightness)+,125,,,,,
-25721,2,100,99,14,Crest of Unwavering+,125,,,,,
-25722,2,100,99,9,Crest of Sheer Intelligence+,125,,,,,
-25723,2,100,99,14,Crest of Wisdom+,125,,,,,
-25724,2,100,99,14,Crest of Wisdom (Health)+,125,,,,,
-25725,2,100,99,14,Crest of Wisdom (Endurance)+,125,,,,,
-25726,2,100,99,14,Crest of Wisdom (Vitality)+,125,,,,,
-25727,2,100,99,14,Crest of Wisdom (Lightness)+,125,,,,,
-25728,2,100,99,9,Crest of Resurgence+,125,,,,,
-25729,2,100,99,14,Crest of Stoicism+,125,,,,,
-25730,2,100,99,9,Crest of Determination+,125,,,,,
-25731,2,100,99,14,Crest of Pertinacity+,125,,,,,
-25732,2,100,99,9,Crest of Health+,125,,,,,
-25733,2,100,99,14,Crest of Strong Health+,125,,,,,
-25734,2,100,99,9,Crest of Stamina+,125,,,,,
-25735,2,100,99,14,Crest of Strong Stamina+,125,,,,,
-25736,2,100,99,14,Crest of Vigor+,125,,,,,
-25737,2,100,99,9,Crest of Lightness+,125,,,,,
-25738,2,100,99,14,Crest of Unburdening+,125,,,,,
-25739,2,100,99,14,Crest of Hellfire Warding+,125,,,,,
-25740,2,100,99,14,Crest of Snowstorm Warding+,125,,,,,
-25741,2,100,99,14,Crest of Thunder Warding+,125,,,,,
-25742,2,100,99,14,Crest of Sacred Warding+,125,,,,,
-25743,2,100,99,14,Crest of Shadow Warding+,125,,,,,
-25744,2,100,99,14,Crest of Burn Immunity+,125,,,,,
-25745,2,100,99,14,Crest of Freeze Immunity+,125,,,,,
-25746,2,100,99,14,Crest of Shock Immunity+,125,,,,,
-25747,2,100,99,14,Crest of Holy Drain Immunity+,125,,,,,
-25748,2,100,99,14,Crest of Blind Immunity+,125,,,,,
-25749,2,100,99,14,Crest of Fire Protection+,125,,,,,
-25750,2,100,99,14,Crest of Ice Protection+,125,,,,,
-25751,2,100,99,14,Crest of Lightning Protection+,125,,,,,
-25752,2,100,99,14,Crest of Holy Protection+,125,,,,,
-25753,2,100,99,14,Crest of Dark Protection+,125,,,,,
-25754,2,100,99,14,Crest of Poison Prevention+,125,,,,,
-25755,2,100,99,14,Crest of Torpor Prevention+,125,,,,,
-25756,2,100,99,14,Crest of Sleep Prevention+,125,,,,,
-25757,2,100,99,14,Crest of Stunning Prevention+,125,,,,,
-25758,2,100,99,14,Crest of Drench Prevention+,125,,,,,
-25759,2,100,99,14,Crest of Tar Prevention+,125,,,,,
-25760,2,100,99,14,Crest of Stifle Prevention+,125,,,,,
-25761,2,100,99,14,Crest of Curse Prevention+,125,,,,,
-25762,2,100,99,14,Crest of Frail Prevention+,125,,,,,
-25763,2,100,99,14,Crest of Petrification Prevention+,125,,,,,
-25764,2,100,99,14,Crest of Golden Prevention+,125,,,,,
-25765,2,100,99,14,Crest of Double Resist (Lowered Strength/Defense)+,125,,,,,
-25766,2,100,99,14,Crest of Double Resist (Lowered Magick/Magick Defense)+,125,,,,,
-25767,2,100,99,14,Crest of Superior Magick (Freezing)+,124,,,,,
-25768,2,100,99,14,Crest of Firm Protection+,125,,,,,
+25521,2,350,99,140,Madness Amulet,120,,,,,
+25522,2,350,99,145,Dragon Cotton Flower in the Temple Medicinal Garden,114,,,,,
+25523,2,350,99,150,Kunstkette,101,,,,,
+25524,2,350,99,140,Shiny white Bonebiter Beetle,123,,,,,
+25525,2,350,99,145,Demon Leather Tanning Solution,119,,,,,
+25526,2,350,99,150,Elegant Harp Steel Ingot,101,,,,,
+25527,2,350,99,140,Spirit Resonance Mudsand,103,,,,,
+25528,2,350,99,145,Cobalt Heliotrope,114,,,,,
+25529,2,350,99,150,Zircon,113,,,,,
+25654,2,100,99,25,Crest of Sheer Power+,124,,,,,
+25655,2,100,99,30,Crest of Herculean Power+,124,,,,,
+25656,2,100,99,30,Crest of Herculean Power (Burning)+,124,,,,,
+25657,2,100,99,30,Crest of Herculean Power (Freezing)+,124,,,,,
+25658,2,100,99,30,Crest of Herculean Power (Shock)+,124,,,,,
+25659,2,100,99,30,Crest of Herculean Power (Holy Drain)+,124,,,,,
+25660,2,100,99,30,Crest of Herculean Power (Blinding)+,124,,,,,
+25661,2,100,99,30,Crest of Herculean Power (Blow Power)+,124,,,,,
+25662,2,100,99,30,Crest of Herculean Power (Stun)+,124,,,,,
+25663,2,100,99,30,Crest of Herculean Power (Poison)+,124,,,,,
+25664,2,100,99,30,Crest of Herculean Power (Torpor)+,124,,,,,
+25665,2,100,99,30,Crest of Herculean Power (Sleep)+,124,,,,,
+25666,2,100,99,30,Crest of Herculean Power (Petrification)+,124,,,,,
+25668,2,100,99,30,Crest of Herculean Power (Gilding)+,124,,,,,
+25669,2,100,99,30,Crest of Herculean Power (Lowered Defense)+,124,,,,,
+25670,2,100,99,25,Crest of Sheer Magick+,124,,,,,
+25671,2,100,99,30,Crest of Superior Magick+,124,,,,,
+25672,2,100,99,30,Crest of Superior Magick (Burning)+,124,,,,,
+25673,2,100,99,30,Crest of Superior Magick (Shock)+,124,,,,,
+25674,2,100,99,30,Crest of Superior Magick (Holy Drain)+,124,,,,,
+25675,2,100,99,30,Crest of Superior Magick (Blow Power)+,124,,,,,
+25676,2,100,99,30,Crest of Superior Magick (Blinding)+,124,,,,,
+25677,2,100,99,30,Crest of Superior Magick (Stun)+,124,,,,,
+25678,2,100,99,30,Crest of Superior Magick (Poison)+,124,,,,,
+25679,2,100,99,30,Crest of Superior Magick (Torpor)+,124,,,,,
+25680,2,100,99,30,Crest of Superior Magick (Sleep)+,124,,,,,
+25681,2,100,99,30,Crest of Superior Magick (Petrification)+,124,,,,,
+25682,2,100,99,30,Crest of Superior Magick (Gilding)+,124,,,,,
+25683,2,100,99,30,Crest of Superior Magick (Lowered Magick Defense)+,124,,,,,
+25684,2,100,99,30,Crest of Incineration+,124,,,,,
+25685,2,100,99,30,Crest of Incineration (Decreased Fire Resist)+,124,,,,,
+25686,2,100,99,30,Crest of Permafrost+,124,,,,,
+25687,2,100,99,30,Crest of Permafrost (Decreased Ice Resist)+,124,,,,,
+25688,2,100,99,30,Crest of Electrocution+,124,,,,,
+25689,2,100,99,30,Crest of Electrocution (Decreased Lightning Resist)+,124,,,,,
+25690,2,100,99,30,Crest of Sanctity+,124,,,,,
+25691,2,100,99,30,Crest of Sanctity (Decreased Holy Resist)+,124,,,,,
+25692,2,100,99,30,Crest of Twilight+,124,,,,,
+25693,2,100,99,30,Crest of Twilight (Decreased Dark Resist)+,124,,,,,
+25694,2,100,99,30,Crest of Depleted Defense+,124,,,,,
+25695,2,100,99,30,Crest of Depleted Magick Defense+,124,,,,,
+25696,2,100,99,25,Crest of Dazzling+,124,,,,,
+25697,2,100,99,30,Crest of Sidesplitting Laughter+,124,,,,,
+25698,2,100,99,30,Crest of Fatal Poison+,124,,,,,
+25699,2,100,99,25,Crest of Sleep+,124,,,,,
+25700,2,100,99,30,Crest of Deeper Sleep+,124,,,,,
+25701,2,100,99,25,Crest of Gilding+,124,,,,,
+25702,2,100,99,30,Crest of Glittering Gold+,124,,,,,
+25703,2,100,99,25,Crest of Petrification+,124,,,,,
+25704,2,100,99,30,Crest of Crystallization+,124,,,,,
+25705,2,100,99,25,Crest of Frailness+,124,,,,,
+25706,2,100,99,30,Crest of Fragility+,124,,,,,
+25707,2,100,99,25,Crest of Stifling+,124,,,,,
+25708,2,100,99,30,Crest of Sealing+,124,,,,,
+25709,2,100,99,25,Crest of Drenching+,124,,,,,
+25710,2,100,99,30,Crest of Drowning+,124,,,,,
+25711,2,100,99,25,Crest of Tarring+,124,,,,,
+25712,2,100,99,30,Crest of Greater Tarring+,124,,,,,
+25713,2,100,99,30,Crest of Greater Torpor+,124,,,,,
+25714,2,100,99,25,Crest of Increased Attack+,124,,,,,
+25715,2,100,99,30,Crest of Amplified Attack+,124,,,,,
+25716,2,100,99,25,Crest of Sheer Protection+,125,,,,,
+25717,2,100,99,30,Crest of Firm Protection (Health)+,125,,,,,
+25718,2,100,99,30,Crest of Firm Protection (Endurance)+,125,,,,,
+25719,2,100,99,30,Crest of Firm Protection (Vitality)+,125,,,,,
+25720,2,100,99,30,Crest of Firm Protection (Lightness)+,125,,,,,
+25721,2,100,99,30,Crest of Unwavering+,125,,,,,
+25722,2,100,99,25,Crest of Sheer Intelligence+,125,,,,,
+25723,2,100,99,30,Crest of Wisdom+,125,,,,,
+25724,2,100,99,30,Crest of Wisdom (Health)+,125,,,,,
+25725,2,100,99,30,Crest of Wisdom (Endurance)+,125,,,,,
+25726,2,100,99,30,Crest of Wisdom (Vitality)+,125,,,,,
+25727,2,100,99,30,Crest of Wisdom (Lightness)+,125,,,,,
+25728,2,100,99,25,Crest of Resurgence+,125,,,,,
+25729,2,100,99,30,Crest of Stoicism+,125,,,,,
+25730,2,100,99,25,Crest of Determination+,125,,,,,
+25731,2,100,99,30,Crest of Pertinacity+,125,,,,,
+25732,2,100,99,25,Crest of Health+,125,,,,,
+25733,2,100,99,30,Crest of Strong Health+,125,,,,,
+25734,2,100,99,25,Crest of Stamina+,125,,,,,
+25735,2,100,99,30,Crest of Strong Stamina+,125,,,,,
+25736,2,100,99,30,Crest of Vigor+,125,,,,,
+25737,2,100,99,25,Crest of Lightness+,125,,,,,
+25738,2,100,99,30,Crest of Unburdening+,125,,,,,
+25739,2,100,99,30,Crest of Hellfire Warding+,125,,,,,
+25740,2,100,99,30,Crest of Snowstorm Warding+,125,,,,,
+25741,2,100,99,30,Crest of Thunder Warding+,125,,,,,
+25742,2,100,99,30,Crest of Sacred Warding+,125,,,,,
+25743,2,100,99,30,Crest of Shadow Warding+,125,,,,,
+25744,2,100,99,30,Crest of Burn Immunity+,125,,,,,
+25745,2,100,99,30,Crest of Freeze Immunity+,125,,,,,
+25746,2,100,99,30,Crest of Shock Immunity+,125,,,,,
+25747,2,100,99,30,Crest of Holy Drain Immunity+,125,,,,,
+25748,2,100,99,30,Crest of Blind Immunity+,125,,,,,
+25749,2,100,99,30,Crest of Fire Protection+,125,,,,,
+25750,2,100,99,30,Crest of Ice Protection+,125,,,,,
+25751,2,100,99,30,Crest of Lightning Protection+,125,,,,,
+25752,2,100,99,30,Crest of Holy Protection+,125,,,,,
+25753,2,100,99,30,Crest of Dark Protection+,125,,,,,
+25754,2,100,99,30,Crest of Poison Prevention+,125,,,,,
+25755,2,100,99,30,Crest of Torpor Prevention+,125,,,,,
+25756,2,100,99,30,Crest of Sleep Prevention+,125,,,,,
+25757,2,100,99,30,Crest of Stunning Prevention+,125,,,,,
+25758,2,100,99,30,Crest of Drench Prevention+,125,,,,,
+25759,2,100,99,30,Crest of Tar Prevention+,125,,,,,
+25760,2,100,99,30,Crest of Stifle Prevention+,125,,,,,
+25761,2,100,99,30,Crest of Curse Prevention+,125,,,,,
+25762,2,100,99,30,Crest of Frail Prevention+,125,,,,,
+25763,2,100,99,30,Crest of Petrification Prevention+,125,,,,,
+25764,2,100,99,30,Crest of Golden Prevention+,125,,,,,
+25765,2,100,99,30,Crest of Double Resist (Lowered Strength/Defense)+,125,,,,,
+25766,2,100,99,30,Crest of Double Resist (Lowered Magick/Magick Defense)+,125,,,,,
+25767,2,100,99,30,Crest of Superior Magick (Freezing)+,124,,,,,
+25768,2,100,99,30,Crest of Firm Protection+,125,,,,,
 1026,4,0,1,0,Riftstone Ore,,,,,,
 1029,4,0,1,0,Alchemy Research Building Key,,,,,,
 1030,4,0,1,0,Dreed Chapel Key,,,,,,
@@ -5876,21 +5876,21 @@
 3011,3,8005,1,8,Noblesse Oblige,203,40,7,1,2,1
 4034,3,8005,1,8,Noblesse Oblige,203,40,7,1,3,1
 5057,3,8005,1,8,Noblesse Oblige,203,40,7,1,4,1
-377,3,21130,1,4,Demolish Hammer,203,65,7,1,0,1
-1989,3,21130,1,4,Demolish Hammer,203,65,7,1,1,1
-3012,3,21130,1,4,Demolish Hammer,203,65,7,1,2,1
-4035,3,21130,1,4,Demolish Hammer,203,65,7,1,3,1
-5058,3,21130,1,4,Demolish Hammer,203,65,7,1,4,1
+377,3,21130,1,20,Demolish Hammer,203,65,7,1,0,1
+1989,3,21130,1,20,Demolish Hammer,203,65,7,1,1,1
+3012,3,21130,1,20,Demolish Hammer,203,65,7,1,2,1
+4035,3,21130,1,20,Demolish Hammer,203,65,7,1,3,1
+5058,3,21130,1,20,Demolish Hammer,203,65,7,1,4,1
 378,3,9250,1,11,Saving Grace,203,55,7,1,0,1
 1990,3,9250,1,11,Saving Grace,203,55,7,1,1,1
 3013,3,9250,1,11,Saving Grace,203,55,7,1,2,1
 4036,3,9250,1,11,Saving Grace,203,55,7,1,3,1
 5059,3,9250,1,11,Saving Grace,203,55,7,1,4,1
-379,3,24505,1,3,Egg of Agony,203,70,7,1,0,1
-1991,3,24505,1,3,Egg of Agony,203,70,7,1,1,1
-3014,3,24505,1,3,Egg of Agony,203,70,7,1,2,1
-4037,3,24505,1,3,Egg of Agony,203,70,7,1,3,1
-5060,3,24505,1,3,Egg of Agony,203,70,7,1,4,1
+379,3,24505,1,35,Egg of Agony,203,70,7,1,0,1
+1991,3,24505,1,35,Egg of Agony,203,70,7,1,1,1
+3014,3,24505,1,35,Egg of Agony,203,70,7,1,2,1
+4037,3,24505,1,35,Egg of Agony,203,70,7,1,3,1
+5060,3,24505,1,35,Egg of Agony,203,70,7,1,4,1
 380,3,18005,1,12,Tomos Chromos,203,60,7,1,0,1
 1992,3,18005,1,12,Tomos Chromos,203,60,7,1,1,1
 3015,3,18005,1,12,Tomos Chromos,203,60,7,1,2,1
@@ -5916,11 +5916,11 @@
 3020,3,11050,1,11,Tri-Head,203,55,7,1,2,1
 4043,3,11050,1,11,Tri-Head,203,55,7,1,3,1
 5066,3,11050,1,11,Tri-Head,203,55,7,1,4,1
-386,3,22450,1,14,Gilgamesh Lance,203,67,7,1,0,1
-1998,3,22450,1,14,Gilgamesh Lance,203,67,7,1,1,1
-3021,3,22450,1,14,Gilgamesh Lance,203,67,7,1,2,1
-4044,3,22450,1,14,Gilgamesh Lance,203,67,7,1,3,1
-5067,3,22450,1,14,Gilgamesh Lance,203,67,7,1,4,1
+386,3,22450,1,30,Gilgamesh Lance,203,67,7,1,0,1
+1998,3,22450,1,30,Gilgamesh Lance,203,67,7,1,1,1
+3021,3,22450,1,30,Gilgamesh Lance,203,67,7,1,2,1
+4044,3,22450,1,30,Gilgamesh Lance,203,67,7,1,3,1
+5067,3,22450,1,30,Gilgamesh Lance,203,67,7,1,4,1
 387,3,18005,1,12,Hartenklinger,203,60,7,1,0,1
 1999,3,18005,1,12,Hartenklinger,203,60,7,1,1,1
 3022,3,18005,1,12,Hartenklinger,203,60,7,1,2,1
@@ -6001,21 +6001,21 @@
 3040,3,15685,1,12,Veritas,208,56,9,1,2,1
 4063,3,15685,1,12,Veritas,208,56,9,1,3,1
 5086,3,15685,1,12,Veritas,208,56,9,1,4,1
-406,3,28130,1,2,Animus,208,75,9,1,0,1
-2018,3,28130,1,2,Animus,208,75,9,1,1,1
-3041,3,28130,1,2,Animus,208,75,9,1,2,1
-4064,3,28130,1,2,Animus,208,75,9,1,3,1
-5087,3,28130,1,2,Animus,208,75,9,1,4,1
+406,3,28130,1,50,Animus,208,75,9,1,0,1
+2018,3,28130,1,50,Animus,208,75,9,1,1,1
+3041,3,28130,1,50,Animus,208,75,9,1,2,1
+4064,3,28130,1,50,Animus,208,75,9,1,3,1
+5087,3,28130,1,50,Animus,208,75,9,1,4,1
 407,3,8005,1,8,Testament Scale,208,40,9,1,0,1
 2019,3,8005,1,8,Testament Scale,208,40,9,1,1,1
 3042,3,8005,1,8,Testament Scale,208,40,9,1,2,1
 4065,3,8005,1,8,Testament Scale,208,40,9,1,3,1
 5088,3,8005,1,8,Testament Scale,208,40,9,1,4,1
-408,3,28130,1,2,Victor,208,75,9,1,0,1
-2020,3,28130,1,2,Victor,208,75,9,1,1,1
-3043,3,28130,1,2,Victor,208,75,9,1,2,1
-4066,3,28130,1,2,Victor,208,75,9,1,3,1
-5089,3,28130,1,2,Victor,208,75,9,1,4,1
+408,3,28130,1,50,Victor,208,75,9,1,0,1
+2020,3,28130,1,50,Victor,208,75,9,1,1,1
+3043,3,28130,1,50,Victor,208,75,9,1,2,1
+4066,3,28130,1,50,Victor,208,75,9,1,3,1
+5089,3,28130,1,50,Victor,208,75,9,1,4,1
 409,3,10130,1,9,Arcanum,208,45,9,1,0,1
 2021,3,10130,1,9,Arcanum,208,45,9,1,1,1
 3044,3,10130,1,9,Arcanum,208,45,9,1,2,1
@@ -6026,51 +6026,51 @@
 3045,3,19225,1,15,Centuria,208,62,9,1,2,1
 4068,3,19225,1,15,Centuria,208,62,9,1,3,1
 5091,3,19225,1,15,Centuria,208,62,9,1,4,1
-411,3,21130,1,4,Adamant,208,65,9,1,0,1
-2023,3,21130,1,4,Adamant,208,65,9,1,1,1
-3046,3,21130,1,4,Adamant,208,65,9,1,2,1
-4069,3,21130,1,4,Adamant,208,65,9,1,3,1
-5092,3,21130,1,4,Adamant,208,65,9,1,4,1
-412,3,24505,1,3,Ostium,208,70,9,1,0,1
-2024,3,24505,1,3,Ostium,208,70,9,1,1,1
-3047,3,24505,1,3,Ostium,208,70,9,1,2,1
-4070,3,24505,1,3,Ostium,208,70,9,1,3,1
-5093,3,24505,1,3,Ostium,208,70,9,1,4,1
+411,3,21130,1,20,Adamant,208,65,9,1,0,1
+2023,3,21130,1,20,Adamant,208,65,9,1,1,1
+3046,3,21130,1,20,Adamant,208,65,9,1,2,1
+4069,3,21130,1,20,Adamant,208,65,9,1,3,1
+5092,3,21130,1,20,Adamant,208,65,9,1,4,1
+412,3,24505,1,35,Ostium,208,70,9,1,0,1
+2024,3,24505,1,35,Ostium,208,70,9,1,1,1
+3047,3,24505,1,35,Ostium,208,70,9,1,2,1
+4070,3,24505,1,35,Ostium,208,70,9,1,3,1
+5093,3,24505,1,35,Ostium,208,70,9,1,4,1
 413,3,15130,1,11,Portae Lucis,208,55,9,1,0,1
 2025,3,15130,1,11,Portae Lucis,208,55,9,1,1,1
 3048,3,15130,1,11,Portae Lucis,208,55,9,1,2,1
 4071,3,15130,1,11,Portae Lucis,208,55,9,1,3,1
 5094,3,15130,1,11,Portae Lucis,208,55,9,1,4,1
-414,3,29650,1,12,Rorem Cubito,208,77,9,1,0,1
-2026,3,29650,1,12,Rorem Cubito,208,77,9,1,1,1
-3049,3,29650,1,12,Rorem Cubito,208,77,9,1,2,1
-4072,3,29650,1,12,Rorem Cubito,208,77,9,1,3,1
-5095,3,29650,1,12,Rorem Cubito,208,77,9,1,4,1
+414,3,29650,1,60,Rorem Cubito,208,77,9,1,0,1
+2026,3,29650,1,60,Rorem Cubito,208,77,9,1,1,1
+3049,3,29650,1,60,Rorem Cubito,208,77,9,1,2,1
+4072,3,29650,1,60,Rorem Cubito,208,77,9,1,3,1
+5095,3,29650,1,60,Rorem Cubito,208,77,9,1,4,1
 415,3,18005,1,12,Brachium Spiritus,208,60,9,1,0,1
 2027,3,18005,1,12,Brachium Spiritus,208,60,9,1,1,1
 3050,3,18005,1,12,Brachium Spiritus,208,60,9,1,2,1
 4073,3,18005,1,12,Brachium Spiritus,208,60,9,1,3,1
 5096,3,18005,1,12,Brachium Spiritus,208,60,9,1,4,1
-416,3,32005,1,1,Solitude,208,80,9,1,0,1
-2028,3,32005,1,1,Solitude,208,80,9,1,1,1
-3051,3,32005,1,1,Solitude,208,80,9,1,2,1
-4074,3,32005,1,1,Solitude,208,80,9,1,3,1
-5097,3,32005,1,1,Solitude,208,80,9,1,4,1
+416,3,32005,1,65,Solitude,208,80,9,1,0,1
+2028,3,32005,1,65,Solitude,208,80,9,1,1,1
+3051,3,32005,1,65,Solitude,208,80,9,1,2,1
+4074,3,32005,1,65,Solitude,208,80,9,1,3,1
+5097,3,32005,1,65,Solitude,208,80,9,1,4,1
 417,3,18005,1,12,Nigrum Corpus,208,60,9,1,0,1
 2029,3,18005,1,12,Nigrum Corpus,208,60,9,1,1,1
 3052,3,18005,1,12,Nigrum Corpus,208,60,9,1,2,1
 4075,3,18005,1,12,Nigrum Corpus,208,60,9,1,3,1
 5098,3,18005,1,12,Nigrum Corpus,208,60,9,1,4,1
-418,3,32005,1,1,Tenebrae de Ragel,208,80,9,1,0,1
-2030,3,32005,1,1,Tenebrae de Ragel,208,80,9,1,1,1
-3053,3,32005,1,1,Tenebrae de Ragel,208,80,9,1,2,1
-4076,3,32005,1,1,Tenebrae de Ragel,208,80,9,1,3,1
-5099,3,32005,1,1,Tenebrae de Ragel,208,80,9,1,4,1
-419,3,22450,1,14,Ichthus Terram,208,67,9,1,0,1
-2031,3,22450,1,14,Ichthus Terram,208,67,9,1,1,1
-3054,3,22450,1,14,Ichthus Terram,208,67,9,1,2,1
-4077,3,22450,1,14,Ichthus Terram,208,67,9,1,3,1
-5100,3,22450,1,14,Ichthus Terram,208,67,9,1,4,1
+418,3,32005,1,65,Tenebrae de Ragel,208,80,9,1,0,1
+2030,3,32005,1,65,Tenebrae de Ragel,208,80,9,1,1,1
+3053,3,32005,1,65,Tenebrae de Ragel,208,80,9,1,2,1
+4076,3,32005,1,65,Tenebrae de Ragel,208,80,9,1,3,1
+5099,3,32005,1,65,Tenebrae de Ragel,208,80,9,1,4,1
+419,3,22450,1,30,Ichthus Terram,208,67,9,1,0,1
+2031,3,22450,1,30,Ichthus Terram,208,67,9,1,1,1
+3054,3,22450,1,30,Ichthus Terram,208,67,9,1,2,1
+4077,3,22450,1,30,Ichthus Terram,208,67,9,1,3,1
+5100,3,22450,1,30,Ichthus Terram,208,67,9,1,4,1
 421,3,18005,1,12,Ars Magna,208,60,9,1,0,1
 2033,3,18005,1,12,Ars Magna,208,60,9,1,1,1
 3056,3,18005,1,12,Ars Magna,208,60,9,1,2,1
@@ -6545,11 +6545,11 @@
 11416,3,12548,1,12,Sky Hatchet,201,55,1,1,2,1
 11417,3,12548,1,12,Sky Hatchet,201,55,1,1,3,1
 11418,3,12548,1,12,Sky Hatchet,201,55,1,1,4,1
-11424,3,28130,1,12,Verdant Force,203,75,7,1,0,1
-11425,3,28130,1,12,Verdant Force,203,75,7,1,1,1
-11426,3,28130,1,12,Verdant Force,203,75,7,1,2,1
-11427,3,28130,1,12,Verdant Force,203,75,7,1,3,1
-11428,3,28130,1,12,Verdant Force,203,75,7,1,4,1
+11424,3,28130,1,60,Verdant Force,203,75,7,1,0,1
+11425,3,28130,1,60,Verdant Force,203,75,7,1,1,1
+11426,3,28130,1,60,Verdant Force,203,75,7,1,2,1
+11427,3,28130,1,60,Verdant Force,203,75,7,1,3,1
+11428,3,28130,1,60,Verdant Force,203,75,7,1,4,1
 11429,3,12548,1,12,Gravestone,204,55,5,1,0,1
 11430,3,12548,1,12,Gravestone,204,55,5,1,1,1
 11431,3,12548,1,12,Gravestone,204,55,5,1,2,1
@@ -6765,106 +6765,106 @@
 11823,3,15380,1,15,Truth Falcata,201,62,1,1,2,1
 11824,3,15380,1,15,Truth Falcata,201,62,1,1,3,1
 11825,3,15380,1,15,Truth Falcata,201,62,1,1,4,1
-11826,3,16904,1,4,Clunky Beak,201,65,1,1,0,1
-11827,3,16904,1,4,Clunky Beak,201,65,1,1,1,1
-11828,3,16904,1,4,Clunky Beak,201,65,1,1,2,1
-11829,3,16904,1,4,Clunky Beak,201,65,1,1,3,1
-11830,3,16904,1,4,Clunky Beak,201,65,1,1,4,1
-11831,3,16904,1,4,Thuân Thiên,201,65,1,1,0,1
-11832,3,16904,1,4,Thuân Thiên,201,65,1,1,1,1
-11833,3,16904,1,4,Thuân Thiên,201,65,1,1,2,1
-11834,3,16904,1,4,Thuân Thiên,201,65,1,1,3,1
-11835,3,16904,1,4,Thuân Thiên,201,65,1,1,4,1
-11836,3,16904,1,9,Navodnenie,201,65,1,1,0,1
-11837,3,16904,1,9,Navodnenie,201,65,1,1,1,1
-11838,3,16904,1,9,Navodnenie,201,65,1,1,2,1
-11839,3,16904,1,9,Navodnenie,201,65,1,1,3,1
-11840,3,16904,1,9,Navodnenie,201,65,1,1,4,1
-11841,3,16904,1,14,Ascalon,201,65,1,1,0,1
-11842,3,16904,1,14,Ascalon,201,65,1,1,1,1
-11843,3,16904,1,14,Ascalon,201,65,1,1,2,1
-11844,3,16904,1,14,Ascalon,201,65,1,1,3,1
-11845,3,16904,1,14,Ascalon,201,65,1,1,4,1
-11851,3,17960,1,14,Tempered Francisca,201,67,1,1,0,1
-11852,3,17960,1,14,Tempered Francisca,201,67,1,1,1,1
-11853,3,17960,1,14,Tempered Francisca,201,67,1,1,2,1
-11854,3,17960,1,14,Tempered Francisca,201,67,1,1,3,1
-11855,3,17960,1,14,Tempered Francisca,201,67,1,1,4,1
-11856,3,19604,1,3,Constellation,201,70,1,1,0,1
-11857,3,19604,1,3,Constellation,201,70,1,1,1,1
-11858,3,19604,1,3,Constellation,201,70,1,1,2,1
-11859,3,19604,1,3,Constellation,201,70,1,1,3,1
-11860,3,19604,1,3,Constellation,201,70,1,1,4,1
-11861,3,19604,1,3,Moderate Savior,201,70,1,1,0,1
-11862,3,19604,1,3,Moderate Savior,201,70,1,1,1,1
-11863,3,19604,1,3,Moderate Savior,201,70,1,1,2,1
-11864,3,19604,1,3,Moderate Savior,201,70,1,1,3,1
-11865,3,19604,1,3,Moderate Savior,201,70,1,1,4,1
-11866,3,19604,1,8,Sword of Tyrant,201,70,1,1,0,1
-11867,3,19604,1,8,Sword of Tyrant,201,70,1,1,1,1
-11868,3,19604,1,8,Sword of Tyrant,201,70,1,1,2,1
-11869,3,19604,1,8,Sword of Tyrant,201,70,1,1,3,1
-11870,3,19604,1,8,Sword of Tyrant,201,70,1,1,4,1
-11871,3,19604,1,13,Sacred Succeed,201,70,1,1,0,1
-11872,3,19604,1,13,Sacred Succeed,201,70,1,1,1,1
-11873,3,19604,1,13,Sacred Succeed,201,70,1,1,2,1
-11874,3,19604,1,13,Sacred Succeed,201,70,1,1,3,1
-11875,3,19604,1,13,Sacred Succeed,201,70,1,1,4,1
-11916,3,25925,1,13,Breaker of Tribe,203,72,7,1,0,1
-11917,3,25925,1,13,Breaker of Tribe,203,72,7,1,1,1
-11918,3,25925,1,13,Breaker of Tribe,203,72,7,1,2,1
-11919,3,25925,1,13,Breaker of Tribe,203,72,7,1,3,1
-11920,3,25925,1,13,Breaker of Tribe,203,72,7,1,4,1
-11921,3,21130,1,4,Espadon,203,65,7,1,0,1
-11922,3,21130,1,4,Espadon,203,65,7,1,1,1
-11923,3,21130,1,4,Espadon,203,65,7,1,2,1
-11924,3,21130,1,4,Espadon,203,65,7,1,3,1
-11925,3,21130,1,4,Espadon,203,65,7,1,4,1
-11926,3,21130,1,9,Brutal Torrent,203,65,7,1,0,1
-11927,3,21130,1,9,Brutal Torrent,203,65,7,1,1,1
-11928,3,21130,1,9,Brutal Torrent,203,65,7,1,2,1
-11929,3,21130,1,9,Brutal Torrent,203,65,7,1,3,1
-11930,3,21130,1,9,Brutal Torrent,203,65,7,1,4,1
-11931,3,21130,1,14,Dwells-In-Light,203,65,7,1,0,1
-11932,3,21130,1,14,Dwells-In-Light,203,65,7,1,1,1
-11933,3,21130,1,14,Dwells-In-Light,203,65,7,1,2,1
-11934,3,21130,1,14,Dwells-In-Light,203,65,7,1,3,1
-11935,3,21130,1,14,Dwells-In-Light,203,65,7,1,4,1
-11936,3,28130,1,2,Highlanders,203,75,7,1,0,1
-11937,3,28130,1,2,Highlanders,203,75,7,1,1,1
-11938,3,28130,1,2,Highlanders,203,75,7,1,2,1
-11939,3,28130,1,2,Highlanders,203,75,7,1,3,1
-11940,3,28130,1,2,Highlanders,203,75,7,1,4,1
-11941,3,28130,1,2,Silver Stakes,203,75,7,1,0,1
-11942,3,28130,1,2,Silver Stakes,203,75,7,1,1,1
-11943,3,28130,1,2,Silver Stakes,203,75,7,1,2,1
-11944,3,28130,1,2,Silver Stakes,203,75,7,1,3,1
-11945,3,28130,1,2,Silver Stakes,203,75,7,1,4,1
-11946,3,28130,1,7,Phindymian Breaker,203,75,7,1,0,1
-11947,3,28130,1,7,Phindymian Breaker,203,75,7,1,1,1
-11948,3,28130,1,7,Phindymian Breaker,203,75,7,1,2,1
-11949,3,28130,1,7,Phindymian Breaker,203,75,7,1,3,1
-11950,3,28130,1,7,Phindymian Breaker,203,75,7,1,4,1
-11951,3,24505,1,3,Hauteclere,203,70,7,1,0,1
-11952,3,24505,1,3,Hauteclere,203,70,7,1,1,1
-11953,3,24505,1,3,Hauteclere,203,70,7,1,2,1
-11954,3,24505,1,3,Hauteclere,203,70,7,1,3,1
-11955,3,24505,1,3,Hauteclere,203,70,7,1,4,1
-11956,3,24505,1,8,Saw of Tyrant,203,70,7,1,0,1
-11957,3,24505,1,8,Saw of Tyrant,203,70,7,1,1,1
-11958,3,24505,1,8,Saw of Tyrant,203,70,7,1,2,1
-11959,3,24505,1,8,Saw of Tyrant,203,70,7,1,3,1
-11960,3,24505,1,8,Saw of Tyrant,203,70,7,1,4,1
-11961,3,24505,1,13,Gallant Figure,203,70,7,1,0,1
-11962,3,24505,1,13,Gallant Figure,203,70,7,1,1,1
-11963,3,24505,1,13,Gallant Figure,203,70,7,1,2,1
-11964,3,24505,1,13,Gallant Figure,203,70,7,1,3,1
-11965,3,24505,1,13,Gallant Figure,203,70,7,1,4,1
-11966,3,5000,1,2,Olfring Breaker (Black),203,1,7,4,0,1
-11967,3,5000,1,2,Olfring Breaker (Black),203,1,7,4,1,1
-11968,3,5000,1,2,Olfring Breaker (Black),203,1,7,4,2,1
-11969,3,5000,1,2,Olfring Breaker (Black),203,1,7,4,3,1
-11970,3,5000,1,2,Olfring Breaker (Black),203,1,7,4,4,1
+11826,3,16904,1,20,Clunky Beak,201,65,1,1,0,1
+11827,3,16904,1,20,Clunky Beak,201,65,1,1,1,1
+11828,3,16904,1,20,Clunky Beak,201,65,1,1,2,1
+11829,3,16904,1,20,Clunky Beak,201,65,1,1,3,1
+11830,3,16904,1,20,Clunky Beak,201,65,1,1,4,1
+11831,3,16904,1,20,Thuân Thiên,201,65,1,1,0,1
+11832,3,16904,1,20,Thuân Thiên,201,65,1,1,1,1
+11833,3,16904,1,20,Thuân Thiên,201,65,1,1,2,1
+11834,3,16904,1,20,Thuân Thiên,201,65,1,1,3,1
+11835,3,16904,1,20,Thuân Thiên,201,65,1,1,4,1
+11836,3,16904,1,25,Navodnenie,201,65,1,1,0,1
+11837,3,16904,1,25,Navodnenie,201,65,1,1,1,1
+11838,3,16904,1,25,Navodnenie,201,65,1,1,2,1
+11839,3,16904,1,25,Navodnenie,201,65,1,1,3,1
+11840,3,16904,1,25,Navodnenie,201,65,1,1,4,1
+11841,3,16904,1,30,Ascalon,201,65,1,1,0,1
+11842,3,16904,1,30,Ascalon,201,65,1,1,1,1
+11843,3,16904,1,30,Ascalon,201,65,1,1,2,1
+11844,3,16904,1,30,Ascalon,201,65,1,1,3,1
+11845,3,16904,1,30,Ascalon,201,65,1,1,4,1
+11851,3,17960,1,30,Tempered Francisca,201,67,1,1,0,1
+11852,3,17960,1,30,Tempered Francisca,201,67,1,1,1,1
+11853,3,17960,1,30,Tempered Francisca,201,67,1,1,2,1
+11854,3,17960,1,30,Tempered Francisca,201,67,1,1,3,1
+11855,3,17960,1,30,Tempered Francisca,201,67,1,1,4,1
+11856,3,19604,1,35,Constellation,201,70,1,1,0,1
+11857,3,19604,1,35,Constellation,201,70,1,1,1,1
+11858,3,19604,1,35,Constellation,201,70,1,1,2,1
+11859,3,19604,1,35,Constellation,201,70,1,1,3,1
+11860,3,19604,1,35,Constellation,201,70,1,1,4,1
+11861,3,19604,1,35,Moderate Savior,201,70,1,1,0,1
+11862,3,19604,1,35,Moderate Savior,201,70,1,1,1,1
+11863,3,19604,1,35,Moderate Savior,201,70,1,1,2,1
+11864,3,19604,1,35,Moderate Savior,201,70,1,1,3,1
+11865,3,19604,1,35,Moderate Savior,201,70,1,1,4,1
+11866,3,19604,1,40,Sword of Tyrant,201,70,1,1,0,1
+11867,3,19604,1,40,Sword of Tyrant,201,70,1,1,1,1
+11868,3,19604,1,40,Sword of Tyrant,201,70,1,1,2,1
+11869,3,19604,1,40,Sword of Tyrant,201,70,1,1,3,1
+11870,3,19604,1,40,Sword of Tyrant,201,70,1,1,4,1
+11871,3,19604,1,45,Sacred Succeed,201,70,1,1,0,1
+11872,3,19604,1,45,Sacred Succeed,201,70,1,1,1,1
+11873,3,19604,1,45,Sacred Succeed,201,70,1,1,2,1
+11874,3,19604,1,45,Sacred Succeed,201,70,1,1,3,1
+11875,3,19604,1,45,Sacred Succeed,201,70,1,1,4,1
+11916,3,25925,1,45,Breaker of Tribe,203,72,7,1,0,1
+11917,3,25925,1,45,Breaker of Tribe,203,72,7,1,1,1
+11918,3,25925,1,45,Breaker of Tribe,203,72,7,1,2,1
+11919,3,25925,1,45,Breaker of Tribe,203,72,7,1,3,1
+11920,3,25925,1,45,Breaker of Tribe,203,72,7,1,4,1
+11921,3,21130,1,20,Espadon,203,65,7,1,0,1
+11922,3,21130,1,20,Espadon,203,65,7,1,1,1
+11923,3,21130,1,20,Espadon,203,65,7,1,2,1
+11924,3,21130,1,20,Espadon,203,65,7,1,3,1
+11925,3,21130,1,20,Espadon,203,65,7,1,4,1
+11926,3,21130,1,25,Brutal Torrent,203,65,7,1,0,1
+11927,3,21130,1,25,Brutal Torrent,203,65,7,1,1,1
+11928,3,21130,1,25,Brutal Torrent,203,65,7,1,2,1
+11929,3,21130,1,25,Brutal Torrent,203,65,7,1,3,1
+11930,3,21130,1,25,Brutal Torrent,203,65,7,1,4,1
+11931,3,21130,1,30,Dwells-In-Light,203,65,7,1,0,1
+11932,3,21130,1,30,Dwells-In-Light,203,65,7,1,1,1
+11933,3,21130,1,30,Dwells-In-Light,203,65,7,1,2,1
+11934,3,21130,1,30,Dwells-In-Light,203,65,7,1,3,1
+11935,3,21130,1,30,Dwells-In-Light,203,65,7,1,4,1
+11936,3,28130,1,50,Highlanders,203,75,7,1,0,1
+11937,3,28130,1,50,Highlanders,203,75,7,1,1,1
+11938,3,28130,1,50,Highlanders,203,75,7,1,2,1
+11939,3,28130,1,50,Highlanders,203,75,7,1,3,1
+11940,3,28130,1,50,Highlanders,203,75,7,1,4,1
+11941,3,28130,1,50,Silver Stakes,203,75,7,1,0,1
+11942,3,28130,1,50,Silver Stakes,203,75,7,1,1,1
+11943,3,28130,1,50,Silver Stakes,203,75,7,1,2,1
+11944,3,28130,1,50,Silver Stakes,203,75,7,1,3,1
+11945,3,28130,1,50,Silver Stakes,203,75,7,1,4,1
+11946,3,28130,1,55,Phindymian Breaker,203,75,7,1,0,1
+11947,3,28130,1,55,Phindymian Breaker,203,75,7,1,1,1
+11948,3,28130,1,55,Phindymian Breaker,203,75,7,1,2,1
+11949,3,28130,1,55,Phindymian Breaker,203,75,7,1,3,1
+11950,3,28130,1,55,Phindymian Breaker,203,75,7,1,4,1
+11951,3,24505,1,35,Hauteclere,203,70,7,1,0,1
+11952,3,24505,1,35,Hauteclere,203,70,7,1,1,1
+11953,3,24505,1,35,Hauteclere,203,70,7,1,2,1
+11954,3,24505,1,35,Hauteclere,203,70,7,1,3,1
+11955,3,24505,1,35,Hauteclere,203,70,7,1,4,1
+11956,3,24505,1,40,Saw of Tyrant,203,70,7,1,0,1
+11957,3,24505,1,40,Saw of Tyrant,203,70,7,1,1,1
+11958,3,24505,1,40,Saw of Tyrant,203,70,7,1,2,1
+11959,3,24505,1,40,Saw of Tyrant,203,70,7,1,3,1
+11960,3,24505,1,40,Saw of Tyrant,203,70,7,1,4,1
+11961,3,24505,1,45,Gallant Figure,203,70,7,1,0,1
+11962,3,24505,1,45,Gallant Figure,203,70,7,1,1,1
+11963,3,24505,1,45,Gallant Figure,203,70,7,1,2,1
+11964,3,24505,1,45,Gallant Figure,203,70,7,1,3,1
+11965,3,24505,1,45,Gallant Figure,203,70,7,1,4,1
+11966,3,5000,1,50,Olfring Breaker (Black),203,1,7,4,0,1
+11967,3,5000,1,50,Olfring Breaker (Black),203,1,7,4,1,1
+11968,3,5000,1,50,Olfring Breaker (Black),203,1,7,4,2,1
+11969,3,5000,1,50,Olfring Breaker (Black),203,1,7,4,3,1
+11970,3,5000,1,50,Olfring Breaker (Black),203,1,7,4,4,1
 11975,3,5000,1,11,Olfring Breaker (Earth),203,1,7,0,4,1
 11976,3,5000,1,4,Olfring Breaker (Heaven),203,1,7,2,0,1
 11977,3,5000,1,4,Olfring Breaker (Heaven),203,1,7,2,1,1
@@ -6872,116 +6872,116 @@
 11979,3,5000,1,4,Olfring Breaker (Heaven),203,1,7,2,3,1
 11980,3,5000,1,4,Olfring Breaker (Heaven),203,1,7,2,4,1
 11985,3,5000,1,11,Olfring Breaker (Blue),203,1,7,4,4,1
-11986,3,5000,1,13,Olfring Breaker (Red),203,1,7,4,0,1
-11987,3,5000,1,13,Olfring Breaker (Red),203,1,7,4,1,1
-11988,3,5000,1,13,Olfring Breaker (Red),203,1,7,4,2,1
-11989,3,5000,1,13,Olfring Breaker (Red),203,1,7,4,3,1
-11990,3,5000,1,13,Olfring Breaker (Red),203,1,7,4,4,1
-11991,3,5000,1,13,Olfring Breaker (Green),203,1,7,4,0,1
-11992,3,5000,1,13,Olfring Breaker (Green),203,1,7,4,1,1
-11993,3,5000,1,13,Olfring Breaker (Green),203,1,7,4,2,1
-11994,3,5000,1,13,Olfring Breaker (Green),203,1,7,4,3,1
-11995,3,5000,1,13,Olfring Breaker (Green),203,1,7,4,4,1
+11986,3,5000,1,45,Olfring Breaker (Red),203,1,7,4,0,1
+11987,3,5000,1,45,Olfring Breaker (Red),203,1,7,4,1,1
+11988,3,5000,1,45,Olfring Breaker (Red),203,1,7,4,2,1
+11989,3,5000,1,45,Olfring Breaker (Red),203,1,7,4,3,1
+11990,3,5000,1,45,Olfring Breaker (Red),203,1,7,4,4,1
+11991,3,5000,1,45,Olfring Breaker (Green),203,1,7,4,0,1
+11992,3,5000,1,45,Olfring Breaker (Green),203,1,7,4,1,1
+11993,3,5000,1,45,Olfring Breaker (Green),203,1,7,4,2,1
+11994,3,5000,1,45,Olfring Breaker (Green),203,1,7,4,3,1
+11995,3,5000,1,45,Olfring Breaker (Green),203,1,7,4,4,1
 11996,3,15380,1,15,Protect Frame,204,62,5,1,0,1
 11997,3,15380,1,15,Protect Frame,204,62,5,1,1,1
 11998,3,15380,1,15,Protect Frame,204,62,5,1,2,1
 11999,3,15380,1,15,Protect Frame,204,62,5,1,3,1
 12000,3,15380,1,15,Protect Frame,204,62,5,1,4,1
-12001,3,16904,1,4,Scareface,204,65,5,1,0,1
-12002,3,16904,1,4,Scareface,204,65,5,1,1,1
-12003,3,16904,1,4,Scareface,204,65,5,1,2,1
-12004,3,16904,1,4,Scareface,204,65,5,1,3,1
-12005,3,16904,1,4,Scareface,204,65,5,1,4,1
-12006,3,16904,1,4,Savior Shrine,204,65,5,1,0,1
-12007,3,16904,1,4,Savior Shrine,204,65,5,1,1,1
-12008,3,16904,1,4,Savior Shrine,204,65,5,1,2,1
-12009,3,16904,1,4,Savior Shrine,204,65,5,1,3,1
-12010,3,16904,1,4,Savior Shrine,204,65,5,1,4,1
-12011,3,16904,1,9,Primera,204,65,5,1,0,1
-12012,3,16904,1,9,Primera,204,65,5,1,1,1
-12013,3,16904,1,9,Primera,204,65,5,1,2,1
-12014,3,16904,1,9,Primera,204,65,5,1,3,1
-12015,3,16904,1,9,Primera,204,65,5,1,4,1
-12016,3,16904,1,14,Scheinschild,204,65,5,1,0,1
-12017,3,16904,1,14,Scheinschild,204,65,5,1,1,1
-12018,3,16904,1,14,Scheinschild,204,65,5,1,2,1
-12019,3,16904,1,14,Scheinschild,204,65,5,1,3,1
-12020,3,16904,1,14,Scheinschild,204,65,5,1,4,1
-12026,3,17960,1,14,Holy Crest Tower Shield,204,67,5,1,0,1
-12027,3,17960,1,14,Holy Crest Tower Shield,204,67,5,1,1,1
-12028,3,17960,1,14,Holy Crest Tower Shield,204,67,5,1,2,1
-12029,3,17960,1,14,Holy Crest Tower Shield,204,67,5,1,3,1
-12030,3,17960,1,14,Holy Crest Tower Shield,204,67,5,1,4,1
-12031,3,19604,1,3,Angelic Protection,204,70,5,1,0,1
-12032,3,19604,1,3,Angelic Protection,204,70,5,1,1,1
-12033,3,19604,1,3,Angelic Protection,204,70,5,1,2,1
-12034,3,19604,1,3,Angelic Protection,204,70,5,1,3,1
-12035,3,19604,1,3,Angelic Protection,204,70,5,1,4,1
-12036,3,19604,1,3,Corpse's Groan,204,70,5,1,0,1
-12037,3,19604,1,3,Corpse's Groan,204,70,5,1,1,1
-12038,3,19604,1,3,Corpse's Groan,204,70,5,1,2,1
-12039,3,19604,1,3,Corpse's Groan,204,70,5,1,3,1
-12040,3,19604,1,3,Corpse's Groan,204,70,5,1,4,1
-12041,3,19604,1,8,Wall of Tyrant,204,70,5,1,0,1
-12042,3,19604,1,8,Wall of Tyrant,204,70,5,1,1,1
-12043,3,19604,1,8,Wall of Tyrant,204,70,5,1,2,1
-12044,3,19604,1,8,Wall of Tyrant,204,70,5,1,3,1
-12045,3,19604,1,8,Wall of Tyrant,204,70,5,1,4,1
-12046,3,19604,1,13,Immortal Glory,204,70,5,1,0,1
-12047,3,19604,1,13,Immortal Glory,204,70,5,1,1,1
-12048,3,19604,1,13,Immortal Glory,204,70,5,1,2,1
-12049,3,19604,1,13,Immortal Glory,204,70,5,1,3,1
-12050,3,19604,1,13,Immortal Glory,204,70,5,1,4,1
+12001,3,16904,1,20,Scareface,204,65,5,1,0,1
+12002,3,16904,1,20,Scareface,204,65,5,1,1,1
+12003,3,16904,1,20,Scareface,204,65,5,1,2,1
+12004,3,16904,1,20,Scareface,204,65,5,1,3,1
+12005,3,16904,1,20,Scareface,204,65,5,1,4,1
+12006,3,16904,1,20,Savior Shrine,204,65,5,1,0,1
+12007,3,16904,1,20,Savior Shrine,204,65,5,1,1,1
+12008,3,16904,1,20,Savior Shrine,204,65,5,1,2,1
+12009,3,16904,1,20,Savior Shrine,204,65,5,1,3,1
+12010,3,16904,1,20,Savior Shrine,204,65,5,1,4,1
+12011,3,16904,1,25,Primera,204,65,5,1,0,1
+12012,3,16904,1,25,Primera,204,65,5,1,1,1
+12013,3,16904,1,25,Primera,204,65,5,1,2,1
+12014,3,16904,1,25,Primera,204,65,5,1,3,1
+12015,3,16904,1,25,Primera,204,65,5,1,4,1
+12016,3,16904,1,30,Scheinschild,204,65,5,1,0,1
+12017,3,16904,1,30,Scheinschild,204,65,5,1,1,1
+12018,3,16904,1,30,Scheinschild,204,65,5,1,2,1
+12019,3,16904,1,30,Scheinschild,204,65,5,1,3,1
+12020,3,16904,1,30,Scheinschild,204,65,5,1,4,1
+12026,3,17960,1,30,Holy Crest Tower Shield,204,67,5,1,0,1
+12027,3,17960,1,30,Holy Crest Tower Shield,204,67,5,1,1,1
+12028,3,17960,1,30,Holy Crest Tower Shield,204,67,5,1,2,1
+12029,3,17960,1,30,Holy Crest Tower Shield,204,67,5,1,3,1
+12030,3,17960,1,30,Holy Crest Tower Shield,204,67,5,1,4,1
+12031,3,19604,1,35,Angelic Protection,204,70,5,1,0,1
+12032,3,19604,1,35,Angelic Protection,204,70,5,1,1,1
+12033,3,19604,1,35,Angelic Protection,204,70,5,1,2,1
+12034,3,19604,1,35,Angelic Protection,204,70,5,1,3,1
+12035,3,19604,1,35,Angelic Protection,204,70,5,1,4,1
+12036,3,19604,1,35,Corpse's Groan,204,70,5,1,0,1
+12037,3,19604,1,35,Corpse's Groan,204,70,5,1,1,1
+12038,3,19604,1,35,Corpse's Groan,204,70,5,1,2,1
+12039,3,19604,1,35,Corpse's Groan,204,70,5,1,3,1
+12040,3,19604,1,35,Corpse's Groan,204,70,5,1,4,1
+12041,3,19604,1,40,Wall of Tyrant,204,70,5,1,0,1
+12042,3,19604,1,40,Wall of Tyrant,204,70,5,1,1,1
+12043,3,19604,1,40,Wall of Tyrant,204,70,5,1,2,1
+12044,3,19604,1,40,Wall of Tyrant,204,70,5,1,3,1
+12045,3,19604,1,40,Wall of Tyrant,204,70,5,1,4,1
+12046,3,19604,1,45,Immortal Glory,204,70,5,1,0,1
+12047,3,19604,1,45,Immortal Glory,204,70,5,1,1,1
+12048,3,19604,1,45,Immortal Glory,204,70,5,1,2,1
+12049,3,19604,1,45,Immortal Glory,204,70,5,1,3,1
+12050,3,19604,1,45,Immortal Glory,204,70,5,1,4,1
 12086,3,19225,1,15,Shining Daggers,206,62,2,1,0,1
 12087,3,19225,1,15,Shining Daggers,206,62,2,1,1,1
 12088,3,19225,1,15,Shining Daggers,206,62,2,1,2,1
 12089,3,19225,1,15,Shining Daggers,206,62,2,1,3,1
 12090,3,19225,1,15,Shining Daggers,206,62,2,1,4,1
-12091,3,21130,1,4,Dussel Lizard,206,65,2,1,0,1
-12092,3,21130,1,4,Dussel Lizard,206,65,2,1,1,1
-12093,3,21130,1,4,Dussel Lizard,206,65,2,1,2,1
-12094,3,21130,1,4,Dussel Lizard,206,65,2,1,3,1
-12095,3,21130,1,4,Dussel Lizard,206,65,2,1,4,1
-12096,3,21130,1,4,Karsnaut,206,65,2,1,0,1
-12097,3,21130,1,4,Karsnaut,206,65,2,1,1,1
-12098,3,21130,1,4,Karsnaut,206,65,2,1,2,1
-12099,3,21130,1,4,Karsnaut,206,65,2,1,3,1
-12100,3,21130,1,4,Karsnaut,206,65,2,1,4,1
-12101,3,21130,1,9,Immersion,206,65,2,1,0,1
-12102,3,21130,1,9,Immersion,206,65,2,1,1,1
-12103,3,21130,1,9,Immersion,206,65,2,1,2,1
-12104,3,21130,1,9,Immersion,206,65,2,1,3,1
-12105,3,21130,1,9,Immersion,206,65,2,1,4,1
-12106,3,21130,1,14,White Wanderer,206,65,2,1,0,1
-12107,3,21130,1,14,White Wanderer,206,65,2,1,1,1
-12108,3,21130,1,14,White Wanderer,206,65,2,1,2,1
-12109,3,21130,1,14,White Wanderer,206,65,2,1,3,1
-12110,3,21130,1,14,White Wanderer,206,65,2,1,4,1
-12116,3,22450,1,14,Broad Edge,206,67,2,1,0,1
-12117,3,22450,1,14,Broad Edge,206,67,2,1,1,1
-12118,3,22450,1,14,Broad Edge,206,67,2,1,2,1
-12119,3,22450,1,14,Broad Edge,206,67,2,1,3,1
-12120,3,22450,1,14,Broad Edge,206,67,2,1,4,1
-12121,3,24505,1,3,Libertine's Blade,206,70,2,1,0,1
-12122,3,24505,1,3,Libertine's Blade,206,70,2,1,1,1
-12123,3,24505,1,3,Libertine's Blade,206,70,2,1,2,1
-12124,3,24505,1,3,Libertine's Blade,206,70,2,1,3,1
-12125,3,24505,1,3,Libertine's Blade,206,70,2,1,4,1
-12126,3,24505,1,3,Unify Feeling,206,70,2,1,0,1
-12127,3,24505,1,3,Unify Feeling,206,70,2,1,1,1
-12128,3,24505,1,3,Unify Feeling,206,70,2,1,2,1
-12129,3,24505,1,3,Unify Feeling,206,70,2,1,3,1
-12130,3,24505,1,3,Unify Feeling,206,70,2,1,4,1
-12131,3,24505,1,8,Blade of Tyrant,206,70,2,1,0,1
-12132,3,24505,1,8,Blade of Tyrant,206,70,2,1,1,1
-12133,3,24505,1,8,Blade of Tyrant,206,70,2,1,2,1
-12134,3,24505,1,8,Blade of Tyrant,206,70,2,1,3,1
-12135,3,24505,1,8,Blade of Tyrant,206,70,2,1,4,1
-12136,3,24505,1,13,Crisis Cleaver,206,70,2,1,0,1
-12137,3,24505,1,13,Crisis Cleaver,206,70,2,1,1,1
-12138,3,24505,1,13,Crisis Cleaver,206,70,2,1,2,1
-12139,3,24505,1,13,Crisis Cleaver,206,70,2,1,3,1
-12140,3,24505,1,13,Crisis Cleaver,206,70,2,1,4,1
+12091,3,21130,1,20,Dussel Lizard,206,65,2,1,0,1
+12092,3,21130,1,20,Dussel Lizard,206,65,2,1,1,1
+12093,3,21130,1,20,Dussel Lizard,206,65,2,1,2,1
+12094,3,21130,1,20,Dussel Lizard,206,65,2,1,3,1
+12095,3,21130,1,20,Dussel Lizard,206,65,2,1,4,1
+12096,3,21130,1,20,Karsnaut,206,65,2,1,0,1
+12097,3,21130,1,20,Karsnaut,206,65,2,1,1,1
+12098,3,21130,1,20,Karsnaut,206,65,2,1,2,1
+12099,3,21130,1,20,Karsnaut,206,65,2,1,3,1
+12100,3,21130,1,20,Karsnaut,206,65,2,1,4,1
+12101,3,21130,1,25,Immersion,206,65,2,1,0,1
+12102,3,21130,1,25,Immersion,206,65,2,1,1,1
+12103,3,21130,1,25,Immersion,206,65,2,1,2,1
+12104,3,21130,1,25,Immersion,206,65,2,1,3,1
+12105,3,21130,1,25,Immersion,206,65,2,1,4,1
+12106,3,21130,1,30,White Wanderer,206,65,2,1,0,1
+12107,3,21130,1,30,White Wanderer,206,65,2,1,1,1
+12108,3,21130,1,30,White Wanderer,206,65,2,1,2,1
+12109,3,21130,1,30,White Wanderer,206,65,2,1,3,1
+12110,3,21130,1,30,White Wanderer,206,65,2,1,4,1
+12116,3,22450,1,30,Broad Edge,206,67,2,1,0,1
+12117,3,22450,1,30,Broad Edge,206,67,2,1,1,1
+12118,3,22450,1,30,Broad Edge,206,67,2,1,2,1
+12119,3,22450,1,30,Broad Edge,206,67,2,1,3,1
+12120,3,22450,1,30,Broad Edge,206,67,2,1,4,1
+12121,3,24505,1,35,Libertine's Blade,206,70,2,1,0,1
+12122,3,24505,1,35,Libertine's Blade,206,70,2,1,1,1
+12123,3,24505,1,35,Libertine's Blade,206,70,2,1,2,1
+12124,3,24505,1,35,Libertine's Blade,206,70,2,1,3,1
+12125,3,24505,1,35,Libertine's Blade,206,70,2,1,4,1
+12126,3,24505,1,35,Unify Feeling,206,70,2,1,0,1
+12127,3,24505,1,35,Unify Feeling,206,70,2,1,1,1
+12128,3,24505,1,35,Unify Feeling,206,70,2,1,2,1
+12129,3,24505,1,35,Unify Feeling,206,70,2,1,3,1
+12130,3,24505,1,35,Unify Feeling,206,70,2,1,4,1
+12131,3,24505,1,40,Blade of Tyrant,206,70,2,1,0,1
+12132,3,24505,1,40,Blade of Tyrant,206,70,2,1,1,1
+12133,3,24505,1,40,Blade of Tyrant,206,70,2,1,2,1
+12134,3,24505,1,40,Blade of Tyrant,206,70,2,1,3,1
+12135,3,24505,1,40,Blade of Tyrant,206,70,2,1,4,1
+12136,3,24505,1,45,Crisis Cleaver,206,70,2,1,0,1
+12137,3,24505,1,45,Crisis Cleaver,206,70,2,1,1,1
+12138,3,24505,1,45,Crisis Cleaver,206,70,2,1,2,1
+12139,3,24505,1,45,Crisis Cleaver,206,70,2,1,3,1
+12140,3,24505,1,45,Crisis Cleaver,206,70,2,1,4,1
 12141,3,5000,1,11,Olfring Daggers (Black),206,1,2,3,0,1
 12142,3,5000,1,11,Olfring Daggers (Black),206,1,2,3,1,1
 12143,3,5000,1,11,Olfring Daggers (Black),206,1,2,3,2,1
@@ -7013,81 +7013,81 @@
 12173,3,19225,1,15,Elder's Hunter Bow,207,62,3,1,2,1
 12174,3,19225,1,15,Elder's Hunter Bow,207,62,3,1,3,1
 12175,3,19225,1,15,Elder's Hunter Bow,207,62,3,1,4,1
-12176,3,21130,1,4,Antique Bow,207,65,3,1,0,1
-12177,3,21130,1,4,Antique Bow,207,65,3,1,1,1
-12178,3,21130,1,4,Antique Bow,207,65,3,1,2,1
-12179,3,21130,1,4,Antique Bow,207,65,3,1,3,1
-12180,3,21130,1,4,Antique Bow,207,65,3,1,4,1
-12181,3,21130,1,4,Redfin,207,65,3,1,0,1
-12182,3,21130,1,4,Redfin,207,65,3,1,1,1
-12183,3,21130,1,4,Redfin,207,65,3,1,2,1
-12184,3,21130,1,4,Redfin,207,65,3,1,3,1
-12185,3,21130,1,4,Redfin,207,65,3,1,4,1
-12186,3,21130,1,9,Woge,207,65,3,1,0,1
-12187,3,21130,1,9,Woge,207,65,3,1,1,1
-12188,3,21130,1,9,Woge,207,65,3,1,2,1
-12189,3,21130,1,9,Woge,207,65,3,1,3,1
-12190,3,21130,1,9,Woge,207,65,3,1,4,1
-12191,3,21130,1,14,Savage Fang,207,65,3,1,0,1
-12192,3,21130,1,14,Savage Fang,207,65,3,1,1,1
-12193,3,21130,1,14,Savage Fang,207,65,3,1,2,1
-12194,3,21130,1,14,Savage Fang,207,65,3,1,3,1
-12195,3,21130,1,14,Savage Fang,207,65,3,1,4,1
-12201,3,22450,1,14,Sharpshooter,207,67,3,1,0,1
-12202,3,22450,1,14,Sharpshooter,207,67,3,1,1,1
-12203,3,22450,1,14,Sharpshooter,207,67,3,1,2,1
-12204,3,22450,1,14,Sharpshooter,207,67,3,1,3,1
-12205,3,22450,1,14,Sharpshooter,207,67,3,1,4,1
-12206,3,24505,1,3,Heavy Bow Archery,207,70,3,1,0,1
-12207,3,24505,1,3,Heavy Bow Archery,207,70,3,1,1,1
-12208,3,24505,1,3,Heavy Bow Archery,207,70,3,1,2,1
-12209,3,24505,1,3,Heavy Bow Archery,207,70,3,1,3,1
-12210,3,24505,1,3,Heavy Bow Archery,207,70,3,1,4,1
-12211,3,24505,1,3,Spirit Blink,207,70,3,1,0,1
-12212,3,24505,1,3,Spirit Blink,207,70,3,1,1,1
-12213,3,24505,1,3,Spirit Blink,207,70,3,1,2,1
-12214,3,24505,1,3,Spirit Blink,207,70,3,1,3,1
-12215,3,24505,1,3,Spirit Blink,207,70,3,1,4,1
-12216,3,24505,1,8,Bow of Tyrant,207,70,3,1,0,1
-12217,3,24505,1,8,Bow of Tyrant,207,70,3,1,1,1
-12218,3,24505,1,8,Bow of Tyrant,207,70,3,1,2,1
-12219,3,24505,1,8,Bow of Tyrant,207,70,3,1,3,1
-12220,3,24505,1,8,Bow of Tyrant,207,70,3,1,4,1
-12221,3,24505,1,13,Radiant String,207,70,3,1,0,1
-12222,3,24505,1,13,Radiant String,207,70,3,1,1,1
-12223,3,24505,1,13,Radiant String,207,70,3,1,2,1
-12224,3,24505,1,13,Radiant String,207,70,3,1,3,1
-12225,3,24505,1,13,Radiant String,207,70,3,1,4,1
-12236,3,21130,1,4,Regulus,208,65,9,1,0,1
-12237,3,21130,1,4,Regulus,208,65,9,1,1,1
-12238,3,21130,1,4,Regulus,208,65,9,1,2,1
-12239,3,21130,1,4,Regulus,208,65,9,1,3,1
-12240,3,21130,1,4,Regulus,208,65,9,1,4,1
-12241,3,21130,1,9,Fata Morgana,208,65,9,1,0,1
-12242,3,21130,1,9,Fata Morgana,208,65,9,1,1,1
-12243,3,21130,1,9,Fata Morgana,208,65,9,1,2,1
-12244,3,21130,1,9,Fata Morgana,208,65,9,1,3,1
-12245,3,21130,1,9,Fata Morgana,208,65,9,1,4,1
-12246,3,21130,1,14,Albus Lumen,208,65,9,1,0,1
-12247,3,21130,1,14,Albus Lumen,208,65,9,1,1,1
-12248,3,21130,1,14,Albus Lumen,208,65,9,1,2,1
-12249,3,21130,1,14,Albus Lumen,208,65,9,1,3,1
-12250,3,21130,1,14,Albus Lumen,208,65,9,1,4,1
-12266,3,24505,1,3,Incrementum,208,70,9,1,0,1
-12267,3,24505,1,3,Incrementum,208,70,9,1,1,1
-12268,3,24505,1,3,Incrementum,208,70,9,1,2,1
-12269,3,24505,1,3,Incrementum,208,70,9,1,3,1
-12270,3,24505,1,3,Incrementum,208,70,9,1,4,1
-12271,3,24505,1,8,Gauntlet of Tyrant,208,70,9,1,0,1
-12272,3,24505,1,8,Gauntlet of Tyrant,208,70,9,1,1,1
-12273,3,24505,1,8,Gauntlet of Tyrant,208,70,9,1,2,1
-12274,3,24505,1,8,Gauntlet of Tyrant,208,70,9,1,3,1
-12275,3,24505,1,8,Gauntlet of Tyrant,208,70,9,1,4,1
-12276,3,24505,1,13,Magna Dux,208,70,9,1,0,1
-12277,3,24505,1,13,Magna Dux,208,70,9,1,1,1
-12278,3,24505,1,13,Magna Dux,208,70,9,1,2,1
-12279,3,24505,1,13,Magna Dux,208,70,9,1,3,1
-12280,3,24505,1,13,Magna Dux,208,70,9,1,4,1
+12176,3,21130,1,20,Antique Bow,207,65,3,1,0,1
+12177,3,21130,1,20,Antique Bow,207,65,3,1,1,1
+12178,3,21130,1,20,Antique Bow,207,65,3,1,2,1
+12179,3,21130,1,20,Antique Bow,207,65,3,1,3,1
+12180,3,21130,1,20,Antique Bow,207,65,3,1,4,1
+12181,3,21130,1,20,Redfin,207,65,3,1,0,1
+12182,3,21130,1,20,Redfin,207,65,3,1,1,1
+12183,3,21130,1,20,Redfin,207,65,3,1,2,1
+12184,3,21130,1,20,Redfin,207,65,3,1,3,1
+12185,3,21130,1,20,Redfin,207,65,3,1,4,1
+12186,3,21130,1,25,Woge,207,65,3,1,0,1
+12187,3,21130,1,25,Woge,207,65,3,1,1,1
+12188,3,21130,1,25,Woge,207,65,3,1,2,1
+12189,3,21130,1,25,Woge,207,65,3,1,3,1
+12190,3,21130,1,25,Woge,207,65,3,1,4,1
+12191,3,21130,1,30,Savage Fang,207,65,3,1,0,1
+12192,3,21130,1,30,Savage Fang,207,65,3,1,1,1
+12193,3,21130,1,30,Savage Fang,207,65,3,1,2,1
+12194,3,21130,1,30,Savage Fang,207,65,3,1,3,1
+12195,3,21130,1,30,Savage Fang,207,65,3,1,4,1
+12201,3,22450,1,30,Sharpshooter,207,67,3,1,0,1
+12202,3,22450,1,30,Sharpshooter,207,67,3,1,1,1
+12203,3,22450,1,30,Sharpshooter,207,67,3,1,2,1
+12204,3,22450,1,30,Sharpshooter,207,67,3,1,3,1
+12205,3,22450,1,30,Sharpshooter,207,67,3,1,4,1
+12206,3,24505,1,35,Heavy Bow Archery,207,70,3,1,0,1
+12207,3,24505,1,35,Heavy Bow Archery,207,70,3,1,1,1
+12208,3,24505,1,35,Heavy Bow Archery,207,70,3,1,2,1
+12209,3,24505,1,35,Heavy Bow Archery,207,70,3,1,3,1
+12210,3,24505,1,35,Heavy Bow Archery,207,70,3,1,4,1
+12211,3,24505,1,35,Spirit Blink,207,70,3,1,0,1
+12212,3,24505,1,35,Spirit Blink,207,70,3,1,1,1
+12213,3,24505,1,35,Spirit Blink,207,70,3,1,2,1
+12214,3,24505,1,35,Spirit Blink,207,70,3,1,3,1
+12215,3,24505,1,35,Spirit Blink,207,70,3,1,4,1
+12216,3,24505,1,40,Bow of Tyrant,207,70,3,1,0,1
+12217,3,24505,1,40,Bow of Tyrant,207,70,3,1,1,1
+12218,3,24505,1,40,Bow of Tyrant,207,70,3,1,2,1
+12219,3,24505,1,40,Bow of Tyrant,207,70,3,1,3,1
+12220,3,24505,1,40,Bow of Tyrant,207,70,3,1,4,1
+12221,3,24505,1,45,Radiant String,207,70,3,1,0,1
+12222,3,24505,1,45,Radiant String,207,70,3,1,1,1
+12223,3,24505,1,45,Radiant String,207,70,3,1,2,1
+12224,3,24505,1,45,Radiant String,207,70,3,1,3,1
+12225,3,24505,1,45,Radiant String,207,70,3,1,4,1
+12236,3,21130,1,20,Regulus,208,65,9,1,0,1
+12237,3,21130,1,20,Regulus,208,65,9,1,1,1
+12238,3,21130,1,20,Regulus,208,65,9,1,2,1
+12239,3,21130,1,20,Regulus,208,65,9,1,3,1
+12240,3,21130,1,20,Regulus,208,65,9,1,4,1
+12241,3,21130,1,25,Fata Morgana,208,65,9,1,0,1
+12242,3,21130,1,25,Fata Morgana,208,65,9,1,1,1
+12243,3,21130,1,25,Fata Morgana,208,65,9,1,2,1
+12244,3,21130,1,25,Fata Morgana,208,65,9,1,3,1
+12245,3,21130,1,25,Fata Morgana,208,65,9,1,4,1
+12246,3,21130,1,30,Albus Lumen,208,65,9,1,0,1
+12247,3,21130,1,30,Albus Lumen,208,65,9,1,1,1
+12248,3,21130,1,30,Albus Lumen,208,65,9,1,2,1
+12249,3,21130,1,30,Albus Lumen,208,65,9,1,3,1
+12250,3,21130,1,30,Albus Lumen,208,65,9,1,4,1
+12266,3,24505,1,35,Incrementum,208,70,9,1,0,1
+12267,3,24505,1,35,Incrementum,208,70,9,1,1,1
+12268,3,24505,1,35,Incrementum,208,70,9,1,2,1
+12269,3,24505,1,35,Incrementum,208,70,9,1,3,1
+12270,3,24505,1,35,Incrementum,208,70,9,1,4,1
+12271,3,24505,1,40,Gauntlet of Tyrant,208,70,9,1,0,1
+12272,3,24505,1,40,Gauntlet of Tyrant,208,70,9,1,1,1
+12273,3,24505,1,40,Gauntlet of Tyrant,208,70,9,1,2,1
+12274,3,24505,1,40,Gauntlet of Tyrant,208,70,9,1,3,1
+12275,3,24505,1,40,Gauntlet of Tyrant,208,70,9,1,4,1
+12276,3,24505,1,45,Magna Dux,208,70,9,1,0,1
+12277,3,24505,1,45,Magna Dux,208,70,9,1,1,1
+12278,3,24505,1,45,Magna Dux,208,70,9,1,2,1
+12279,3,24505,1,45,Magna Dux,208,70,9,1,3,1
+12280,3,24505,1,45,Magna Dux,208,70,9,1,4,1
 12281,3,5000,1,10,Olfring Seiðr (Black),208,25,9,3,0,1
 12282,3,5000,1,10,Olfring Seiðr (Black),208,25,9,3,1,1
 12283,3,5000,1,10,Olfring Seiðr (Black),208,25,9,3,2,1
@@ -7113,73 +7113,73 @@
 12303,3,5000,1,9,Olfring Seiðr (Red),208,1,9,3,2,1
 12304,3,5000,1,9,Olfring Seiðr (Red),208,1,9,3,3,1
 12305,3,5000,1,9,Olfring Seiðr (Red),208,1,9,3,4,1
-12306,3,5000,1,13,Olfring Seiðr (Green),208,1,9,4,0,1
-12307,3,5000,1,13,Olfring Seiðr (Green),208,1,9,4,1,1
-12308,3,5000,1,13,Olfring Seiðr (Green),208,1,9,4,2,1
-12309,3,5000,1,13,Olfring Seiðr (Green),208,1,9,4,3,1
-12310,3,5000,1,13,Olfring Seiðr (Green),208,1,9,4,4,1
+12306,3,5000,1,45,Olfring Seiðr (Green),208,1,9,4,0,1
+12307,3,5000,1,45,Olfring Seiðr (Green),208,1,9,4,1,1
+12308,3,5000,1,45,Olfring Seiðr (Green),208,1,9,4,2,1
+12309,3,5000,1,45,Olfring Seiðr (Green),208,1,9,4,3,1
+12310,3,5000,1,45,Olfring Seiðr (Green),208,1,9,4,4,1
 12311,3,19225,1,15,Reines Herz,209,62,8,1,0,1
 12312,3,19225,1,15,Reines Herz,209,62,8,1,1,1
 12313,3,19225,1,15,Reines Herz,209,62,8,1,2,1
 12314,3,19225,1,15,Reines Herz,209,62,8,1,3,1
 12315,3,19225,1,15,Reines Herz,209,62,8,1,4,1
-12316,3,21130,1,4,Neumondlicht,209,65,8,1,0,1
-12317,3,21130,1,4,Neumondlicht,209,65,8,1,1,1
-12318,3,21130,1,4,Neumondlicht,209,65,8,1,2,1
-12319,3,21130,1,4,Neumondlicht,209,65,8,1,3,1
-12320,3,21130,1,4,Neumondlicht,209,65,8,1,4,1
-12321,3,21130,1,4,Skáld,209,65,8,1,0,1
-12322,3,21130,1,4,Skáld,209,65,8,1,1,1
-12323,3,21130,1,4,Skáld,209,65,8,1,2,1
-12324,3,21130,1,4,Skáld,209,65,8,1,3,1
-12325,3,21130,1,4,Skáld,209,65,8,1,4,1
-12326,3,21130,1,9,Vodovorot,209,65,8,1,0,1
-12327,3,21130,1,9,Vodovorot,209,65,8,1,1,1
-12328,3,21130,1,9,Vodovorot,209,65,8,1,2,1
-12329,3,21130,1,9,Vodovorot,209,65,8,1,3,1
-12330,3,21130,1,9,Vodovorot,209,65,8,1,4,1
-12331,3,21130,1,14,Bright Calling,209,65,8,1,0,1
-12332,3,21130,1,14,Bright Calling,209,65,8,1,1,1
-12333,3,21130,1,14,Bright Calling,209,65,8,1,2,1
-12334,3,21130,1,14,Bright Calling,209,65,8,1,3,1
-12335,3,21130,1,14,Bright Calling,209,65,8,1,4,1
-12341,3,22450,1,14,Zwei Geschichten,209,67,8,1,0,1
-12342,3,22450,1,14,Zwei Geschichten,209,67,8,1,1,1
-12343,3,22450,1,14,Zwei Geschichten,209,67,8,1,2,1
-12344,3,22450,1,14,Zwei Geschichten,209,67,8,1,3,1
-12345,3,22450,1,14,Zwei Geschichten,209,67,8,1,4,1
-12346,3,24505,1,3,Hávamál,209,70,8,1,0,1
-12347,3,24505,1,3,Hávamál,209,70,8,1,1,1
-12348,3,24505,1,3,Hávamál,209,70,8,1,2,1
-12349,3,24505,1,3,Hávamál,209,70,8,1,3,1
-12350,3,24505,1,3,Hávamál,209,70,8,1,4,1
-12351,3,24505,1,3,Angleichen,209,70,8,1,0,1
-12352,3,24505,1,3,Angleichen,209,70,8,1,1,1
-12353,3,24505,1,3,Angleichen,209,70,8,1,2,1
-12354,3,24505,1,3,Angleichen,209,70,8,1,3,1
-12355,3,24505,1,3,Angleichen,209,70,8,1,4,1
-12356,3,24505,1,8,Spell of Tyrant,209,70,8,1,0,1
-12357,3,24505,1,8,Spell of Tyrant,209,70,8,1,1,1
-12358,3,24505,1,8,Spell of Tyrant,209,70,8,1,2,1
-12359,3,24505,1,8,Spell of Tyrant,209,70,8,1,3,1
-12360,3,24505,1,8,Spell of Tyrant,209,70,8,1,4,1
-12361,3,24505,1,13,Religious Dragoon,209,70,8,1,0,1
-12362,3,24505,1,13,Religious Dragoon,209,70,8,1,1,1
-12363,3,24505,1,13,Religious Dragoon,209,70,8,1,2,1
-12364,3,24505,1,13,Religious Dragoon,209,70,8,1,3,1
-12365,3,24505,1,13,Religious Dragoon,209,70,8,1,4,1
-12366,3,5000,1,7,Olfring Shooter (Black),209,1,8,4,0,1
-12367,3,5000,1,7,Olfring Shooter (Black),209,1,8,4,1,1
-12368,3,5000,1,7,Olfring Shooter (Black),209,1,8,4,2,1
-12369,3,5000,1,7,Olfring Shooter (Black),209,1,8,4,3,1
-12370,3,5000,1,7,Olfring Shooter (Black),209,1,8,4,4,1
+12316,3,21130,1,20,Neumondlicht,209,65,8,1,0,1
+12317,3,21130,1,20,Neumondlicht,209,65,8,1,1,1
+12318,3,21130,1,20,Neumondlicht,209,65,8,1,2,1
+12319,3,21130,1,20,Neumondlicht,209,65,8,1,3,1
+12320,3,21130,1,20,Neumondlicht,209,65,8,1,4,1
+12321,3,21130,1,20,Skáld,209,65,8,1,0,1
+12322,3,21130,1,20,Skáld,209,65,8,1,1,1
+12323,3,21130,1,20,Skáld,209,65,8,1,2,1
+12324,3,21130,1,20,Skáld,209,65,8,1,3,1
+12325,3,21130,1,20,Skáld,209,65,8,1,4,1
+12326,3,21130,1,25,Vodovorot,209,65,8,1,0,1
+12327,3,21130,1,25,Vodovorot,209,65,8,1,1,1
+12328,3,21130,1,25,Vodovorot,209,65,8,1,2,1
+12329,3,21130,1,25,Vodovorot,209,65,8,1,3,1
+12330,3,21130,1,25,Vodovorot,209,65,8,1,4,1
+12331,3,21130,1,30,Bright Calling,209,65,8,1,0,1
+12332,3,21130,1,30,Bright Calling,209,65,8,1,1,1
+12333,3,21130,1,30,Bright Calling,209,65,8,1,2,1
+12334,3,21130,1,30,Bright Calling,209,65,8,1,3,1
+12335,3,21130,1,30,Bright Calling,209,65,8,1,4,1
+12341,3,22450,1,30,Zwei Geschichten,209,67,8,1,0,1
+12342,3,22450,1,30,Zwei Geschichten,209,67,8,1,1,1
+12343,3,22450,1,30,Zwei Geschichten,209,67,8,1,2,1
+12344,3,22450,1,30,Zwei Geschichten,209,67,8,1,3,1
+12345,3,22450,1,30,Zwei Geschichten,209,67,8,1,4,1
+12346,3,24505,1,35,Hávamál,209,70,8,1,0,1
+12347,3,24505,1,35,Hávamál,209,70,8,1,1,1
+12348,3,24505,1,35,Hávamál,209,70,8,1,2,1
+12349,3,24505,1,35,Hávamál,209,70,8,1,3,1
+12350,3,24505,1,35,Hávamál,209,70,8,1,4,1
+12351,3,24505,1,35,Angleichen,209,70,8,1,0,1
+12352,3,24505,1,35,Angleichen,209,70,8,1,1,1
+12353,3,24505,1,35,Angleichen,209,70,8,1,2,1
+12354,3,24505,1,35,Angleichen,209,70,8,1,3,1
+12355,3,24505,1,35,Angleichen,209,70,8,1,4,1
+12356,3,24505,1,40,Spell of Tyrant,209,70,8,1,0,1
+12357,3,24505,1,40,Spell of Tyrant,209,70,8,1,1,1
+12358,3,24505,1,40,Spell of Tyrant,209,70,8,1,2,1
+12359,3,24505,1,40,Spell of Tyrant,209,70,8,1,3,1
+12360,3,24505,1,40,Spell of Tyrant,209,70,8,1,4,1
+12361,3,24505,1,45,Religious Dragoon,209,70,8,1,0,1
+12362,3,24505,1,45,Religious Dragoon,209,70,8,1,1,1
+12363,3,24505,1,45,Religious Dragoon,209,70,8,1,2,1
+12364,3,24505,1,45,Religious Dragoon,209,70,8,1,3,1
+12365,3,24505,1,45,Religious Dragoon,209,70,8,1,4,1
+12366,3,5000,1,55,Olfring Shooter (Black),209,1,8,4,0,1
+12367,3,5000,1,55,Olfring Shooter (Black),209,1,8,4,1,1
+12368,3,5000,1,55,Olfring Shooter (Black),209,1,8,4,2,1
+12369,3,5000,1,55,Olfring Shooter (Black),209,1,8,4,3,1
+12370,3,5000,1,55,Olfring Shooter (Black),209,1,8,4,4,1
 12375,3,5000,1,11,Olfring Shooter (Earth),209,1,8,4,4,1
 12380,3,5000,1,11,Olfring Shooter (Heaven),209,1,8,4,4,1
-12381,3,5000,1,12,Olfring Shooter (Blue),209,1,8,4,0,1
-12382,3,5000,1,12,Olfring Shooter (Blue),209,1,8,4,1,1
-12383,3,5000,1,12,Olfring Shooter (Blue),209,1,8,4,2,1
-12384,3,5000,1,12,Olfring Shooter (Blue),209,1,8,4,3,1
-12385,3,5000,1,12,Olfring Shooter (Blue),209,1,8,4,4,1
+12381,3,5000,1,60,Olfring Shooter (Blue),209,1,8,4,0,1
+12382,3,5000,1,60,Olfring Shooter (Blue),209,1,8,4,1,1
+12383,3,5000,1,60,Olfring Shooter (Blue),209,1,8,4,2,1
+12384,3,5000,1,60,Olfring Shooter (Blue),209,1,8,4,3,1
+12385,3,5000,1,60,Olfring Shooter (Blue),209,1,8,4,4,1
 12386,3,5000,1,11,Olfring Shooter (Red),209,1,8,3,0,1
 12387,3,5000,1,11,Olfring Shooter (Red),209,1,8,3,1,1
 12388,3,5000,1,11,Olfring Shooter (Red),209,1,8,3,2,1
@@ -7195,106 +7195,106 @@
 12398,3,19225,1,15,Circle of Life,211,62,4,1,2,1
 12399,3,19225,1,15,Circle of Life,211,62,4,1,3,1
 12400,3,19225,1,15,Circle of Life,211,62,4,1,4,1
-12401,3,21130,1,4,Ambition,211,65,4,1,0,1
-12402,3,21130,1,4,Ambition,211,65,4,1,1,1
-12403,3,21130,1,4,Ambition,211,65,4,1,2,1
-12404,3,21130,1,4,Ambition,211,65,4,1,3,1
-12405,3,21130,1,4,Ambition,211,65,4,1,4,1
-12406,3,21130,1,4,Dawn of Wyvern,211,65,4,1,0,1
-12407,3,21130,1,4,Dawn of Wyvern,211,65,4,1,1,1
-12408,3,21130,1,4,Dawn of Wyvern,211,65,4,1,2,1
-12409,3,21130,1,4,Dawn of Wyvern,211,65,4,1,3,1
-12410,3,21130,1,4,Dawn of Wyvern,211,65,4,1,4,1
-12411,3,21130,1,9,Vortices,211,65,4,1,0,1
-12412,3,21130,1,9,Vortices,211,65,4,1,1,1
-12413,3,21130,1,9,Vortices,211,65,4,1,2,1
-12414,3,21130,1,9,Vortices,211,65,4,1,3,1
-12415,3,21130,1,9,Vortices,211,65,4,1,4,1
-12416,3,21130,1,14,White Glide,211,65,4,1,0,1
-12417,3,21130,1,14,White Glide,211,65,4,1,1,1
-12418,3,21130,1,14,White Glide,211,65,4,1,2,1
-12419,3,21130,1,14,White Glide,211,65,4,1,3,1
-12420,3,21130,1,14,White Glide,211,65,4,1,4,1
-12426,3,22450,1,14,Paled Heart,211,67,4,1,0,1
-12427,3,22450,1,14,Paled Heart,211,67,4,1,1,1
-12428,3,22450,1,14,Paled Heart,211,67,4,1,2,1
-12429,3,22450,1,14,Paled Heart,211,67,4,1,3,1
-12430,3,22450,1,14,Paled Heart,211,67,4,1,4,1
-12431,3,24505,1,3,Seeker's Staff,211,70,4,1,0,1
-12432,3,24505,1,3,Seeker's Staff,211,70,4,1,1,1
-12433,3,24505,1,3,Seeker's Staff,211,70,4,1,2,1
-12434,3,24505,1,3,Seeker's Staff,211,70,4,1,3,1
-12435,3,24505,1,3,Seeker's Staff,211,70,4,1,4,1
-12436,3,24505,1,3,Orient Charm,211,70,4,1,0,1
-12437,3,24505,1,3,Orient Charm,211,70,4,1,1,1
-12438,3,24505,1,3,Orient Charm,211,70,4,1,2,1
-12439,3,24505,1,3,Orient Charm,211,70,4,1,3,1
-12440,3,24505,1,3,Orient Charm,211,70,4,1,4,1
-12441,3,24505,1,8,Staff of Tyrant,211,70,4,1,0,1
-12442,3,24505,1,8,Staff of Tyrant,211,70,4,1,1,1
-12443,3,24505,1,8,Staff of Tyrant,211,70,4,1,2,1
-12444,3,24505,1,8,Staff of Tyrant,211,70,4,1,3,1
-12445,3,24505,1,8,Staff of Tyrant,211,70,4,1,4,1
-12446,3,24505,1,13,Reviving,211,70,4,1,0,1
-12447,3,24505,1,13,Reviving,211,70,4,1,1,1
-12448,3,24505,1,13,Reviving,211,70,4,1,2,1
-12449,3,24505,1,13,Reviving,211,70,4,1,3,1
-12450,3,24505,1,13,Reviving,211,70,4,1,4,1
+12401,3,21130,1,20,Ambition,211,65,4,1,0,1
+12402,3,21130,1,20,Ambition,211,65,4,1,1,1
+12403,3,21130,1,20,Ambition,211,65,4,1,2,1
+12404,3,21130,1,20,Ambition,211,65,4,1,3,1
+12405,3,21130,1,20,Ambition,211,65,4,1,4,1
+12406,3,21130,1,20,Dawn of Wyvern,211,65,4,1,0,1
+12407,3,21130,1,20,Dawn of Wyvern,211,65,4,1,1,1
+12408,3,21130,1,20,Dawn of Wyvern,211,65,4,1,2,1
+12409,3,21130,1,20,Dawn of Wyvern,211,65,4,1,3,1
+12410,3,21130,1,20,Dawn of Wyvern,211,65,4,1,4,1
+12411,3,21130,1,25,Vortices,211,65,4,1,0,1
+12412,3,21130,1,25,Vortices,211,65,4,1,1,1
+12413,3,21130,1,25,Vortices,211,65,4,1,2,1
+12414,3,21130,1,25,Vortices,211,65,4,1,3,1
+12415,3,21130,1,25,Vortices,211,65,4,1,4,1
+12416,3,21130,1,30,White Glide,211,65,4,1,0,1
+12417,3,21130,1,30,White Glide,211,65,4,1,1,1
+12418,3,21130,1,30,White Glide,211,65,4,1,2,1
+12419,3,21130,1,30,White Glide,211,65,4,1,3,1
+12420,3,21130,1,30,White Glide,211,65,4,1,4,1
+12426,3,22450,1,30,Paled Heart,211,67,4,1,0,1
+12427,3,22450,1,30,Paled Heart,211,67,4,1,1,1
+12428,3,22450,1,30,Paled Heart,211,67,4,1,2,1
+12429,3,22450,1,30,Paled Heart,211,67,4,1,3,1
+12430,3,22450,1,30,Paled Heart,211,67,4,1,4,1
+12431,3,24505,1,35,Seeker's Staff,211,70,4,1,0,1
+12432,3,24505,1,35,Seeker's Staff,211,70,4,1,1,1
+12433,3,24505,1,35,Seeker's Staff,211,70,4,1,2,1
+12434,3,24505,1,35,Seeker's Staff,211,70,4,1,3,1
+12435,3,24505,1,35,Seeker's Staff,211,70,4,1,4,1
+12436,3,24505,1,35,Orient Charm,211,70,4,1,0,1
+12437,3,24505,1,35,Orient Charm,211,70,4,1,1,1
+12438,3,24505,1,35,Orient Charm,211,70,4,1,2,1
+12439,3,24505,1,35,Orient Charm,211,70,4,1,3,1
+12440,3,24505,1,35,Orient Charm,211,70,4,1,4,1
+12441,3,24505,1,40,Staff of Tyrant,211,70,4,1,0,1
+12442,3,24505,1,40,Staff of Tyrant,211,70,4,1,1,1
+12443,3,24505,1,40,Staff of Tyrant,211,70,4,1,2,1
+12444,3,24505,1,40,Staff of Tyrant,211,70,4,1,3,1
+12445,3,24505,1,40,Staff of Tyrant,211,70,4,1,4,1
+12446,3,24505,1,45,Reviving,211,70,4,1,0,1
+12447,3,24505,1,45,Reviving,211,70,4,1,1,1
+12448,3,24505,1,45,Reviving,211,70,4,1,2,1
+12449,3,24505,1,45,Reviving,211,70,4,1,3,1
+12450,3,24505,1,45,Reviving,211,70,4,1,4,1
 12451,3,19225,1,15,Spectral Ivy,212,62,6,1,0,1
 12452,3,19225,1,15,Spectral Ivy,212,62,6,1,1,1
 12453,3,19225,1,15,Spectral Ivy,212,62,6,1,2,1
 12454,3,19225,1,15,Spectral Ivy,212,62,6,1,3,1
 12455,3,19225,1,15,Spectral Ivy,212,62,6,1,4,1
-12456,3,21130,1,4,Decayed Evil Eye,212,65,6,1,0,1
-12457,3,21130,1,4,Decayed Evil Eye,212,65,6,1,1,1
-12458,3,21130,1,4,Decayed Evil Eye,212,65,6,1,2,1
-12459,3,21130,1,4,Decayed Evil Eye,212,65,6,1,3,1
-12460,3,21130,1,4,Decayed Evil Eye,212,65,6,1,4,1
-12461,3,21130,1,4,Wand of Zeal,212,65,6,1,0,1
-12462,3,21130,1,4,Wand of Zeal,212,65,6,1,1,1
-12463,3,21130,1,4,Wand of Zeal,212,65,6,1,2,1
-12464,3,21130,1,4,Wand of Zeal,212,65,6,1,3,1
-12465,3,21130,1,4,Wand of Zeal,212,65,6,1,4,1
-12466,3,21130,1,9,Thyella,212,65,6,1,0,1
-12467,3,21130,1,9,Thyella,212,65,6,1,1,1
-12468,3,21130,1,9,Thyella,212,65,6,1,2,1
-12469,3,21130,1,9,Thyella,212,65,6,1,3,1
-12470,3,21130,1,9,Thyella,212,65,6,1,4,1
-12471,3,21130,1,14,White Wings,212,65,6,1,0,1
-12472,3,21130,1,14,White Wings,212,65,6,1,1,1
-12473,3,21130,1,14,White Wings,212,65,6,1,2,1
-12474,3,21130,1,14,White Wings,212,65,6,1,3,1
-12475,3,21130,1,14,White Wings,212,65,6,1,4,1
-12481,3,22450,1,14,Crying Goddess,212,67,6,1,0,1
-12482,3,22450,1,14,Crying Goddess,212,67,6,1,1,1
-12483,3,22450,1,14,Crying Goddess,212,67,6,1,2,1
-12484,3,22450,1,14,Crying Goddess,212,67,6,1,3,1
-12485,3,22450,1,14,Crying Goddess,212,67,6,1,4,1
-12486,3,24505,1,3,New Moon,212,70,6,1,0,1
-12487,3,24505,1,3,New Moon,212,70,6,1,1,1
-12488,3,24505,1,3,New Moon,212,70,6,1,2,1
-12489,3,24505,1,3,New Moon,212,70,6,1,3,1
-12490,3,24505,1,3,New Moon,212,70,6,1,4,1
-12491,3,24505,1,3,Loathsome Sign,212,70,6,1,0,1
-12492,3,24505,1,3,Loathsome Sign,212,70,6,1,1,1
-12493,3,24505,1,3,Loathsome Sign,212,70,6,1,2,1
-12494,3,24505,1,3,Loathsome Sign,212,70,6,1,3,1
-12495,3,24505,1,3,Loathsome Sign,212,70,6,1,4,1
-12496,3,24505,1,8,Wand of Tyrant,212,70,6,1,0,1
-12497,3,24505,1,8,Wand of Tyrant,212,70,6,1,1,1
-12498,3,24505,1,8,Wand of Tyrant,212,70,6,1,2,1
-12499,3,24505,1,8,Wand of Tyrant,212,70,6,1,3,1
-12500,3,24505,1,8,Wand of Tyrant,212,70,6,1,4,1
-12501,3,24505,1,13,Ataraxia,212,70,6,1,0,1
-12502,3,24505,1,13,Ataraxia,212,70,6,1,1,1
-12503,3,24505,1,13,Ataraxia,212,70,6,1,2,1
-12504,3,24505,1,13,Ataraxia,212,70,6,1,3,1
-12505,3,24505,1,13,Ataraxia,212,70,6,1,4,1
-12506,3,5000,1,12,Olfring Wand (Black),212,1,6,4,0,1
-12507,3,5000,1,12,Olfring Wand (Black),212,1,6,4,1,1
-12508,3,5000,1,12,Olfring Wand (Black),212,1,6,4,2,1
-12509,3,5000,1,12,Olfring Wand (Black),212,1,6,4,3,1
-12510,3,5000,1,12,Olfring Wand (Black),212,1,6,4,4,1
+12456,3,21130,1,20,Decayed Evil Eye,212,65,6,1,0,1
+12457,3,21130,1,20,Decayed Evil Eye,212,65,6,1,1,1
+12458,3,21130,1,20,Decayed Evil Eye,212,65,6,1,2,1
+12459,3,21130,1,20,Decayed Evil Eye,212,65,6,1,3,1
+12460,3,21130,1,20,Decayed Evil Eye,212,65,6,1,4,1
+12461,3,21130,1,20,Wand of Zeal,212,65,6,1,0,1
+12462,3,21130,1,20,Wand of Zeal,212,65,6,1,1,1
+12463,3,21130,1,20,Wand of Zeal,212,65,6,1,2,1
+12464,3,21130,1,20,Wand of Zeal,212,65,6,1,3,1
+12465,3,21130,1,20,Wand of Zeal,212,65,6,1,4,1
+12466,3,21130,1,25,Thyella,212,65,6,1,0,1
+12467,3,21130,1,25,Thyella,212,65,6,1,1,1
+12468,3,21130,1,25,Thyella,212,65,6,1,2,1
+12469,3,21130,1,25,Thyella,212,65,6,1,3,1
+12470,3,21130,1,25,Thyella,212,65,6,1,4,1
+12471,3,21130,1,30,White Wings,212,65,6,1,0,1
+12472,3,21130,1,30,White Wings,212,65,6,1,1,1
+12473,3,21130,1,30,White Wings,212,65,6,1,2,1
+12474,3,21130,1,30,White Wings,212,65,6,1,3,1
+12475,3,21130,1,30,White Wings,212,65,6,1,4,1
+12481,3,22450,1,30,Crying Goddess,212,67,6,1,0,1
+12482,3,22450,1,30,Crying Goddess,212,67,6,1,1,1
+12483,3,22450,1,30,Crying Goddess,212,67,6,1,2,1
+12484,3,22450,1,30,Crying Goddess,212,67,6,1,3,1
+12485,3,22450,1,30,Crying Goddess,212,67,6,1,4,1
+12486,3,24505,1,35,New Moon,212,70,6,1,0,1
+12487,3,24505,1,35,New Moon,212,70,6,1,1,1
+12488,3,24505,1,35,New Moon,212,70,6,1,2,1
+12489,3,24505,1,35,New Moon,212,70,6,1,3,1
+12490,3,24505,1,35,New Moon,212,70,6,1,4,1
+12491,3,24505,1,35,Loathsome Sign,212,70,6,1,0,1
+12492,3,24505,1,35,Loathsome Sign,212,70,6,1,1,1
+12493,3,24505,1,35,Loathsome Sign,212,70,6,1,2,1
+12494,3,24505,1,35,Loathsome Sign,212,70,6,1,3,1
+12495,3,24505,1,35,Loathsome Sign,212,70,6,1,4,1
+12496,3,24505,1,40,Wand of Tyrant,212,70,6,1,0,1
+12497,3,24505,1,40,Wand of Tyrant,212,70,6,1,1,1
+12498,3,24505,1,40,Wand of Tyrant,212,70,6,1,2,1
+12499,3,24505,1,40,Wand of Tyrant,212,70,6,1,3,1
+12500,3,24505,1,40,Wand of Tyrant,212,70,6,1,4,1
+12501,3,24505,1,45,Ataraxia,212,70,6,1,0,1
+12502,3,24505,1,45,Ataraxia,212,70,6,1,1,1
+12503,3,24505,1,45,Ataraxia,212,70,6,1,2,1
+12504,3,24505,1,45,Ataraxia,212,70,6,1,3,1
+12505,3,24505,1,45,Ataraxia,212,70,6,1,4,1
+12506,3,5000,1,60,Olfring Wand (Black),212,1,6,4,0,1
+12507,3,5000,1,60,Olfring Wand (Black),212,1,6,4,1,1
+12508,3,5000,1,60,Olfring Wand (Black),212,1,6,4,2,1
+12509,3,5000,1,60,Olfring Wand (Black),212,1,6,4,3,1
+12510,3,5000,1,60,Olfring Wand (Black),212,1,6,4,4,1
 12515,3,5000,1,11,Olfring Wand (Earth),212,1,6,4,4,1
 12516,3,5000,1,4,Olfring Wand (Heaven),212,1,6,2,0,1
 12517,3,5000,1,4,Olfring Wand (Heaven),212,1,6,2,1,1
@@ -7311,11 +7311,11 @@
 12528,3,5000,1,11,Olfring Wand (Red),212,1,6,3,2,1
 12529,3,5000,1,11,Olfring Wand (Red),212,1,6,3,3,1
 12530,3,5000,1,11,Olfring Wand (Red),212,1,6,3,4,1
-12531,3,5000,1,15,Olfring Wand (Green),212,1,6,4,0,1
-12532,3,5000,1,15,Olfring Wand (Green),212,1,6,4,1,1
-12533,3,5000,1,15,Olfring Wand (Green),212,1,6,4,2,1
-12534,3,5000,1,15,Olfring Wand (Green),212,1,6,4,3,1
-12535,3,5000,1,15,Olfring Wand (Green),212,1,6,4,4,1
+12531,3,5000,1,31,Olfring Wand (Green),212,1,6,4,0,1
+12532,3,5000,1,31,Olfring Wand (Green),212,1,6,4,1,1
+12533,3,5000,1,31,Olfring Wand (Green),212,1,6,4,2,1
+12534,3,5000,1,31,Olfring Wand (Green),212,1,6,4,3,1
+12535,3,5000,1,31,Olfring Wand (Green),212,1,6,4,4,1
 12785,3,12000,1,11,Cross Rapier of Warding Evil,201,45,1,4,4,1
 12786,3,12000,1,11,Solid Swing of Warding Evil,203,45,7,4,4,1
 12787,3,12000,1,11,Gazing Crow of Warding Evil,204,45,5,4,4,1
@@ -7324,544 +7324,544 @@
 12790,3,12000,1,11,Soul Rampage of Warding Evil,209,45,8,4,4,1
 12791,3,12000,1,11,Azure Closer of Warding Evil,211,45,4,4,4,1
 12792,3,12000,1,11,Twin Wisdom of Warding Evil,212,45,6,4,4,1
-13972,3,5000,1,6,Ceremonial Daggers (Heaven),201,1,1,4,0,1
-13973,3,5000,1,6,Ceremonial Daggers (Heaven),201,1,1,4,1,1
-13974,3,5000,1,6,Ceremonial Daggers (Heaven),201,1,1,4,2,1
-13975,3,5000,1,6,Ceremonial Daggers (Heaven),201,1,1,4,3,1
-13976,3,5000,1,6,Ceremonial Daggers (Heaven),201,1,1,4,4,1
-13977,3,5000,1,3,Ritual Sword [Heaven],201,1,1,4,0,1
-13978,3,5000,1,3,Ritual Sword [Heaven],201,1,1,4,1,1
-13979,3,5000,1,3,Ritual Sword [Heaven],201,1,1,4,2,1
-13980,3,5000,1,3,Ritual Sword [Heaven],201,1,1,4,3,1
-13981,3,5000,1,3,Ritual Sword [Heaven],201,1,1,4,4,1
-13992,3,5000,1,6,Ceremonial Bow (Earth),207,1,3,4,0,1
-13993,3,5000,1,6,Ceremonial Bow (Earth),207,1,3,4,1,1
-13994,3,5000,1,6,Ceremonial Bow (Earth),207,1,3,4,2,1
-13995,3,5000,1,6,Ceremonial Bow (Earth),207,1,3,4,3,1
-13996,3,5000,1,6,Ceremonial Bow (Earth),207,1,3,4,4,1
-13997,3,5000,1,3,Ritual Bow [Earth],207,1,3,4,0,1
-13998,3,5000,1,3,Ritual Bow [Earth],207,1,3,4,1,1
-13999,3,5000,1,3,Ritual Bow [Earth],207,1,3,4,2,1
-14000,3,5000,1,3,Ritual Bow [Earth],207,1,3,4,3,1
-14001,3,5000,1,3,Ritual Bow [Earth],207,1,3,4,4,1
-14002,3,5000,1,6,Ceremonial Guard (Red),204,1,5,4,0,1
-14003,3,5000,1,6,Ceremonial Guard (Red),204,1,5,4,1,1
-14004,3,5000,1,6,Ceremonial Guard (Red),204,1,5,4,2,1
-14005,3,5000,1,6,Ceremonial Guard (Red),204,1,5,4,3,1
-14006,3,5000,1,6,Ceremonial Guard (Red),204,1,5,4,4,1
-14007,3,5000,1,3,Ritual Guard [Crimson],204,1,5,4,0,1
-14008,3,5000,1,3,Ritual Guard [Crimson],204,1,5,4,1,1
-14009,3,5000,1,3,Ritual Guard [Crimson],204,1,5,4,2,1
-14010,3,5000,1,3,Ritual Guard [Crimson],204,1,5,4,3,1
-14011,3,5000,1,3,Ritual Guard [Crimson],204,1,5,4,4,1
-14023,3,20000,1,0,Salvation Sword,201,1,1,4,0,1
-14024,3,20000,1,0,Salvation Sword,201,1,1,4,1,1
-14025,3,20000,1,0,Salvation Sword,201,1,1,4,2,1
-14026,3,20000,1,0,Salvation Sword,201,1,1,4,3,1
-14027,3,20000,1,0,Salvation Sword,201,1,1,4,4,1
-14028,3,10000,1,9,Cinquedea of Heroes,201,55,1,4,4,1
-14029,3,20000,1,15,Obsidian Savior,201,1,1,4,0,1
-14030,3,20000,1,15,Obsidian Savior,201,1,1,4,1,1
-14031,3,20000,1,15,Obsidian Savior,201,1,1,4,2,1
-14032,3,20000,1,15,Obsidian Savior,201,1,1,4,3,1
-14033,3,20000,1,15,Obsidian Savior,201,1,1,4,4,1
-14034,3,20000,1,8,Wraith Sword of Legacy,201,60,1,4,4,1
-14045,3,20000,1,0,Salvation Blade,203,1,7,4,0,1
-14046,3,20000,1,0,Salvation Blade,203,1,7,4,1,1
-14047,3,20000,1,0,Salvation Blade,203,1,7,4,2,1
-14048,3,20000,1,0,Salvation Blade,203,1,7,4,3,1
-14049,3,20000,1,0,Salvation Blade,203,1,7,4,4,1
-14050,3,10000,1,9,Dynastes of Heroes,203,55,7,4,4,1
-14051,3,20000,1,15,Obsidian Blade,203,1,7,4,0,1
-14052,3,20000,1,15,Obsidian Blade,203,1,7,4,1,1
-14053,3,20000,1,15,Obsidian Blade,203,1,7,4,2,1
-14054,3,20000,1,15,Obsidian Blade,203,1,7,4,3,1
-14055,3,20000,1,15,Obsidian Blade,203,1,7,4,4,1
-14056,3,20000,1,8,Saving Sword of Legacy,203,60,7,4,4,1
-14057,3,20000,1,0,Salvation Guard,204,1,5,4,0,1
-14058,3,20000,1,0,Salvation Guard,204,1,5,4,1,1
-14059,3,20000,1,0,Salvation Guard,204,1,5,4,2,1
-14060,3,20000,1,0,Salvation Guard,204,1,5,4,3,1
-14061,3,20000,1,0,Salvation Guard,204,1,5,4,4,1
-14062,3,10000,1,9,Tower Shield of Heroes,204,55,5,4,4,1
-14063,3,20000,1,15,Obsidian Guard,204,1,5,4,0,1
-14064,3,20000,1,15,Obsidian Guard,204,1,5,4,1,1
-14065,3,20000,1,15,Obsidian Guard,204,1,5,4,2,1
-14066,3,20000,1,15,Obsidian Guard,204,1,5,4,3,1
-14067,3,20000,1,15,Obsidian Guard,204,1,5,4,4,1
-14068,3,20000,1,8,Hexagon Shield of Legacy,204,60,5,4,4,1
-14079,3,20000,1,0,Salvation Daggers,206,1,2,4,0,1
-14080,3,20000,1,0,Salvation Daggers,206,1,2,4,1,1
-14081,3,20000,1,0,Salvation Daggers,206,1,2,4,2,1
-14082,3,20000,1,0,Salvation Daggers,206,1,2,4,3,1
-14083,3,20000,1,0,Salvation Daggers,206,1,2,4,4,1
-14084,3,10000,1,9,Spear Daggers of Heroes,206,55,2,4,4,1
-14085,3,20000,1,15,Obsidian Daggers,206,1,2,4,0,1
-14086,3,20000,1,15,Obsidian Daggers,206,1,2,4,1,1
-14087,3,20000,1,15,Obsidian Daggers,206,1,2,4,2,1
-14088,3,20000,1,15,Obsidian Daggers,206,1,2,4,3,1
-14089,3,20000,1,15,Obsidian Daggers,206,1,2,4,4,1
-14090,3,20000,1,8,Writhing Daggers of Legacy,206,60,2,4,4,1
-14091,3,20000,1,0,Salvation Bow,207,1,3,4,0,1
-14092,3,20000,1,0,Salvation Bow,207,1,3,4,1,1
-14093,3,20000,1,0,Salvation Bow,207,1,3,4,2,1
-14094,3,20000,1,0,Salvation Bow,207,1,3,4,3,1
-14095,3,20000,1,0,Salvation Bow,207,1,3,4,4,1
-14096,3,10000,1,9,Sturdiness of Heroes,207,55,3,4,4,1
-14097,3,20000,1,15,Obsidian Bow,207,1,3,4,0,1
-14098,3,20000,1,15,Obsidian Bow,207,1,3,4,1,1
-14099,3,20000,1,15,Obsidian Bow,207,1,3,4,2,1
-14100,3,20000,1,15,Obsidian Bow,207,1,3,4,3,1
-14101,3,20000,1,15,Obsidian Bow,207,1,3,4,4,1
-14102,3,20000,1,8,Wing Bow of Legacy,207,60,3,4,4,1
-14103,3,20000,1,0,Salvation Gauntlet,208,1,9,4,0,1
-14104,3,20000,1,0,Salvation Gauntlet,208,1,9,4,1,1
-14105,3,20000,1,0,Salvation Gauntlet,208,1,9,4,2,1
-14106,3,20000,1,0,Salvation Gauntlet,208,1,9,4,3,1
-14107,3,20000,1,0,Salvation Gauntlet,208,1,9,4,4,1
-14108,3,10000,1,9,Dual Hands of Heroes,208,55,9,4,4,1
-14109,3,20000,1,15,Obsidian Gauntlet,208,1,9,4,0,1
-14110,3,20000,1,15,Obsidian Gauntlet,208,1,9,4,1,1
-14111,3,20000,1,15,Obsidian Gauntlet,208,1,9,4,2,1
-14112,3,20000,1,15,Obsidian Gauntlet,208,1,9,4,3,1
-14113,3,20000,1,15,Obsidian Gauntlet,208,1,9,4,4,1
-14114,3,20000,1,8,Covered Arm of Legacy,208,60,9,4,4,1
-14115,3,20000,1,0,Salvation Spell,209,1,8,4,0,1
-14116,3,20000,1,0,Salvation Spell,209,1,8,4,1,1
-14117,3,20000,1,0,Salvation Spell,209,1,8,4,2,1
-14118,3,20000,1,0,Salvation Spell,209,1,8,4,3,1
-14119,3,20000,1,0,Salvation Spell,209,1,8,4,4,1
-14120,3,10000,1,9,Sharp String of Heroes,209,55,8,4,4,1
-14121,3,20000,1,15,Obsidian Spell,209,1,8,4,0,1
-14122,3,20000,1,15,Obsidian Spell,209,1,8,4,1,1
-14123,3,20000,1,15,Obsidian Spell,209,1,8,4,2,1
-14124,3,20000,1,15,Obsidian Spell,209,1,8,4,3,1
-14125,3,20000,1,15,Obsidian Spell,209,1,8,4,4,1
-14126,3,20000,1,8,Twin Spell of Legacy,209,60,8,4,4,1
-14127,3,20000,1,0,Salvation Staff,211,1,4,4,0,1
-14128,3,20000,1,0,Salvation Staff,211,1,4,4,1,1
-14129,3,20000,1,0,Salvation Staff,211,1,4,4,2,1
-14130,3,20000,1,0,Salvation Staff,211,1,4,4,3,1
-14131,3,20000,1,0,Salvation Staff,211,1,4,4,4,1
-14132,3,10000,1,9,Corundum Cane of Heroes,211,55,4,4,4,1
-14133,3,20000,1,15,Obsidian Staff,211,1,4,4,0,1
-14134,3,20000,1,15,Obsidian Staff,211,1,4,4,1,1
-14135,3,20000,1,15,Obsidian Staff,211,1,4,4,2,1
-14136,3,20000,1,15,Obsidian Staff,211,1,4,4,3,1
-14137,3,20000,1,15,Obsidian Staff,211,1,4,4,4,1
-14138,3,20000,1,8,Tri-Caster of Legacy,211,60,4,4,4,1
-14139,3,20000,1,0,Salvation Wand,212,1,6,4,0,1
-14140,3,20000,1,0,Salvation Wand,212,1,6,4,1,1
-14141,3,20000,1,0,Salvation Wand,212,1,6,4,2,1
-14142,3,20000,1,0,Salvation Wand,212,1,6,4,3,1
-14143,3,20000,1,0,Salvation Wand,212,1,6,4,4,1
-14144,3,10000,1,9,Thought Wand of Heroes,212,55,6,4,4,1
-14145,3,20000,1,15,Obsidian Wand,212,1,6,4,0,1
-14146,3,20000,1,15,Obsidian Wand,212,1,6,4,1,1
-14147,3,20000,1,15,Obsidian Wand,212,1,6,4,2,1
-14148,3,20000,1,15,Obsidian Wand,212,1,6,4,3,1
-14149,3,20000,1,15,Obsidian Wand,212,1,6,4,4,1
-14150,3,20000,1,8,Heart Wand of Legacy,212,60,6,4,4,1
-14257,3,20740,1,13,Sword of Tribe,201,72,1,1,0,1
-14258,3,20740,1,13,Sword of Tribe,201,72,1,1,1,1
-14259,3,20740,1,13,Sword of Tribe,201,72,1,1,2,1
-14260,3,20740,1,13,Sword of Tribe,201,72,1,1,3,1
-14261,3,20740,1,13,Sword of Tribe,201,72,1,1,4,1
-14262,3,22504,1,2,Noble Jaggy,201,75,1,1,0,1
-14263,3,22504,1,2,Noble Jaggy,201,75,1,1,1,1
-14264,3,22504,1,2,Noble Jaggy,201,75,1,1,2,1
-14265,3,22504,1,2,Noble Jaggy,201,75,1,1,3,1
-14266,3,22504,1,2,Noble Jaggy,201,75,1,1,4,1
-14267,3,22504,1,2,Mace of Rain on Greenery,201,75,1,1,0,1
-14268,3,22504,1,2,Mace of Rain on Greenery,201,75,1,1,1,1
-14269,3,22504,1,2,Mace of Rain on Greenery,201,75,1,1,2,1
-14270,3,22504,1,2,Mace of Rain on Greenery,201,75,1,1,3,1
-14271,3,22504,1,2,Mace of Rain on Greenery,201,75,1,1,4,1
-14272,3,22504,1,7,Phindymian Sword,201,75,1,1,0,1
-14273,3,22504,1,7,Phindymian Sword,201,75,1,1,1,1
-14274,3,22504,1,7,Phindymian Sword,201,75,1,1,2,1
-14275,3,22504,1,7,Phindymian Sword,201,75,1,1,3,1
-14276,3,22504,1,7,Phindymian Sword,201,75,1,1,4,1
-14277,3,22504,1,12,Verdant Sharpness,201,75,1,1,0,1
-14278,3,22504,1,12,Verdant Sharpness,201,75,1,1,1,1
-14279,3,22504,1,12,Verdant Sharpness,201,75,1,1,2,1
-14280,3,22504,1,12,Verdant Sharpness,201,75,1,1,3,1
-14281,3,22504,1,12,Verdant Sharpness,201,75,1,1,4,1
-14282,3,23720,1,12,Fleeting Sword,201,77,1,1,0,1
-14283,3,23720,1,12,Fleeting Sword,201,77,1,1,1,1
-14284,3,23720,1,12,Fleeting Sword,201,77,1,1,2,1
-14285,3,23720,1,12,Fleeting Sword,201,77,1,1,3,1
-14286,3,23720,1,12,Fleeting Sword,201,77,1,1,4,1
-14287,3,25604,1,1,Captain's Fury,201,80,1,1,0,1
-14288,3,25604,1,1,Captain's Fury,201,80,1,1,1,1
-14289,3,25604,1,1,Captain's Fury,201,80,1,1,2,1
-14290,3,25604,1,1,Captain's Fury,201,80,1,1,3,1
-14291,3,25604,1,1,Captain's Fury,201,80,1,1,4,1
-14292,3,25604,1,1,Old Warpick,201,80,1,1,0,1
-14293,3,25604,1,1,Old Warpick,201,80,1,1,1,1
-14294,3,25604,1,1,Old Warpick,201,80,1,1,2,1
-14295,3,25604,1,1,Old Warpick,201,80,1,1,3,1
-14296,3,25604,1,1,Old Warpick,201,80,1,1,4,1
-14297,3,25604,1,6,Demon Slayer,201,80,1,1,0,1
-14298,3,25604,1,6,Demon Slayer,201,80,1,1,1,1
-14299,3,25604,1,6,Demon Slayer,201,80,1,1,2,1
-14300,3,25604,1,6,Demon Slayer,201,80,1,1,3,1
-14301,3,25604,1,6,Demon Slayer,201,80,1,1,4,1
-14302,3,25604,1,11,Nucleus,201,80,1,1,0,1
-14303,3,25604,1,11,Nucleus,201,80,1,1,1,1
-14304,3,25604,1,11,Nucleus,201,80,1,1,2,1
-14305,3,25604,1,11,Nucleus,201,80,1,1,3,1
-14306,3,25604,1,11,Nucleus,201,80,1,1,4,1
-14347,3,29650,1,12,Dynastes Horn,203,77,7,1,0,1
-14348,3,29650,1,12,Dynastes Horn,203,77,7,1,1,1
-14349,3,29650,1,12,Dynastes Horn,203,77,7,1,2,1
-14350,3,29650,1,12,Dynastes Horn,203,77,7,1,3,1
-14351,3,29650,1,12,Dynastes Horn,203,77,7,1,4,1
-14352,3,32005,1,1,Stout Lancer,203,80,7,1,0,1
-14353,3,32005,1,1,Stout Lancer,203,80,7,1,1,1
-14354,3,32005,1,1,Stout Lancer,203,80,7,1,2,1
-14355,3,32005,1,1,Stout Lancer,203,80,7,1,3,1
-14356,3,32005,1,1,Stout Lancer,203,80,7,1,4,1
-14357,3,32005,1,1,Behemoth's Hammer,203,80,7,1,0,1
-14358,3,32005,1,1,Behemoth's Hammer,203,80,7,1,1,1
-14359,3,32005,1,1,Behemoth's Hammer,203,80,7,1,2,1
-14360,3,32005,1,1,Behemoth's Hammer,203,80,7,1,3,1
-14361,3,32005,1,1,Behemoth's Hammer,203,80,7,1,4,1
-14362,3,32005,1,6,Destin Sword,203,80,7,1,0,1
-14363,3,32005,1,6,Destin Sword,203,80,7,1,1,1
-14364,3,32005,1,6,Destin Sword,203,80,7,1,2,1
-14365,3,32005,1,6,Destin Sword,203,80,7,1,3,1
-14366,3,32005,1,6,Destin Sword,203,80,7,1,4,1
-14367,3,32005,1,11,Cadré,203,80,7,1,0,1
-14368,3,32005,1,11,Cadré,203,80,7,1,1,1
-14369,3,32005,1,11,Cadré,203,80,7,1,2,1
-14370,3,32005,1,11,Cadré,203,80,7,1,3,1
-14371,3,32005,1,11,Cadré,203,80,7,1,4,1
-14372,3,20740,1,13,Wall of Tribe,204,72,5,1,0,1
-14373,3,20740,1,13,Wall of Tribe,204,72,5,1,1,1
-14374,3,20740,1,13,Wall of Tribe,204,72,5,1,2,1
-14375,3,20740,1,13,Wall of Tribe,204,72,5,1,3,1
-14376,3,20740,1,13,Wall of Tribe,204,72,5,1,4,1
-14377,3,22504,1,2,Old Wise Man,204,75,5,1,0,1
-14378,3,22504,1,2,Old Wise Man,204,75,5,1,1,1
-14379,3,22504,1,2,Old Wise Man,204,75,5,1,2,1
-14380,3,22504,1,2,Old Wise Man,204,75,5,1,3,1
-14381,3,22504,1,2,Old Wise Man,204,75,5,1,4,1
-14382,3,22504,1,2,Obstinance,204,75,5,1,0,1
-14383,3,22504,1,2,Obstinance,204,75,5,1,1,1
-14384,3,22504,1,2,Obstinance,204,75,5,1,2,1
-14385,3,22504,1,2,Obstinance,204,75,5,1,3,1
-14386,3,22504,1,2,Obstinance,204,75,5,1,4,1
-14387,3,22504,1,7,Phindymian Guard,204,75,5,1,0,1
-14388,3,22504,1,7,Phindymian Guard,204,75,5,1,1,1
-14389,3,22504,1,7,Phindymian Guard,204,75,5,1,2,1
-14390,3,22504,1,7,Phindymian Guard,204,75,5,1,3,1
-14391,3,22504,1,7,Phindymian Guard,204,75,5,1,4,1
-14392,3,22504,1,12,Verdant Wall,204,75,5,1,0,1
-14393,3,22504,1,12,Verdant Wall,204,75,5,1,1,1
-14394,3,22504,1,12,Verdant Wall,204,75,5,1,2,1
-14395,3,22504,1,12,Verdant Wall,204,75,5,1,3,1
-14396,3,22504,1,12,Verdant Wall,204,75,5,1,4,1
-14397,3,23720,1,12,Iron Coffin,204,77,5,1,0,1
-14398,3,23720,1,12,Iron Coffin,204,77,5,1,1,1
-14399,3,23720,1,12,Iron Coffin,204,77,5,1,2,1
-14400,3,23720,1,12,Iron Coffin,204,77,5,1,3,1
-14401,3,23720,1,12,Iron Coffin,204,77,5,1,4,1
-14402,3,25604,1,1,Fairy Fort,204,80,5,1,0,1
-14403,3,25604,1,1,Fairy Fort,204,80,5,1,1,1
-14404,3,25604,1,1,Fairy Fort,204,80,5,1,2,1
-14405,3,25604,1,1,Fairy Fort,204,80,5,1,3,1
-14406,3,25604,1,1,Fairy Fort,204,80,5,1,4,1
-14407,3,25604,1,1,Enshrine,204,80,5,1,0,1
-14408,3,25604,1,1,Enshrine,204,80,5,1,1,1
-14409,3,25604,1,1,Enshrine,204,80,5,1,2,1
-14410,3,25604,1,1,Enshrine,204,80,5,1,3,1
-14411,3,25604,1,1,Enshrine,204,80,5,1,4,1
-14412,3,25604,1,6,Diabolic Shield,204,80,5,1,0,1
-14413,3,25604,1,6,Diabolic Shield,204,80,5,1,1,1
-14414,3,25604,1,6,Diabolic Shield,204,80,5,1,2,1
-14415,3,25604,1,6,Diabolic Shield,204,80,5,1,3,1
-14416,3,25604,1,6,Diabolic Shield,204,80,5,1,4,1
-14417,3,25604,1,11,Inwardness,204,80,5,1,0,1
-14418,3,25604,1,11,Inwardness,204,80,5,1,1,1
-14419,3,25604,1,11,Inwardness,204,80,5,1,2,1
-14420,3,25604,1,11,Inwardness,204,80,5,1,3,1
-14421,3,25604,1,11,Inwardness,204,80,5,1,4,1
-14462,3,25925,1,13,Dagger of Tribe,206,72,2,1,0,1
-14463,3,25925,1,13,Dagger of Tribe,206,72,2,1,1,1
-14464,3,25925,1,13,Dagger of Tribe,206,72,2,1,2,1
-14465,3,25925,1,13,Dagger of Tribe,206,72,2,1,3,1
-14466,3,25925,1,13,Dagger of Tribe,206,72,2,1,4,1
-14467,3,28130,1,2,Protector's Spearheads,206,75,2,1,0,1
-14468,3,28130,1,2,Protector's Spearheads,206,75,2,1,1,1
-14469,3,28130,1,2,Protector's Spearheads,206,75,2,1,2,1
-14470,3,28130,1,2,Protector's Spearheads,206,75,2,1,3,1
-14471,3,28130,1,2,Protector's Spearheads,206,75,2,1,4,1
-14472,3,28130,1,2,Kris Naga Pulse,206,75,2,1,0,1
-14473,3,28130,1,2,Kris Naga Pulse,206,75,2,1,1,1
-14474,3,28130,1,2,Kris Naga Pulse,206,75,2,1,2,1
-14475,3,28130,1,2,Kris Naga Pulse,206,75,2,1,3,1
-14476,3,28130,1,2,Kris Naga Pulse,206,75,2,1,4,1
-14477,3,28130,1,7,Phindymian Daggers,206,75,2,1,0,1
-14478,3,28130,1,7,Phindymian Daggers,206,75,2,1,1,1
-14479,3,28130,1,7,Phindymian Daggers,206,75,2,1,2,1
-14480,3,28130,1,7,Phindymian Daggers,206,75,2,1,3,1
-14481,3,28130,1,7,Phindymian Daggers,206,75,2,1,4,1
-14482,3,28130,1,12,Verdant Fang,206,75,2,1,0,1
-14483,3,28130,1,12,Verdant Fang,206,75,2,1,1,1
-14484,3,28130,1,12,Verdant Fang,206,75,2,1,2,1
-14485,3,28130,1,12,Verdant Fang,206,75,2,1,3,1
-14486,3,28130,1,12,Verdant Fang,206,75,2,1,4,1
-14487,3,29650,1,12,Deep Ripper,206,77,2,1,0,1
-14488,3,29650,1,12,Deep Ripper,206,77,2,1,1,1
-14489,3,29650,1,12,Deep Ripper,206,77,2,1,2,1
-14490,3,29650,1,12,Deep Ripper,206,77,2,1,3,1
-14491,3,29650,1,12,Deep Ripper,206,77,2,1,4,1
-14492,3,32005,1,1,Underworld Triple Daggers,206,80,2,1,0,1
-14493,3,32005,1,1,Underworld Triple Daggers,206,80,2,1,1,1
-14494,3,32005,1,1,Underworld Triple Daggers,206,80,2,1,2,1
-14495,3,32005,1,1,Underworld Triple Daggers,206,80,2,1,3,1
-14496,3,32005,1,1,Underworld Triple Daggers,206,80,2,1,4,1
-14497,3,32005,1,1,Lizard's Glare,206,80,2,1,0,1
-14498,3,32005,1,1,Lizard's Glare,206,80,2,1,1,1
-14499,3,32005,1,1,Lizard's Glare,206,80,2,1,2,1
-14500,3,32005,1,1,Lizard's Glare,206,80,2,1,3,1
-14501,3,32005,1,1,Lizard's Glare,206,80,2,1,4,1
-14502,3,32005,1,6,Demon Framea,206,80,2,1,0,1
-14503,3,32005,1,6,Demon Framea,206,80,2,1,1,1
-14504,3,32005,1,6,Demon Framea,206,80,2,1,2,1
-14505,3,32005,1,6,Demon Framea,206,80,2,1,3,1
-14506,3,32005,1,6,Demon Framea,206,80,2,1,4,1
-14507,3,32005,1,11,The Colonel,206,80,2,1,0,1
-14508,3,32005,1,11,The Colonel,206,80,2,1,1,1
-14509,3,32005,1,11,The Colonel,206,80,2,1,2,1
-14510,3,32005,1,11,The Colonel,206,80,2,1,3,1
-14511,3,32005,1,11,The Colonel,206,80,2,1,4,1
-14512,3,25925,1,13,Bow of Tribe,207,72,3,1,0,1
-14513,3,25925,1,13,Bow of Tribe,207,72,3,1,1,1
-14514,3,25925,1,13,Bow of Tribe,207,72,3,1,2,1
-14515,3,25925,1,13,Bow of Tribe,207,72,3,1,3,1
-14516,3,25925,1,13,Bow of Tribe,207,72,3,1,4,1
-14517,3,28130,1,2,Abridged Bow,207,75,3,1,0,1
-14518,3,28130,1,2,Abridged Bow,207,75,3,1,1,1
-14519,3,28130,1,2,Abridged Bow,207,75,3,1,2,1
-14520,3,28130,1,2,Abridged Bow,207,75,3,1,3,1
-14521,3,28130,1,2,Abridged Bow,207,75,3,1,4,1
-14522,3,28130,1,2,Extension Bow,207,75,3,1,0,1
-14523,3,28130,1,2,Extension Bow,207,75,3,1,1,1
-14524,3,28130,1,2,Extension Bow,207,75,3,1,2,1
-14525,3,28130,1,2,Extension Bow,207,75,3,1,3,1
-14526,3,28130,1,2,Extension Bow,207,75,3,1,4,1
-14527,3,28130,1,7,Phindymian Bow,207,75,3,1,0,1
-14528,3,28130,1,7,Phindymian Bow,207,75,3,1,1,1
-14529,3,28130,1,7,Phindymian Bow,207,75,3,1,2,1
-14530,3,28130,1,7,Phindymian Bow,207,75,3,1,3,1
-14531,3,28130,1,7,Phindymian Bow,207,75,3,1,4,1
-14532,3,28130,1,12,Verdant Accuracy,207,75,3,1,0,1
-14533,3,28130,1,12,Verdant Accuracy,207,75,3,1,1,1
-14534,3,28130,1,12,Verdant Accuracy,207,75,3,1,2,1
-14535,3,28130,1,12,Verdant Accuracy,207,75,3,1,3,1
-14536,3,28130,1,12,Verdant Accuracy,207,75,3,1,4,1
-14537,3,29650,1,12,Loner's Strain,207,77,3,1,0,1
-14538,3,29650,1,12,Loner's Strain,207,77,3,1,1,1
-14539,3,29650,1,12,Loner's Strain,207,77,3,1,2,1
-14540,3,29650,1,12,Loner's Strain,207,77,3,1,3,1
-14541,3,29650,1,12,Loner's Strain,207,77,3,1,4,1
-14542,3,32005,1,1,Orthogenesis,207,80,3,1,0,1
-14543,3,32005,1,1,Orthogenesis,207,80,3,1,1,1
-14544,3,32005,1,1,Orthogenesis,207,80,3,1,2,1
-14545,3,32005,1,1,Orthogenesis,207,80,3,1,3,1
-14546,3,32005,1,1,Orthogenesis,207,80,3,1,4,1
-14547,3,32005,1,1,Twin Griffin,207,80,3,1,0,1
-14548,3,32005,1,1,Twin Griffin,207,80,3,1,1,1
-14549,3,32005,1,1,Twin Griffin,207,80,3,1,2,1
-14550,3,32005,1,1,Twin Griffin,207,80,3,1,3,1
-14551,3,32005,1,1,Twin Griffin,207,80,3,1,4,1
-14552,3,32005,1,6,Demon Horn,207,80,3,1,0,1
-14553,3,32005,1,6,Demon Horn,207,80,3,1,1,1
-14554,3,32005,1,6,Demon Horn,207,80,3,1,2,1
-14555,3,32005,1,6,Demon Horn,207,80,3,1,3,1
-14556,3,32005,1,6,Demon Horn,207,80,3,1,4,1
-14557,3,32005,1,11,Substance,207,80,3,1,0,1
-14558,3,32005,1,11,Substance,207,80,3,1,1,1
-14559,3,32005,1,11,Substance,207,80,3,1,2,1
-14560,3,32005,1,11,Substance,207,80,3,1,3,1
-14561,3,32005,1,11,Substance,207,80,3,1,4,1
-14562,3,25925,1,13,Gauntlet of Tribe,208,72,9,1,0,1
-14563,3,25925,1,13,Gauntlet of Tribe,208,72,9,1,1,1
-14564,3,25925,1,13,Gauntlet of Tribe,208,72,9,1,2,1
-14565,3,25925,1,13,Gauntlet of Tribe,208,72,9,1,3,1
-14566,3,25925,1,13,Gauntlet of Tribe,208,72,9,1,4,1
-14567,3,28130,1,7,Phindymian Seiðr,208,75,9,1,0,1
-14568,3,28130,1,7,Phindymian Seiðr,208,75,9,1,1,1
-14569,3,28130,1,7,Phindymian Seiðr,208,75,9,1,2,1
-14570,3,28130,1,7,Phindymian Seiðr,208,75,9,1,3,1
-14571,3,28130,1,7,Phindymian Seiðr,208,75,9,1,4,1
-14572,3,28130,1,12,Verdant Logician,208,75,9,1,0,1
-14573,3,28130,1,12,Verdant Logician,208,75,9,1,1,1
-14574,3,28130,1,12,Verdant Logician,208,75,9,1,2,1
-14575,3,28130,1,12,Verdant Logician,208,75,9,1,3,1
-14576,3,28130,1,12,Verdant Logician,208,75,9,1,4,1
-14577,3,32005,1,6,Brachium Diabolus,208,80,9,1,0,1
-14578,3,32005,1,6,Brachium Diabolus,208,80,9,1,1,1
-14579,3,32005,1,6,Brachium Diabolus,208,80,9,1,2,1
-14580,3,32005,1,6,Brachium Diabolus,208,80,9,1,3,1
-14581,3,32005,1,6,Brachium Diabolus,208,80,9,1,4,1
-14582,3,32005,1,11,Mesocaldia,208,80,9,1,0,1
-14583,3,32005,1,11,Mesocaldia,208,80,9,1,1,1
-14584,3,32005,1,11,Mesocaldia,208,80,9,1,2,1
-14585,3,32005,1,11,Mesocaldia,208,80,9,1,3,1
-14586,3,32005,1,11,Mesocaldia,208,80,9,1,4,1
-14587,3,25925,1,13,Spell of Tribe,209,72,8,1,0,1
-14588,3,25925,1,13,Spell of Tribe,209,72,8,1,1,1
-14589,3,25925,1,13,Spell of Tribe,209,72,8,1,2,1
-14590,3,25925,1,13,Spell of Tribe,209,72,8,1,3,1
-14591,3,25925,1,13,Spell of Tribe,209,72,8,1,4,1
-14592,3,28130,1,2,Tannhäuser,209,75,8,1,0,1
-14593,3,28130,1,2,Tannhäuser,209,75,8,1,1,1
-14594,3,28130,1,2,Tannhäuser,209,75,8,1,2,1
-14595,3,28130,1,2,Tannhäuser,209,75,8,1,3,1
-14596,3,28130,1,2,Tannhäuser,209,75,8,1,4,1
-14597,3,28130,1,2,Kenn-brecher of Thirst,209,75,8,1,0,1
-14598,3,28130,1,2,Kenn-brecher of Thirst,209,75,8,1,1,1
-14599,3,28130,1,2,Kenn-brecher of Thirst,209,75,8,1,2,1
-14600,3,28130,1,2,Kenn-brecher of Thirst,209,75,8,1,3,1
-14601,3,28130,1,2,Kenn-brecher of Thirst,209,75,8,1,4,1
-14602,3,28130,1,7,Phindymian Shooter,209,75,8,1,0,1
-14603,3,28130,1,7,Phindymian Shooter,209,75,8,1,1,1
-14604,3,28130,1,7,Phindymian Shooter,209,75,8,1,2,1
-14605,3,28130,1,7,Phindymian Shooter,209,75,8,1,3,1
-14606,3,28130,1,7,Phindymian Shooter,209,75,8,1,4,1
-14607,3,28130,1,12,Verdant Investor,209,75,8,1,0,1
-14608,3,28130,1,12,Verdant Investor,209,75,8,1,1,1
-14609,3,28130,1,12,Verdant Investor,209,75,8,1,2,1
-14610,3,28130,1,12,Verdant Investor,209,75,8,1,3,1
-14611,3,28130,1,12,Verdant Investor,209,75,8,1,4,1
-14612,3,29650,1,12,Gullinkambi,209,77,8,1,0,1
-14613,3,29650,1,12,Gullinkambi,209,77,8,1,1,1
-14614,3,29650,1,12,Gullinkambi,209,77,8,1,2,1
-14615,3,29650,1,12,Gullinkambi,209,77,8,1,3,1
-14616,3,29650,1,12,Gullinkambi,209,77,8,1,4,1
-14617,3,32005,1,1,Irrlicht,209,80,8,1,0,1
-14618,3,32005,1,1,Irrlicht,209,80,8,1,1,1
-14619,3,32005,1,1,Irrlicht,209,80,8,1,2,1
-14620,3,32005,1,1,Irrlicht,209,80,8,1,3,1
-14621,3,32005,1,1,Irrlicht,209,80,8,1,4,1
-14622,3,32005,1,1,Lightning Shape,209,80,8,1,0,1
-14623,3,32005,1,1,Lightning Shape,209,80,8,1,1,1
-14624,3,32005,1,1,Lightning Shape,209,80,8,1,2,1
-14625,3,32005,1,1,Lightning Shape,209,80,8,1,3,1
-14626,3,32005,1,1,Lightning Shape,209,80,8,1,4,1
-14627,3,32005,1,6,Demon Wing,209,80,8,1,0,1
-14628,3,32005,1,6,Demon Wing,209,80,8,1,1,1
-14629,3,32005,1,6,Demon Wing,209,80,8,1,2,1
-14630,3,32005,1,6,Demon Wing,209,80,8,1,3,1
-14631,3,32005,1,6,Demon Wing,209,80,8,1,4,1
-14632,3,32005,1,11,Axis,209,80,8,1,0,1
-14633,3,32005,1,11,Axis,209,80,8,1,1,1
-14634,3,32005,1,11,Axis,209,80,8,1,2,1
-14635,3,32005,1,11,Axis,209,80,8,1,3,1
-14636,3,32005,1,11,Axis,209,80,8,1,4,1
-14637,3,25925,1,13,Staff of Tribe,211,72,4,1,0,1
-14638,3,25925,1,13,Staff of Tribe,211,72,4,1,1,1
-14639,3,25925,1,13,Staff of Tribe,211,72,4,1,2,1
-14640,3,25925,1,13,Staff of Tribe,211,72,4,1,3,1
-14641,3,25925,1,13,Staff of Tribe,211,72,4,1,4,1
-14642,3,28130,1,2,Goblin's Worship,211,75,4,1,0,1
-14643,3,28130,1,2,Goblin's Worship,211,75,4,1,1,1
-14644,3,28130,1,2,Goblin's Worship,211,75,4,1,2,1
-14645,3,28130,1,2,Goblin's Worship,211,75,4,1,3,1
-14646,3,28130,1,2,Goblin's Worship,211,75,4,1,4,1
-14647,3,28130,1,2,Elderly Mentor,211,75,4,1,0,1
-14648,3,28130,1,2,Elderly Mentor,211,75,4,1,1,1
-14649,3,28130,1,2,Elderly Mentor,211,75,4,1,2,1
-14650,3,28130,1,2,Elderly Mentor,211,75,4,1,3,1
-14651,3,28130,1,2,Elderly Mentor,211,75,4,1,4,1
-14652,3,28130,1,7,Phindymian Cane,211,75,4,1,0,1
-14653,3,28130,1,7,Phindymian Cane,211,75,4,1,1,1
-14654,3,28130,1,7,Phindymian Cane,211,75,4,1,2,1
-14655,3,28130,1,7,Phindymian Cane,211,75,4,1,3,1
-14656,3,28130,1,7,Phindymian Cane,211,75,4,1,4,1
-14657,3,28130,1,12,Verdant Relief,211,75,4,1,0,1
-14658,3,28130,1,12,Verdant Relief,211,75,4,1,1,1
-14659,3,28130,1,12,Verdant Relief,211,75,4,1,2,1
-14660,3,28130,1,12,Verdant Relief,211,75,4,1,3,1
-14661,3,28130,1,12,Verdant Relief,211,75,4,1,4,1
-14662,3,29650,1,12,Petrified Staff,211,77,4,1,0,1
-14663,3,29650,1,12,Petrified Staff,211,77,4,1,1,1
-14664,3,29650,1,12,Petrified Staff,211,77,4,1,2,1
-14665,3,29650,1,12,Petrified Staff,211,77,4,1,3,1
-14666,3,29650,1,12,Petrified Staff,211,77,4,1,4,1
-14667,3,32005,1,1,Green Light's Nail Freed,211,80,4,1,0,1
-14668,3,32005,1,1,Green Light's Nail Freed,211,80,4,1,1,1
-14669,3,32005,1,1,Green Light's Nail Freed,211,80,4,1,2,1
-14670,3,32005,1,1,Green Light's Nail Freed,211,80,4,1,3,1
-14671,3,32005,1,1,Green Light's Nail Freed,211,80,4,1,4,1
-14672,3,32005,1,1,Symbiosis,211,80,4,1,0,1
-14673,3,32005,1,1,Symbiosis,211,80,4,1,1,1
-14674,3,32005,1,1,Symbiosis,211,80,4,1,2,1
-14675,3,32005,1,1,Symbiosis,211,80,4,1,3,1
-14676,3,32005,1,1,Symbiosis,211,80,4,1,4,1
-14677,3,32005,1,6,Dominating Claw,211,80,4,1,0,1
-14678,3,32005,1,6,Dominating Claw,211,80,4,1,1,1
-14679,3,32005,1,6,Dominating Claw,211,80,4,1,2,1
-14680,3,32005,1,6,Dominating Claw,211,80,4,1,3,1
-14681,3,32005,1,6,Dominating Claw,211,80,4,1,4,1
-14682,3,32005,1,11,Quintessence,211,80,4,1,0,1
-14683,3,32005,1,11,Quintessence,211,80,4,1,1,1
-14684,3,32005,1,11,Quintessence,211,80,4,1,2,1
-14685,3,32005,1,11,Quintessence,211,80,4,1,3,1
-14686,3,32005,1,11,Quintessence,211,80,4,1,4,1
-14687,3,25925,1,13,Wand of Tribe,212,72,6,1,0,1
-14688,3,25925,1,13,Wand of Tribe,212,72,6,1,1,1
-14689,3,25925,1,13,Wand of Tribe,212,72,6,1,2,1
-14690,3,25925,1,13,Wand of Tribe,212,72,6,1,3,1
-14691,3,25925,1,13,Wand of Tribe,212,72,6,1,4,1
-14692,3,28130,1,2,Zone of Liberty,212,75,6,1,0,1
-14693,3,28130,1,2,Zone of Liberty,212,75,6,1,1,1
-14694,3,28130,1,2,Zone of Liberty,212,75,6,1,2,1
-14695,3,28130,1,2,Zone of Liberty,212,75,6,1,3,1
-14696,3,28130,1,2,Zone of Liberty,212,75,6,1,4,1
-14697,3,28130,1,2,Divergence,212,75,6,1,0,1
-14698,3,28130,1,2,Divergence,212,75,6,1,1,1
-14699,3,28130,1,2,Divergence,212,75,6,1,2,1
-14700,3,28130,1,2,Divergence,212,75,6,1,3,1
-14701,3,28130,1,2,Divergence,212,75,6,1,4,1
-14702,3,28130,1,7,Phindymian Wand,212,75,6,1,0,1
-14703,3,28130,1,7,Phindymian Wand,212,75,6,1,1,1
-14704,3,28130,1,7,Phindymian Wand,212,75,6,1,2,1
-14705,3,28130,1,7,Phindymian Wand,212,75,6,1,3,1
-14706,3,28130,1,7,Phindymian Wand,212,75,6,1,4,1
-14707,3,28130,1,12,Verdant Ruin,212,75,6,1,0,1
-14708,3,28130,1,12,Verdant Ruin,212,75,6,1,1,1
-14709,3,28130,1,12,Verdant Ruin,212,75,6,1,2,1
-14710,3,28130,1,12,Verdant Ruin,212,75,6,1,3,1
-14711,3,28130,1,12,Verdant Ruin,212,75,6,1,4,1
-14712,3,29650,1,12,Warping Soul,212,77,6,1,0,1
-14713,3,29650,1,12,Warping Soul,212,77,6,1,1,1
-14714,3,29650,1,12,Warping Soul,212,77,6,1,2,1
-14715,3,29650,1,12,Warping Soul,212,77,6,1,3,1
-14716,3,29650,1,12,Warping Soul,212,77,6,1,4,1
-14717,3,32005,1,1,Fixed Heart,212,80,6,1,0,1
-14718,3,32005,1,1,Fixed Heart,212,80,6,1,1,1
-14719,3,32005,1,1,Fixed Heart,212,80,6,1,2,1
-14720,3,32005,1,1,Fixed Heart,212,80,6,1,3,1
-14721,3,32005,1,1,Fixed Heart,212,80,6,1,4,1
-14722,3,32005,1,1,Authority of Corona,212,80,6,1,0,1
-14723,3,32005,1,1,Authority of Corona,212,80,6,1,1,1
-14724,3,32005,1,1,Authority of Corona,212,80,6,1,2,1
-14725,3,32005,1,1,Authority of Corona,212,80,6,1,3,1
-14726,3,32005,1,1,Authority of Corona,212,80,6,1,4,1
-14727,3,32005,1,6,Black Scourge,212,80,6,1,0,1
-14728,3,32005,1,6,Black Scourge,212,80,6,1,1,1
-14729,3,32005,1,6,Black Scourge,212,80,6,1,2,1
-14730,3,32005,1,6,Black Scourge,212,80,6,1,3,1
-14731,3,32005,1,6,Black Scourge,212,80,6,1,4,1
-14732,3,32005,1,11,Sanctorum,212,80,6,1,0,1
-14733,3,32005,1,11,Sanctorum,212,80,6,1,1,1
-14734,3,32005,1,11,Sanctorum,212,80,6,1,2,1
-14735,3,32005,1,11,Sanctorum,212,80,6,1,3,1
-14736,3,32005,1,11,Sanctorum,212,80,6,1,4,1
+13972,3,5000,1,22,Ceremonial Daggers (Heaven),201,1,1,4,0,1
+13973,3,5000,1,22,Ceremonial Daggers (Heaven),201,1,1,4,1,1
+13974,3,5000,1,22,Ceremonial Daggers (Heaven),201,1,1,4,2,1
+13975,3,5000,1,22,Ceremonial Daggers (Heaven),201,1,1,4,3,1
+13976,3,5000,1,22,Ceremonial Daggers (Heaven),201,1,1,4,4,1
+13977,3,5000,1,35,Ritual Sword [Heaven],201,1,1,4,0,1
+13978,3,5000,1,35,Ritual Sword [Heaven],201,1,1,4,1,1
+13979,3,5000,1,35,Ritual Sword [Heaven],201,1,1,4,2,1
+13980,3,5000,1,35,Ritual Sword [Heaven],201,1,1,4,3,1
+13981,3,5000,1,35,Ritual Sword [Heaven],201,1,1,4,4,1
+13992,3,5000,1,22,Ceremonial Bow (Earth),207,1,3,4,0,1
+13993,3,5000,1,22,Ceremonial Bow (Earth),207,1,3,4,1,1
+13994,3,5000,1,22,Ceremonial Bow (Earth),207,1,3,4,2,1
+13995,3,5000,1,22,Ceremonial Bow (Earth),207,1,3,4,3,1
+13996,3,5000,1,22,Ceremonial Bow (Earth),207,1,3,4,4,1
+13997,3,5000,1,35,Ritual Bow [Earth],207,1,3,4,0,1
+13998,3,5000,1,35,Ritual Bow [Earth],207,1,3,4,1,1
+13999,3,5000,1,35,Ritual Bow [Earth],207,1,3,4,2,1
+14000,3,5000,1,35,Ritual Bow [Earth],207,1,3,4,3,1
+14001,3,5000,1,35,Ritual Bow [Earth],207,1,3,4,4,1
+14002,3,5000,1,22,Ceremonial Guard (Red),204,1,5,4,0,1
+14003,3,5000,1,22,Ceremonial Guard (Red),204,1,5,4,1,1
+14004,3,5000,1,22,Ceremonial Guard (Red),204,1,5,4,2,1
+14005,3,5000,1,22,Ceremonial Guard (Red),204,1,5,4,3,1
+14006,3,5000,1,22,Ceremonial Guard (Red),204,1,5,4,4,1
+14007,3,5000,1,35,Ritual Guard [Crimson],204,1,5,4,0,1
+14008,3,5000,1,35,Ritual Guard [Crimson],204,1,5,4,1,1
+14009,3,5000,1,35,Ritual Guard [Crimson],204,1,5,4,2,1
+14010,3,5000,1,35,Ritual Guard [Crimson],204,1,5,4,3,1
+14011,3,5000,1,35,Ritual Guard [Crimson],204,1,5,4,4,1
+14023,3,20000,1,16,Salvation Sword,201,1,1,4,0,1
+14024,3,20000,1,16,Salvation Sword,201,1,1,4,1,1
+14025,3,20000,1,16,Salvation Sword,201,1,1,4,2,1
+14026,3,20000,1,16,Salvation Sword,201,1,1,4,3,1
+14027,3,20000,1,16,Salvation Sword,201,1,1,4,4,1
+14028,3,10000,1,25,Cinquedea of Heroes,201,55,1,4,4,1
+14029,3,20000,1,31,Obsidian Savior,201,1,1,4,0,1
+14030,3,20000,1,31,Obsidian Savior,201,1,1,4,1,1
+14031,3,20000,1,31,Obsidian Savior,201,1,1,4,2,1
+14032,3,20000,1,31,Obsidian Savior,201,1,1,4,3,1
+14033,3,20000,1,31,Obsidian Savior,201,1,1,4,4,1
+14034,3,20000,1,40,Wraith Sword of Legacy,201,60,1,4,4,1
+14045,3,20000,1,16,Salvation Blade,203,1,7,4,0,1
+14046,3,20000,1,16,Salvation Blade,203,1,7,4,1,1
+14047,3,20000,1,16,Salvation Blade,203,1,7,4,2,1
+14048,3,20000,1,16,Salvation Blade,203,1,7,4,3,1
+14049,3,20000,1,16,Salvation Blade,203,1,7,4,4,1
+14050,3,10000,1,25,Dynastes of Heroes,203,55,7,4,4,1
+14051,3,20000,1,31,Obsidian Blade,203,1,7,4,0,1
+14052,3,20000,1,31,Obsidian Blade,203,1,7,4,1,1
+14053,3,20000,1,31,Obsidian Blade,203,1,7,4,2,1
+14054,3,20000,1,31,Obsidian Blade,203,1,7,4,3,1
+14055,3,20000,1,31,Obsidian Blade,203,1,7,4,4,1
+14056,3,20000,1,40,Saving Sword of Legacy,203,60,7,4,4,1
+14057,3,20000,1,16,Salvation Guard,204,1,5,4,0,1
+14058,3,20000,1,16,Salvation Guard,204,1,5,4,1,1
+14059,3,20000,1,16,Salvation Guard,204,1,5,4,2,1
+14060,3,20000,1,16,Salvation Guard,204,1,5,4,3,1
+14061,3,20000,1,16,Salvation Guard,204,1,5,4,4,1
+14062,3,10000,1,25,Tower Shield of Heroes,204,55,5,4,4,1
+14063,3,20000,1,31,Obsidian Guard,204,1,5,4,0,1
+14064,3,20000,1,31,Obsidian Guard,204,1,5,4,1,1
+14065,3,20000,1,31,Obsidian Guard,204,1,5,4,2,1
+14066,3,20000,1,31,Obsidian Guard,204,1,5,4,3,1
+14067,3,20000,1,31,Obsidian Guard,204,1,5,4,4,1
+14068,3,20000,1,40,Hexagon Shield of Legacy,204,60,5,4,4,1
+14079,3,20000,1,16,Salvation Daggers,206,1,2,4,0,1
+14080,3,20000,1,16,Salvation Daggers,206,1,2,4,1,1
+14081,3,20000,1,16,Salvation Daggers,206,1,2,4,2,1
+14082,3,20000,1,16,Salvation Daggers,206,1,2,4,3,1
+14083,3,20000,1,16,Salvation Daggers,206,1,2,4,4,1
+14084,3,10000,1,25,Spear Daggers of Heroes,206,55,2,4,4,1
+14085,3,20000,1,31,Obsidian Daggers,206,1,2,4,0,1
+14086,3,20000,1,31,Obsidian Daggers,206,1,2,4,1,1
+14087,3,20000,1,31,Obsidian Daggers,206,1,2,4,2,1
+14088,3,20000,1,31,Obsidian Daggers,206,1,2,4,3,1
+14089,3,20000,1,31,Obsidian Daggers,206,1,2,4,4,1
+14090,3,20000,1,40,Writhing Daggers of Legacy,206,60,2,4,4,1
+14091,3,20000,1,16,Salvation Bow,207,1,3,4,0,1
+14092,3,20000,1,16,Salvation Bow,207,1,3,4,1,1
+14093,3,20000,1,16,Salvation Bow,207,1,3,4,2,1
+14094,3,20000,1,16,Salvation Bow,207,1,3,4,3,1
+14095,3,20000,1,16,Salvation Bow,207,1,3,4,4,1
+14096,3,10000,1,25,Sturdiness of Heroes,207,55,3,4,4,1
+14097,3,20000,1,31,Obsidian Bow,207,1,3,4,0,1
+14098,3,20000,1,31,Obsidian Bow,207,1,3,4,1,1
+14099,3,20000,1,31,Obsidian Bow,207,1,3,4,2,1
+14100,3,20000,1,31,Obsidian Bow,207,1,3,4,3,1
+14101,3,20000,1,31,Obsidian Bow,207,1,3,4,4,1
+14102,3,20000,1,40,Wing Bow of Legacy,207,60,3,4,4,1
+14103,3,20000,1,16,Salvation Gauntlet,208,1,9,4,0,1
+14104,3,20000,1,16,Salvation Gauntlet,208,1,9,4,1,1
+14105,3,20000,1,16,Salvation Gauntlet,208,1,9,4,2,1
+14106,3,20000,1,16,Salvation Gauntlet,208,1,9,4,3,1
+14107,3,20000,1,16,Salvation Gauntlet,208,1,9,4,4,1
+14108,3,10000,1,25,Dual Hands of Heroes,208,55,9,4,4,1
+14109,3,20000,1,31,Obsidian Gauntlet,208,1,9,4,0,1
+14110,3,20000,1,31,Obsidian Gauntlet,208,1,9,4,1,1
+14111,3,20000,1,31,Obsidian Gauntlet,208,1,9,4,2,1
+14112,3,20000,1,31,Obsidian Gauntlet,208,1,9,4,3,1
+14113,3,20000,1,31,Obsidian Gauntlet,208,1,9,4,4,1
+14114,3,20000,1,40,Covered Arm of Legacy,208,60,9,4,4,1
+14115,3,20000,1,16,Salvation Spell,209,1,8,4,0,1
+14116,3,20000,1,16,Salvation Spell,209,1,8,4,1,1
+14117,3,20000,1,16,Salvation Spell,209,1,8,4,2,1
+14118,3,20000,1,16,Salvation Spell,209,1,8,4,3,1
+14119,3,20000,1,16,Salvation Spell,209,1,8,4,4,1
+14120,3,10000,1,25,Sharp String of Heroes,209,55,8,4,4,1
+14121,3,20000,1,31,Obsidian Spell,209,1,8,4,0,1
+14122,3,20000,1,31,Obsidian Spell,209,1,8,4,1,1
+14123,3,20000,1,31,Obsidian Spell,209,1,8,4,2,1
+14124,3,20000,1,31,Obsidian Spell,209,1,8,4,3,1
+14125,3,20000,1,31,Obsidian Spell,209,1,8,4,4,1
+14126,3,20000,1,40,Twin Spell of Legacy,209,60,8,4,4,1
+14127,3,20000,1,16,Salvation Staff,211,1,4,4,0,1
+14128,3,20000,1,16,Salvation Staff,211,1,4,4,1,1
+14129,3,20000,1,16,Salvation Staff,211,1,4,4,2,1
+14130,3,20000,1,16,Salvation Staff,211,1,4,4,3,1
+14131,3,20000,1,16,Salvation Staff,211,1,4,4,4,1
+14132,3,10000,1,25,Corundum Cane of Heroes,211,55,4,4,4,1
+14133,3,20000,1,31,Obsidian Staff,211,1,4,4,0,1
+14134,3,20000,1,31,Obsidian Staff,211,1,4,4,1,1
+14135,3,20000,1,31,Obsidian Staff,211,1,4,4,2,1
+14136,3,20000,1,31,Obsidian Staff,211,1,4,4,3,1
+14137,3,20000,1,31,Obsidian Staff,211,1,4,4,4,1
+14138,3,20000,1,40,Tri-Caster of Legacy,211,60,4,4,4,1
+14139,3,20000,1,16,Salvation Wand,212,1,6,4,0,1
+14140,3,20000,1,16,Salvation Wand,212,1,6,4,1,1
+14141,3,20000,1,16,Salvation Wand,212,1,6,4,2,1
+14142,3,20000,1,16,Salvation Wand,212,1,6,4,3,1
+14143,3,20000,1,16,Salvation Wand,212,1,6,4,4,1
+14144,3,10000,1,25,Thought Wand of Heroes,212,55,6,4,4,1
+14145,3,20000,1,31,Obsidian Wand,212,1,6,4,0,1
+14146,3,20000,1,31,Obsidian Wand,212,1,6,4,1,1
+14147,3,20000,1,31,Obsidian Wand,212,1,6,4,2,1
+14148,3,20000,1,31,Obsidian Wand,212,1,6,4,3,1
+14149,3,20000,1,31,Obsidian Wand,212,1,6,4,4,1
+14150,3,20000,1,40,Heart Wand of Legacy,212,60,6,4,4,1
+14257,3,20740,1,45,Sword of Tribe,201,72,1,1,0,1
+14258,3,20740,1,45,Sword of Tribe,201,72,1,1,1,1
+14259,3,20740,1,45,Sword of Tribe,201,72,1,1,2,1
+14260,3,20740,1,45,Sword of Tribe,201,72,1,1,3,1
+14261,3,20740,1,45,Sword of Tribe,201,72,1,1,4,1
+14262,3,22504,1,50,Noble Jaggy,201,75,1,1,0,1
+14263,3,22504,1,50,Noble Jaggy,201,75,1,1,1,1
+14264,3,22504,1,50,Noble Jaggy,201,75,1,1,2,1
+14265,3,22504,1,50,Noble Jaggy,201,75,1,1,3,1
+14266,3,22504,1,50,Noble Jaggy,201,75,1,1,4,1
+14267,3,22504,1,50,Mace of Rain on Greenery,201,75,1,1,0,1
+14268,3,22504,1,50,Mace of Rain on Greenery,201,75,1,1,1,1
+14269,3,22504,1,50,Mace of Rain on Greenery,201,75,1,1,2,1
+14270,3,22504,1,50,Mace of Rain on Greenery,201,75,1,1,3,1
+14271,3,22504,1,50,Mace of Rain on Greenery,201,75,1,1,4,1
+14272,3,22504,1,55,Phindymian Sword,201,75,1,1,0,1
+14273,3,22504,1,55,Phindymian Sword,201,75,1,1,1,1
+14274,3,22504,1,55,Phindymian Sword,201,75,1,1,2,1
+14275,3,22504,1,55,Phindymian Sword,201,75,1,1,3,1
+14276,3,22504,1,55,Phindymian Sword,201,75,1,1,4,1
+14277,3,22504,1,60,Verdant Sharpness,201,75,1,1,0,1
+14278,3,22504,1,60,Verdant Sharpness,201,75,1,1,1,1
+14279,3,22504,1,60,Verdant Sharpness,201,75,1,1,2,1
+14280,3,22504,1,60,Verdant Sharpness,201,75,1,1,3,1
+14281,3,22504,1,60,Verdant Sharpness,201,75,1,1,4,1
+14282,3,23720,1,60,Fleeting Sword,201,77,1,1,0,1
+14283,3,23720,1,60,Fleeting Sword,201,77,1,1,1,1
+14284,3,23720,1,60,Fleeting Sword,201,77,1,1,2,1
+14285,3,23720,1,60,Fleeting Sword,201,77,1,1,3,1
+14286,3,23720,1,60,Fleeting Sword,201,77,1,1,4,1
+14287,3,25604,1,65,Captain's Fury,201,80,1,1,0,1
+14288,3,25604,1,65,Captain's Fury,201,80,1,1,1,1
+14289,3,25604,1,65,Captain's Fury,201,80,1,1,2,1
+14290,3,25604,1,65,Captain's Fury,201,80,1,1,3,1
+14291,3,25604,1,65,Captain's Fury,201,80,1,1,4,1
+14292,3,25604,1,65,Old Warpick,201,80,1,1,0,1
+14293,3,25604,1,65,Old Warpick,201,80,1,1,1,1
+14294,3,25604,1,65,Old Warpick,201,80,1,1,2,1
+14295,3,25604,1,65,Old Warpick,201,80,1,1,3,1
+14296,3,25604,1,65,Old Warpick,201,80,1,1,4,1
+14297,3,25604,1,70,Demon Slayer,201,80,1,1,0,1
+14298,3,25604,1,70,Demon Slayer,201,80,1,1,1,1
+14299,3,25604,1,70,Demon Slayer,201,80,1,1,2,1
+14300,3,25604,1,70,Demon Slayer,201,80,1,1,3,1
+14301,3,25604,1,70,Demon Slayer,201,80,1,1,4,1
+14302,3,25604,1,75,Nucleus,201,80,1,1,0,1
+14303,3,25604,1,75,Nucleus,201,80,1,1,1,1
+14304,3,25604,1,75,Nucleus,201,80,1,1,2,1
+14305,3,25604,1,75,Nucleus,201,80,1,1,3,1
+14306,3,25604,1,75,Nucleus,201,80,1,1,4,1
+14347,3,29650,1,60,Dynastes Horn,203,77,7,1,0,1
+14348,3,29650,1,60,Dynastes Horn,203,77,7,1,1,1
+14349,3,29650,1,60,Dynastes Horn,203,77,7,1,2,1
+14350,3,29650,1,60,Dynastes Horn,203,77,7,1,3,1
+14351,3,29650,1,60,Dynastes Horn,203,77,7,1,4,1
+14352,3,32005,1,65,Stout Lancer,203,80,7,1,0,1
+14353,3,32005,1,65,Stout Lancer,203,80,7,1,1,1
+14354,3,32005,1,65,Stout Lancer,203,80,7,1,2,1
+14355,3,32005,1,65,Stout Lancer,203,80,7,1,3,1
+14356,3,32005,1,65,Stout Lancer,203,80,7,1,4,1
+14357,3,32005,1,65,Behemoth's Hammer,203,80,7,1,0,1
+14358,3,32005,1,65,Behemoth's Hammer,203,80,7,1,1,1
+14359,3,32005,1,65,Behemoth's Hammer,203,80,7,1,2,1
+14360,3,32005,1,65,Behemoth's Hammer,203,80,7,1,3,1
+14361,3,32005,1,65,Behemoth's Hammer,203,80,7,1,4,1
+14362,3,32005,1,70,Destin Sword,203,80,7,1,0,1
+14363,3,32005,1,70,Destin Sword,203,80,7,1,1,1
+14364,3,32005,1,70,Destin Sword,203,80,7,1,2,1
+14365,3,32005,1,70,Destin Sword,203,80,7,1,3,1
+14366,3,32005,1,70,Destin Sword,203,80,7,1,4,1
+14367,3,32005,1,75,Cadré,203,80,7,1,0,1
+14368,3,32005,1,75,Cadré,203,80,7,1,1,1
+14369,3,32005,1,75,Cadré,203,80,7,1,2,1
+14370,3,32005,1,75,Cadré,203,80,7,1,3,1
+14371,3,32005,1,75,Cadré,203,80,7,1,4,1
+14372,3,20740,1,45,Wall of Tribe,204,72,5,1,0,1
+14373,3,20740,1,45,Wall of Tribe,204,72,5,1,1,1
+14374,3,20740,1,45,Wall of Tribe,204,72,5,1,2,1
+14375,3,20740,1,45,Wall of Tribe,204,72,5,1,3,1
+14376,3,20740,1,45,Wall of Tribe,204,72,5,1,4,1
+14377,3,22504,1,50,Old Wise Man,204,75,5,1,0,1
+14378,3,22504,1,50,Old Wise Man,204,75,5,1,1,1
+14379,3,22504,1,50,Old Wise Man,204,75,5,1,2,1
+14380,3,22504,1,50,Old Wise Man,204,75,5,1,3,1
+14381,3,22504,1,50,Old Wise Man,204,75,5,1,4,1
+14382,3,22504,1,50,Obstinance,204,75,5,1,0,1
+14383,3,22504,1,50,Obstinance,204,75,5,1,1,1
+14384,3,22504,1,50,Obstinance,204,75,5,1,2,1
+14385,3,22504,1,50,Obstinance,204,75,5,1,3,1
+14386,3,22504,1,50,Obstinance,204,75,5,1,4,1
+14387,3,22504,1,55,Phindymian Guard,204,75,5,1,0,1
+14388,3,22504,1,55,Phindymian Guard,204,75,5,1,1,1
+14389,3,22504,1,55,Phindymian Guard,204,75,5,1,2,1
+14390,3,22504,1,55,Phindymian Guard,204,75,5,1,3,1
+14391,3,22504,1,55,Phindymian Guard,204,75,5,1,4,1
+14392,3,22504,1,60,Verdant Wall,204,75,5,1,0,1
+14393,3,22504,1,60,Verdant Wall,204,75,5,1,1,1
+14394,3,22504,1,60,Verdant Wall,204,75,5,1,2,1
+14395,3,22504,1,60,Verdant Wall,204,75,5,1,3,1
+14396,3,22504,1,60,Verdant Wall,204,75,5,1,4,1
+14397,3,23720,1,60,Iron Coffin,204,77,5,1,0,1
+14398,3,23720,1,60,Iron Coffin,204,77,5,1,1,1
+14399,3,23720,1,60,Iron Coffin,204,77,5,1,2,1
+14400,3,23720,1,60,Iron Coffin,204,77,5,1,3,1
+14401,3,23720,1,60,Iron Coffin,204,77,5,1,4,1
+14402,3,25604,1,65,Fairy Fort,204,80,5,1,0,1
+14403,3,25604,1,65,Fairy Fort,204,80,5,1,1,1
+14404,3,25604,1,65,Fairy Fort,204,80,5,1,2,1
+14405,3,25604,1,65,Fairy Fort,204,80,5,1,3,1
+14406,3,25604,1,65,Fairy Fort,204,80,5,1,4,1
+14407,3,25604,1,65,Enshrine,204,80,5,1,0,1
+14408,3,25604,1,65,Enshrine,204,80,5,1,1,1
+14409,3,25604,1,65,Enshrine,204,80,5,1,2,1
+14410,3,25604,1,65,Enshrine,204,80,5,1,3,1
+14411,3,25604,1,65,Enshrine,204,80,5,1,4,1
+14412,3,25604,1,70,Diabolic Shield,204,80,5,1,0,1
+14413,3,25604,1,70,Diabolic Shield,204,80,5,1,1,1
+14414,3,25604,1,70,Diabolic Shield,204,80,5,1,2,1
+14415,3,25604,1,70,Diabolic Shield,204,80,5,1,3,1
+14416,3,25604,1,70,Diabolic Shield,204,80,5,1,4,1
+14417,3,25604,1,75,Inwardness,204,80,5,1,0,1
+14418,3,25604,1,75,Inwardness,204,80,5,1,1,1
+14419,3,25604,1,75,Inwardness,204,80,5,1,2,1
+14420,3,25604,1,75,Inwardness,204,80,5,1,3,1
+14421,3,25604,1,75,Inwardness,204,80,5,1,4,1
+14462,3,25925,1,45,Dagger of Tribe,206,72,2,1,0,1
+14463,3,25925,1,45,Dagger of Tribe,206,72,2,1,1,1
+14464,3,25925,1,45,Dagger of Tribe,206,72,2,1,2,1
+14465,3,25925,1,45,Dagger of Tribe,206,72,2,1,3,1
+14466,3,25925,1,45,Dagger of Tribe,206,72,2,1,4,1
+14467,3,28130,1,50,Protector's Spearheads,206,75,2,1,0,1
+14468,3,28130,1,50,Protector's Spearheads,206,75,2,1,1,1
+14469,3,28130,1,50,Protector's Spearheads,206,75,2,1,2,1
+14470,3,28130,1,50,Protector's Spearheads,206,75,2,1,3,1
+14471,3,28130,1,50,Protector's Spearheads,206,75,2,1,4,1
+14472,3,28130,1,50,Kris Naga Pulse,206,75,2,1,0,1
+14473,3,28130,1,50,Kris Naga Pulse,206,75,2,1,1,1
+14474,3,28130,1,50,Kris Naga Pulse,206,75,2,1,2,1
+14475,3,28130,1,50,Kris Naga Pulse,206,75,2,1,3,1
+14476,3,28130,1,50,Kris Naga Pulse,206,75,2,1,4,1
+14477,3,28130,1,55,Phindymian Daggers,206,75,2,1,0,1
+14478,3,28130,1,55,Phindymian Daggers,206,75,2,1,1,1
+14479,3,28130,1,55,Phindymian Daggers,206,75,2,1,2,1
+14480,3,28130,1,55,Phindymian Daggers,206,75,2,1,3,1
+14481,3,28130,1,55,Phindymian Daggers,206,75,2,1,4,1
+14482,3,28130,1,60,Verdant Fang,206,75,2,1,0,1
+14483,3,28130,1,60,Verdant Fang,206,75,2,1,1,1
+14484,3,28130,1,60,Verdant Fang,206,75,2,1,2,1
+14485,3,28130,1,60,Verdant Fang,206,75,2,1,3,1
+14486,3,28130,1,60,Verdant Fang,206,75,2,1,4,1
+14487,3,29650,1,60,Deep Ripper,206,77,2,1,0,1
+14488,3,29650,1,60,Deep Ripper,206,77,2,1,1,1
+14489,3,29650,1,60,Deep Ripper,206,77,2,1,2,1
+14490,3,29650,1,60,Deep Ripper,206,77,2,1,3,1
+14491,3,29650,1,60,Deep Ripper,206,77,2,1,4,1
+14492,3,32005,1,65,Underworld Triple Daggers,206,80,2,1,0,1
+14493,3,32005,1,65,Underworld Triple Daggers,206,80,2,1,1,1
+14494,3,32005,1,65,Underworld Triple Daggers,206,80,2,1,2,1
+14495,3,32005,1,65,Underworld Triple Daggers,206,80,2,1,3,1
+14496,3,32005,1,65,Underworld Triple Daggers,206,80,2,1,4,1
+14497,3,32005,1,65,Lizard's Glare,206,80,2,1,0,1
+14498,3,32005,1,65,Lizard's Glare,206,80,2,1,1,1
+14499,3,32005,1,65,Lizard's Glare,206,80,2,1,2,1
+14500,3,32005,1,65,Lizard's Glare,206,80,2,1,3,1
+14501,3,32005,1,65,Lizard's Glare,206,80,2,1,4,1
+14502,3,32005,1,70,Demon Framea,206,80,2,1,0,1
+14503,3,32005,1,70,Demon Framea,206,80,2,1,1,1
+14504,3,32005,1,70,Demon Framea,206,80,2,1,2,1
+14505,3,32005,1,70,Demon Framea,206,80,2,1,3,1
+14506,3,32005,1,70,Demon Framea,206,80,2,1,4,1
+14507,3,32005,1,75,The Colonel,206,80,2,1,0,1
+14508,3,32005,1,75,The Colonel,206,80,2,1,1,1
+14509,3,32005,1,75,The Colonel,206,80,2,1,2,1
+14510,3,32005,1,75,The Colonel,206,80,2,1,3,1
+14511,3,32005,1,75,The Colonel,206,80,2,1,4,1
+14512,3,25925,1,45,Bow of Tribe,207,72,3,1,0,1
+14513,3,25925,1,45,Bow of Tribe,207,72,3,1,1,1
+14514,3,25925,1,45,Bow of Tribe,207,72,3,1,2,1
+14515,3,25925,1,45,Bow of Tribe,207,72,3,1,3,1
+14516,3,25925,1,45,Bow of Tribe,207,72,3,1,4,1
+14517,3,28130,1,50,Abridged Bow,207,75,3,1,0,1
+14518,3,28130,1,50,Abridged Bow,207,75,3,1,1,1
+14519,3,28130,1,50,Abridged Bow,207,75,3,1,2,1
+14520,3,28130,1,50,Abridged Bow,207,75,3,1,3,1
+14521,3,28130,1,50,Abridged Bow,207,75,3,1,4,1
+14522,3,28130,1,50,Extension Bow,207,75,3,1,0,1
+14523,3,28130,1,50,Extension Bow,207,75,3,1,1,1
+14524,3,28130,1,50,Extension Bow,207,75,3,1,2,1
+14525,3,28130,1,50,Extension Bow,207,75,3,1,3,1
+14526,3,28130,1,50,Extension Bow,207,75,3,1,4,1
+14527,3,28130,1,55,Phindymian Bow,207,75,3,1,0,1
+14528,3,28130,1,55,Phindymian Bow,207,75,3,1,1,1
+14529,3,28130,1,55,Phindymian Bow,207,75,3,1,2,1
+14530,3,28130,1,55,Phindymian Bow,207,75,3,1,3,1
+14531,3,28130,1,55,Phindymian Bow,207,75,3,1,4,1
+14532,3,28130,1,60,Verdant Accuracy,207,75,3,1,0,1
+14533,3,28130,1,60,Verdant Accuracy,207,75,3,1,1,1
+14534,3,28130,1,60,Verdant Accuracy,207,75,3,1,2,1
+14535,3,28130,1,60,Verdant Accuracy,207,75,3,1,3,1
+14536,3,28130,1,60,Verdant Accuracy,207,75,3,1,4,1
+14537,3,29650,1,60,Loner's Strain,207,77,3,1,0,1
+14538,3,29650,1,60,Loner's Strain,207,77,3,1,1,1
+14539,3,29650,1,60,Loner's Strain,207,77,3,1,2,1
+14540,3,29650,1,60,Loner's Strain,207,77,3,1,3,1
+14541,3,29650,1,60,Loner's Strain,207,77,3,1,4,1
+14542,3,32005,1,65,Orthogenesis,207,80,3,1,0,1
+14543,3,32005,1,65,Orthogenesis,207,80,3,1,1,1
+14544,3,32005,1,65,Orthogenesis,207,80,3,1,2,1
+14545,3,32005,1,65,Orthogenesis,207,80,3,1,3,1
+14546,3,32005,1,65,Orthogenesis,207,80,3,1,4,1
+14547,3,32005,1,65,Twin Griffin,207,80,3,1,0,1
+14548,3,32005,1,65,Twin Griffin,207,80,3,1,1,1
+14549,3,32005,1,65,Twin Griffin,207,80,3,1,2,1
+14550,3,32005,1,65,Twin Griffin,207,80,3,1,3,1
+14551,3,32005,1,65,Twin Griffin,207,80,3,1,4,1
+14552,3,32005,1,70,Demon Horn,207,80,3,1,0,1
+14553,3,32005,1,70,Demon Horn,207,80,3,1,1,1
+14554,3,32005,1,70,Demon Horn,207,80,3,1,2,1
+14555,3,32005,1,70,Demon Horn,207,80,3,1,3,1
+14556,3,32005,1,70,Demon Horn,207,80,3,1,4,1
+14557,3,32005,1,75,Substance,207,80,3,1,0,1
+14558,3,32005,1,75,Substance,207,80,3,1,1,1
+14559,3,32005,1,75,Substance,207,80,3,1,2,1
+14560,3,32005,1,75,Substance,207,80,3,1,3,1
+14561,3,32005,1,75,Substance,207,80,3,1,4,1
+14562,3,25925,1,45,Gauntlet of Tribe,208,72,9,1,0,1
+14563,3,25925,1,45,Gauntlet of Tribe,208,72,9,1,1,1
+14564,3,25925,1,45,Gauntlet of Tribe,208,72,9,1,2,1
+14565,3,25925,1,45,Gauntlet of Tribe,208,72,9,1,3,1
+14566,3,25925,1,45,Gauntlet of Tribe,208,72,9,1,4,1
+14567,3,28130,1,55,Phindymian Seiðr,208,75,9,1,0,1
+14568,3,28130,1,55,Phindymian Seiðr,208,75,9,1,1,1
+14569,3,28130,1,55,Phindymian Seiðr,208,75,9,1,2,1
+14570,3,28130,1,55,Phindymian Seiðr,208,75,9,1,3,1
+14571,3,28130,1,55,Phindymian Seiðr,208,75,9,1,4,1
+14572,3,28130,1,60,Verdant Logician,208,75,9,1,0,1
+14573,3,28130,1,60,Verdant Logician,208,75,9,1,1,1
+14574,3,28130,1,60,Verdant Logician,208,75,9,1,2,1
+14575,3,28130,1,60,Verdant Logician,208,75,9,1,3,1
+14576,3,28130,1,60,Verdant Logician,208,75,9,1,4,1
+14577,3,32005,1,70,Brachium Diabolus,208,80,9,1,0,1
+14578,3,32005,1,70,Brachium Diabolus,208,80,9,1,1,1
+14579,3,32005,1,70,Brachium Diabolus,208,80,9,1,2,1
+14580,3,32005,1,70,Brachium Diabolus,208,80,9,1,3,1
+14581,3,32005,1,70,Brachium Diabolus,208,80,9,1,4,1
+14582,3,32005,1,75,Mesocaldia,208,80,9,1,0,1
+14583,3,32005,1,75,Mesocaldia,208,80,9,1,1,1
+14584,3,32005,1,75,Mesocaldia,208,80,9,1,2,1
+14585,3,32005,1,75,Mesocaldia,208,80,9,1,3,1
+14586,3,32005,1,75,Mesocaldia,208,80,9,1,4,1
+14587,3,25925,1,45,Spell of Tribe,209,72,8,1,0,1
+14588,3,25925,1,45,Spell of Tribe,209,72,8,1,1,1
+14589,3,25925,1,45,Spell of Tribe,209,72,8,1,2,1
+14590,3,25925,1,45,Spell of Tribe,209,72,8,1,3,1
+14591,3,25925,1,45,Spell of Tribe,209,72,8,1,4,1
+14592,3,28130,1,50,Tannhäuser,209,75,8,1,0,1
+14593,3,28130,1,50,Tannhäuser,209,75,8,1,1,1
+14594,3,28130,1,50,Tannhäuser,209,75,8,1,2,1
+14595,3,28130,1,50,Tannhäuser,209,75,8,1,3,1
+14596,3,28130,1,50,Tannhäuser,209,75,8,1,4,1
+14597,3,28130,1,50,Kenn-brecher of Thirst,209,75,8,1,0,1
+14598,3,28130,1,50,Kenn-brecher of Thirst,209,75,8,1,1,1
+14599,3,28130,1,50,Kenn-brecher of Thirst,209,75,8,1,2,1
+14600,3,28130,1,50,Kenn-brecher of Thirst,209,75,8,1,3,1
+14601,3,28130,1,50,Kenn-brecher of Thirst,209,75,8,1,4,1
+14602,3,28130,1,55,Phindymian Shooter,209,75,8,1,0,1
+14603,3,28130,1,55,Phindymian Shooter,209,75,8,1,1,1
+14604,3,28130,1,55,Phindymian Shooter,209,75,8,1,2,1
+14605,3,28130,1,55,Phindymian Shooter,209,75,8,1,3,1
+14606,3,28130,1,55,Phindymian Shooter,209,75,8,1,4,1
+14607,3,28130,1,60,Verdant Investor,209,75,8,1,0,1
+14608,3,28130,1,60,Verdant Investor,209,75,8,1,1,1
+14609,3,28130,1,60,Verdant Investor,209,75,8,1,2,1
+14610,3,28130,1,60,Verdant Investor,209,75,8,1,3,1
+14611,3,28130,1,60,Verdant Investor,209,75,8,1,4,1
+14612,3,29650,1,60,Gullinkambi,209,77,8,1,0,1
+14613,3,29650,1,60,Gullinkambi,209,77,8,1,1,1
+14614,3,29650,1,60,Gullinkambi,209,77,8,1,2,1
+14615,3,29650,1,60,Gullinkambi,209,77,8,1,3,1
+14616,3,29650,1,60,Gullinkambi,209,77,8,1,4,1
+14617,3,32005,1,65,Irrlicht,209,80,8,1,0,1
+14618,3,32005,1,65,Irrlicht,209,80,8,1,1,1
+14619,3,32005,1,65,Irrlicht,209,80,8,1,2,1
+14620,3,32005,1,65,Irrlicht,209,80,8,1,3,1
+14621,3,32005,1,65,Irrlicht,209,80,8,1,4,1
+14622,3,32005,1,65,Lightning Shape,209,80,8,1,0,1
+14623,3,32005,1,65,Lightning Shape,209,80,8,1,1,1
+14624,3,32005,1,65,Lightning Shape,209,80,8,1,2,1
+14625,3,32005,1,65,Lightning Shape,209,80,8,1,3,1
+14626,3,32005,1,65,Lightning Shape,209,80,8,1,4,1
+14627,3,32005,1,70,Demon Wing,209,80,8,1,0,1
+14628,3,32005,1,70,Demon Wing,209,80,8,1,1,1
+14629,3,32005,1,70,Demon Wing,209,80,8,1,2,1
+14630,3,32005,1,70,Demon Wing,209,80,8,1,3,1
+14631,3,32005,1,70,Demon Wing,209,80,8,1,4,1
+14632,3,32005,1,75,Axis,209,80,8,1,0,1
+14633,3,32005,1,75,Axis,209,80,8,1,1,1
+14634,3,32005,1,75,Axis,209,80,8,1,2,1
+14635,3,32005,1,75,Axis,209,80,8,1,3,1
+14636,3,32005,1,75,Axis,209,80,8,1,4,1
+14637,3,25925,1,45,Staff of Tribe,211,72,4,1,0,1
+14638,3,25925,1,45,Staff of Tribe,211,72,4,1,1,1
+14639,3,25925,1,45,Staff of Tribe,211,72,4,1,2,1
+14640,3,25925,1,45,Staff of Tribe,211,72,4,1,3,1
+14641,3,25925,1,45,Staff of Tribe,211,72,4,1,4,1
+14642,3,28130,1,50,Goblin's Worship,211,75,4,1,0,1
+14643,3,28130,1,50,Goblin's Worship,211,75,4,1,1,1
+14644,3,28130,1,50,Goblin's Worship,211,75,4,1,2,1
+14645,3,28130,1,50,Goblin's Worship,211,75,4,1,3,1
+14646,3,28130,1,50,Goblin's Worship,211,75,4,1,4,1
+14647,3,28130,1,50,Elderly Mentor,211,75,4,1,0,1
+14648,3,28130,1,50,Elderly Mentor,211,75,4,1,1,1
+14649,3,28130,1,50,Elderly Mentor,211,75,4,1,2,1
+14650,3,28130,1,50,Elderly Mentor,211,75,4,1,3,1
+14651,3,28130,1,50,Elderly Mentor,211,75,4,1,4,1
+14652,3,28130,1,55,Phindymian Cane,211,75,4,1,0,1
+14653,3,28130,1,55,Phindymian Cane,211,75,4,1,1,1
+14654,3,28130,1,55,Phindymian Cane,211,75,4,1,2,1
+14655,3,28130,1,55,Phindymian Cane,211,75,4,1,3,1
+14656,3,28130,1,55,Phindymian Cane,211,75,4,1,4,1
+14657,3,28130,1,60,Verdant Relief,211,75,4,1,0,1
+14658,3,28130,1,60,Verdant Relief,211,75,4,1,1,1
+14659,3,28130,1,60,Verdant Relief,211,75,4,1,2,1
+14660,3,28130,1,60,Verdant Relief,211,75,4,1,3,1
+14661,3,28130,1,60,Verdant Relief,211,75,4,1,4,1
+14662,3,29650,1,60,Petrified Staff,211,77,4,1,0,1
+14663,3,29650,1,60,Petrified Staff,211,77,4,1,1,1
+14664,3,29650,1,60,Petrified Staff,211,77,4,1,2,1
+14665,3,29650,1,60,Petrified Staff,211,77,4,1,3,1
+14666,3,29650,1,60,Petrified Staff,211,77,4,1,4,1
+14667,3,32005,1,65,Green Light's Nail Freed,211,80,4,1,0,1
+14668,3,32005,1,65,Green Light's Nail Freed,211,80,4,1,1,1
+14669,3,32005,1,65,Green Light's Nail Freed,211,80,4,1,2,1
+14670,3,32005,1,65,Green Light's Nail Freed,211,80,4,1,3,1
+14671,3,32005,1,65,Green Light's Nail Freed,211,80,4,1,4,1
+14672,3,32005,1,65,Symbiosis,211,80,4,1,0,1
+14673,3,32005,1,65,Symbiosis,211,80,4,1,1,1
+14674,3,32005,1,65,Symbiosis,211,80,4,1,2,1
+14675,3,32005,1,65,Symbiosis,211,80,4,1,3,1
+14676,3,32005,1,65,Symbiosis,211,80,4,1,4,1
+14677,3,32005,1,70,Dominating Claw,211,80,4,1,0,1
+14678,3,32005,1,70,Dominating Claw,211,80,4,1,1,1
+14679,3,32005,1,70,Dominating Claw,211,80,4,1,2,1
+14680,3,32005,1,70,Dominating Claw,211,80,4,1,3,1
+14681,3,32005,1,70,Dominating Claw,211,80,4,1,4,1
+14682,3,32005,1,75,Quintessence,211,80,4,1,0,1
+14683,3,32005,1,75,Quintessence,211,80,4,1,1,1
+14684,3,32005,1,75,Quintessence,211,80,4,1,2,1
+14685,3,32005,1,75,Quintessence,211,80,4,1,3,1
+14686,3,32005,1,75,Quintessence,211,80,4,1,4,1
+14687,3,25925,1,45,Wand of Tribe,212,72,6,1,0,1
+14688,3,25925,1,45,Wand of Tribe,212,72,6,1,1,1
+14689,3,25925,1,45,Wand of Tribe,212,72,6,1,2,1
+14690,3,25925,1,45,Wand of Tribe,212,72,6,1,3,1
+14691,3,25925,1,45,Wand of Tribe,212,72,6,1,4,1
+14692,3,28130,1,50,Zone of Liberty,212,75,6,1,0,1
+14693,3,28130,1,50,Zone of Liberty,212,75,6,1,1,1
+14694,3,28130,1,50,Zone of Liberty,212,75,6,1,2,1
+14695,3,28130,1,50,Zone of Liberty,212,75,6,1,3,1
+14696,3,28130,1,50,Zone of Liberty,212,75,6,1,4,1
+14697,3,28130,1,50,Divergence,212,75,6,1,0,1
+14698,3,28130,1,50,Divergence,212,75,6,1,1,1
+14699,3,28130,1,50,Divergence,212,75,6,1,2,1
+14700,3,28130,1,50,Divergence,212,75,6,1,3,1
+14701,3,28130,1,50,Divergence,212,75,6,1,4,1
+14702,3,28130,1,55,Phindymian Wand,212,75,6,1,0,1
+14703,3,28130,1,55,Phindymian Wand,212,75,6,1,1,1
+14704,3,28130,1,55,Phindymian Wand,212,75,6,1,2,1
+14705,3,28130,1,55,Phindymian Wand,212,75,6,1,3,1
+14706,3,28130,1,55,Phindymian Wand,212,75,6,1,4,1
+14707,3,28130,1,60,Verdant Ruin,212,75,6,1,0,1
+14708,3,28130,1,60,Verdant Ruin,212,75,6,1,1,1
+14709,3,28130,1,60,Verdant Ruin,212,75,6,1,2,1
+14710,3,28130,1,60,Verdant Ruin,212,75,6,1,3,1
+14711,3,28130,1,60,Verdant Ruin,212,75,6,1,4,1
+14712,3,29650,1,60,Warping Soul,212,77,6,1,0,1
+14713,3,29650,1,60,Warping Soul,212,77,6,1,1,1
+14714,3,29650,1,60,Warping Soul,212,77,6,1,2,1
+14715,3,29650,1,60,Warping Soul,212,77,6,1,3,1
+14716,3,29650,1,60,Warping Soul,212,77,6,1,4,1
+14717,3,32005,1,65,Fixed Heart,212,80,6,1,0,1
+14718,3,32005,1,65,Fixed Heart,212,80,6,1,1,1
+14719,3,32005,1,65,Fixed Heart,212,80,6,1,2,1
+14720,3,32005,1,65,Fixed Heart,212,80,6,1,3,1
+14721,3,32005,1,65,Fixed Heart,212,80,6,1,4,1
+14722,3,32005,1,65,Authority of Corona,212,80,6,1,0,1
+14723,3,32005,1,65,Authority of Corona,212,80,6,1,1,1
+14724,3,32005,1,65,Authority of Corona,212,80,6,1,2,1
+14725,3,32005,1,65,Authority of Corona,212,80,6,1,3,1
+14726,3,32005,1,65,Authority of Corona,212,80,6,1,4,1
+14727,3,32005,1,70,Black Scourge,212,80,6,1,0,1
+14728,3,32005,1,70,Black Scourge,212,80,6,1,1,1
+14729,3,32005,1,70,Black Scourge,212,80,6,1,2,1
+14730,3,32005,1,70,Black Scourge,212,80,6,1,3,1
+14731,3,32005,1,70,Black Scourge,212,80,6,1,4,1
+14732,3,32005,1,75,Sanctorum,212,80,6,1,0,1
+14733,3,32005,1,75,Sanctorum,212,80,6,1,1,1
+14734,3,32005,1,75,Sanctorum,212,80,6,1,2,1
+14735,3,32005,1,75,Sanctorum,212,80,6,1,3,1
+14736,3,32005,1,75,Sanctorum,212,80,6,1,4,1
 14737,3,0,1,1,Novice Spear,213,1,10,1,0,1
 14738,3,10,1,1,Novice Spear,213,1,10,1,1,1
 14739,3,10,1,1,Novice Spear,213,1,10,1,2,1
@@ -7892,286 +7892,286 @@
 14764,3,15130,1,11,Elfin Thrust,213,55,10,1,2,1
 14765,3,15130,1,11,Elfin Thrust,213,55,10,1,3,1
 14766,3,15130,1,11,Elfin Thrust,213,55,10,1,4,1
-14767,3,18005,1,9,Turbulence,213,60,10,1,0,1
-14768,3,18005,1,9,Turbulence,213,60,10,1,1,1
-14769,3,18005,1,9,Turbulence,213,60,10,1,2,1
-14770,3,18005,1,9,Turbulence,213,60,10,1,3,1
-14771,3,18005,1,9,Turbulence,213,60,10,1,4,1
-14772,3,21130,1,14,Ray's Steering,213,65,10,1,0,1
-14773,3,21130,1,14,Ray's Steering,213,65,10,1,1,1
-14774,3,21130,1,14,Ray's Steering,213,65,10,1,2,1
-14775,3,21130,1,14,Ray's Steering,213,65,10,1,3,1
-14776,3,21130,1,14,Ray's Steering,213,65,10,1,4,1
-14777,3,24505,1,8,Spear of Tyrant,213,70,10,1,0,1
-14778,3,24505,1,8,Spear of Tyrant,213,70,10,1,1,1
-14779,3,24505,1,8,Spear of Tyrant,213,70,10,1,2,1
-14780,3,24505,1,8,Spear of Tyrant,213,70,10,1,3,1
-14781,3,24505,1,8,Spear of Tyrant,213,70,10,1,4,1
-14782,3,24505,1,13,Clear Stream,213,70,10,1,0,1
-14783,3,24505,1,13,Clear Stream,213,70,10,1,1,1
-14784,3,24505,1,13,Clear Stream,213,70,10,1,2,1
-14785,3,24505,1,13,Clear Stream,213,70,10,1,3,1
-14786,3,24505,1,13,Clear Stream,213,70,10,1,4,1
-14787,3,25925,1,13,Spear of Tribe,213,72,10,1,0,1
-14788,3,25925,1,13,Spear of Tribe,213,72,10,1,1,1
-14789,3,25925,1,13,Spear of Tribe,213,72,10,1,2,1
-14790,3,25925,1,13,Spear of Tribe,213,72,10,1,3,1
-14791,3,25925,1,13,Spear of Tribe,213,72,10,1,4,1
-14792,3,28130,1,2,Dragon Crest Partisan,213,75,10,1,0,1
-14793,3,28130,1,2,Dragon Crest Partisan,213,75,10,1,1,1
-14794,3,28130,1,2,Dragon Crest Partisan,213,75,10,1,2,1
-14795,3,28130,1,2,Dragon Crest Partisan,213,75,10,1,3,1
-14796,3,28130,1,2,Dragon Crest Partisan,213,75,10,1,4,1
-14797,3,28130,1,2,Gold Spear,213,75,10,1,0,1
-14798,3,28130,1,2,Gold Spear,213,75,10,1,1,1
-14799,3,28130,1,2,Gold Spear,213,75,10,1,2,1
-14800,3,28130,1,2,Gold Spear,213,75,10,1,3,1
-14801,3,28130,1,2,Gold Spear,213,75,10,1,4,1
-14802,3,28130,1,7,Phindymian Spear,213,75,10,1,0,1
-14803,3,28130,1,7,Phindymian Spear,213,75,10,1,1,1
-14804,3,28130,1,7,Phindymian Spear,213,75,10,1,2,1
-14805,3,28130,1,7,Phindymian Spear,213,75,10,1,3,1
-14806,3,28130,1,7,Phindymian Spear,213,75,10,1,4,1
-14807,3,28130,1,12,Verdant Soul,213,75,10,1,0,1
-14808,3,28130,1,12,Verdant Soul,213,75,10,1,1,1
-14809,3,28130,1,12,Verdant Soul,213,75,10,1,2,1
-14810,3,28130,1,12,Verdant Soul,213,75,10,1,3,1
-14811,3,28130,1,12,Verdant Soul,213,75,10,1,4,1
-14812,3,29650,1,12,Spirit's Fury,213,77,10,1,0,1
-14813,3,29650,1,12,Spirit's Fury,213,77,10,1,1,1
-14814,3,29650,1,12,Spirit's Fury,213,77,10,1,2,1
-14815,3,29650,1,12,Spirit's Fury,213,77,10,1,3,1
-14816,3,29650,1,12,Spirit's Fury,213,77,10,1,4,1
-14817,3,32005,1,1,Partisan of the Blue Waters,213,80,10,1,0,1
-14818,3,32005,1,1,Partisan of the Blue Waters,213,80,10,1,1,1
-14819,3,32005,1,1,Partisan of the Blue Waters,213,80,10,1,2,1
-14820,3,32005,1,1,Partisan of the Blue Waters,213,80,10,1,3,1
-14821,3,32005,1,1,Partisan of the Blue Waters,213,80,10,1,4,1
-14822,3,32005,1,1,Freefaller,213,80,10,1,0,1
-14823,3,32005,1,1,Freefaller,213,80,10,1,1,1
-14824,3,32005,1,1,Freefaller,213,80,10,1,2,1
-14825,3,32005,1,1,Freefaller,213,80,10,1,3,1
-14826,3,32005,1,1,Freefaller,213,80,10,1,4,1
-14827,3,32005,1,6,Demon Penetrator,213,80,10,1,0,1
-14828,3,32005,1,6,Demon Penetrator,213,80,10,1,1,1
-14829,3,32005,1,6,Demon Penetrator,213,80,10,1,2,1
-14830,3,32005,1,6,Demon Penetrator,213,80,10,1,3,1
-14831,3,32005,1,6,Demon Penetrator,213,80,10,1,4,1
-14832,3,32005,1,11,Emphasis,213,80,10,1,0,1
-14833,3,32005,1,11,Emphasis,213,80,10,1,1,1
-14834,3,32005,1,11,Emphasis,213,80,10,1,2,1
-14835,3,32005,1,11,Emphasis,213,80,10,1,3,1
-14836,3,32005,1,11,Emphasis,213,80,10,1,4,1
+14767,3,18005,1,25,Turbulence,213,60,10,1,0,1
+14768,3,18005,1,25,Turbulence,213,60,10,1,1,1
+14769,3,18005,1,25,Turbulence,213,60,10,1,2,1
+14770,3,18005,1,25,Turbulence,213,60,10,1,3,1
+14771,3,18005,1,25,Turbulence,213,60,10,1,4,1
+14772,3,21130,1,30,Ray's Steering,213,65,10,1,0,1
+14773,3,21130,1,30,Ray's Steering,213,65,10,1,1,1
+14774,3,21130,1,30,Ray's Steering,213,65,10,1,2,1
+14775,3,21130,1,30,Ray's Steering,213,65,10,1,3,1
+14776,3,21130,1,30,Ray's Steering,213,65,10,1,4,1
+14777,3,24505,1,40,Spear of Tyrant,213,70,10,1,0,1
+14778,3,24505,1,40,Spear of Tyrant,213,70,10,1,1,1
+14779,3,24505,1,40,Spear of Tyrant,213,70,10,1,2,1
+14780,3,24505,1,40,Spear of Tyrant,213,70,10,1,3,1
+14781,3,24505,1,40,Spear of Tyrant,213,70,10,1,4,1
+14782,3,24505,1,45,Clear Stream,213,70,10,1,0,1
+14783,3,24505,1,45,Clear Stream,213,70,10,1,1,1
+14784,3,24505,1,45,Clear Stream,213,70,10,1,2,1
+14785,3,24505,1,45,Clear Stream,213,70,10,1,3,1
+14786,3,24505,1,45,Clear Stream,213,70,10,1,4,1
+14787,3,25925,1,45,Spear of Tribe,213,72,10,1,0,1
+14788,3,25925,1,45,Spear of Tribe,213,72,10,1,1,1
+14789,3,25925,1,45,Spear of Tribe,213,72,10,1,2,1
+14790,3,25925,1,45,Spear of Tribe,213,72,10,1,3,1
+14791,3,25925,1,45,Spear of Tribe,213,72,10,1,4,1
+14792,3,28130,1,50,Dragon Crest Partisan,213,75,10,1,0,1
+14793,3,28130,1,50,Dragon Crest Partisan,213,75,10,1,1,1
+14794,3,28130,1,50,Dragon Crest Partisan,213,75,10,1,2,1
+14795,3,28130,1,50,Dragon Crest Partisan,213,75,10,1,3,1
+14796,3,28130,1,50,Dragon Crest Partisan,213,75,10,1,4,1
+14797,3,28130,1,50,Gold Spear,213,75,10,1,0,1
+14798,3,28130,1,50,Gold Spear,213,75,10,1,1,1
+14799,3,28130,1,50,Gold Spear,213,75,10,1,2,1
+14800,3,28130,1,50,Gold Spear,213,75,10,1,3,1
+14801,3,28130,1,50,Gold Spear,213,75,10,1,4,1
+14802,3,28130,1,55,Phindymian Spear,213,75,10,1,0,1
+14803,3,28130,1,55,Phindymian Spear,213,75,10,1,1,1
+14804,3,28130,1,55,Phindymian Spear,213,75,10,1,2,1
+14805,3,28130,1,55,Phindymian Spear,213,75,10,1,3,1
+14806,3,28130,1,55,Phindymian Spear,213,75,10,1,4,1
+14807,3,28130,1,60,Verdant Soul,213,75,10,1,0,1
+14808,3,28130,1,60,Verdant Soul,213,75,10,1,1,1
+14809,3,28130,1,60,Verdant Soul,213,75,10,1,2,1
+14810,3,28130,1,60,Verdant Soul,213,75,10,1,3,1
+14811,3,28130,1,60,Verdant Soul,213,75,10,1,4,1
+14812,3,29650,1,60,Spirit's Fury,213,77,10,1,0,1
+14813,3,29650,1,60,Spirit's Fury,213,77,10,1,1,1
+14814,3,29650,1,60,Spirit's Fury,213,77,10,1,2,1
+14815,3,29650,1,60,Spirit's Fury,213,77,10,1,3,1
+14816,3,29650,1,60,Spirit's Fury,213,77,10,1,4,1
+14817,3,32005,1,65,Partisan of the Blue Waters,213,80,10,1,0,1
+14818,3,32005,1,65,Partisan of the Blue Waters,213,80,10,1,1,1
+14819,3,32005,1,65,Partisan of the Blue Waters,213,80,10,1,2,1
+14820,3,32005,1,65,Partisan of the Blue Waters,213,80,10,1,3,1
+14821,3,32005,1,65,Partisan of the Blue Waters,213,80,10,1,4,1
+14822,3,32005,1,65,Freefaller,213,80,10,1,0,1
+14823,3,32005,1,65,Freefaller,213,80,10,1,1,1
+14824,3,32005,1,65,Freefaller,213,80,10,1,2,1
+14825,3,32005,1,65,Freefaller,213,80,10,1,3,1
+14826,3,32005,1,65,Freefaller,213,80,10,1,4,1
+14827,3,32005,1,70,Demon Penetrator,213,80,10,1,0,1
+14828,3,32005,1,70,Demon Penetrator,213,80,10,1,1,1
+14829,3,32005,1,70,Demon Penetrator,213,80,10,1,2,1
+14830,3,32005,1,70,Demon Penetrator,213,80,10,1,3,1
+14831,3,32005,1,70,Demon Penetrator,213,80,10,1,4,1
+14832,3,32005,1,75,Emphasis,213,80,10,1,0,1
+14833,3,32005,1,75,Emphasis,213,80,10,1,1,1
+14834,3,32005,1,75,Emphasis,213,80,10,1,2,1
+14835,3,32005,1,75,Emphasis,213,80,10,1,3,1
+14836,3,32005,1,75,Emphasis,213,80,10,1,4,1
 15673,3,100,1,1,Rusted One-handed Sword,201,1,1,1,0,1
 15674,3,100,1,1,Rusted One-handed Sword,201,1,1,1,1,1
 15675,3,100,1,1,Rusted One-handed Sword,201,1,1,1,2,1
 15676,3,100,1,1,Rusted One-handed Sword,201,1,1,1,3,1
 15677,3,100,1,1,Rusted One-handed Sword,201,1,1,1,4,1
-15678,3,1000,1,4,Polished Sword,201,1,1,1,0,1
-15679,3,1000,1,9,Polished Sword,201,1,1,1,1,1
-15680,3,1000,1,9,Polished Sword,201,1,1,1,2,1
-15681,3,1000,1,14,Polished Sword,201,1,1,1,3,1
-15682,3,1000,1,3,Polished Sword,201,1,1,1,4,1
-15683,3,20000,1,13,Arisen's Defeater,201,1,1,4,0,1
-15684,3,20000,1,13,Arisen's Defeater,201,1,1,4,1,1
-15685,3,20000,1,13,Arisen's Defeater,201,1,1,4,2,1
-15686,3,20000,1,13,Arisen's Defeater,201,1,1,4,3,1
-15687,3,20000,1,13,Arisen's Defeater,201,1,1,4,4,1
-15688,3,20000,1,12,Sword of Radiance,201,1,1,4,0,1
-15689,3,20000,1,12,Sword of Radiance,201,1,1,4,1,1
-15690,3,20000,1,12,Sword of Radiance,201,1,1,4,2,1
-15691,3,20000,1,12,Sword of Radiance,201,1,1,4,3,1
-15692,3,20000,1,12,Sword of Radiance,201,1,1,4,4,1
+15678,3,1000,1,20,Polished Sword,201,1,1,1,0,1
+15679,3,1000,1,25,Polished Sword,201,1,1,1,1,1
+15680,3,1000,1,25,Polished Sword,201,1,1,1,2,1
+15681,3,1000,1,30,Polished Sword,201,1,1,1,3,1
+15682,3,1000,1,35,Polished Sword,201,1,1,1,4,1
+15683,3,20000,1,45,Arisen's Defeater,201,1,1,4,0,1
+15684,3,20000,1,45,Arisen's Defeater,201,1,1,4,1,1
+15685,3,20000,1,45,Arisen's Defeater,201,1,1,4,2,1
+15686,3,20000,1,45,Arisen's Defeater,201,1,1,4,3,1
+15687,3,20000,1,45,Arisen's Defeater,201,1,1,4,4,1
+15688,3,20000,1,60,Sword of Radiance,201,1,1,4,0,1
+15689,3,20000,1,60,Sword of Radiance,201,1,1,4,1,1
+15690,3,20000,1,60,Sword of Radiance,201,1,1,4,2,1
+15691,3,20000,1,60,Sword of Radiance,201,1,1,4,3,1
+15692,3,20000,1,60,Sword of Radiance,201,1,1,4,4,1
 15713,3,100,1,1,Rusted Greatsword,203,1,7,1,0,1
 15714,3,100,1,1,Rusted Greatsword,203,1,7,1,1,1
 15715,3,100,1,1,Rusted Greatsword,203,1,7,1,2,1
 15716,3,100,1,1,Rusted Greatsword,203,1,7,1,3,1
 15717,3,100,1,1,Rusted Greatsword,203,1,7,1,4,1
-15718,3,1000,1,4,Polished Breaker,203,1,7,1,0,1
-15719,3,1000,1,9,Polished Breaker,203,1,7,1,1,1
-15720,3,1000,1,9,Polished Breaker,203,1,7,1,2,1
-15721,3,1000,1,14,Polished Breaker,203,1,7,1,3,1
-15722,3,1000,1,3,Polished Breaker,203,1,7,1,4,1
-15723,3,20000,1,13,Arisen's Savior,203,1,7,4,0,1
-15724,3,20000,1,13,Arisen's Savior,203,1,7,4,1,1
-15725,3,20000,1,13,Arisen's Savior,203,1,7,4,2,1
-15726,3,20000,1,13,Arisen's Savior,203,1,7,4,3,1
-15727,3,20000,1,13,Arisen's Savior,203,1,7,4,4,1
-15728,3,20000,1,12,Blade of Radiance,203,1,7,4,0,1
-15729,3,20000,1,12,Blade of Radiance,203,1,7,4,1,1
-15730,3,20000,1,12,Blade of Radiance,203,1,7,4,2,1
-15731,3,20000,1,12,Blade of Radiance,203,1,7,4,3,1
-15732,3,20000,1,12,Blade of Radiance,203,1,7,4,4,1
+15718,3,1000,1,20,Polished Breaker,203,1,7,1,0,1
+15719,3,1000,1,25,Polished Breaker,203,1,7,1,1,1
+15720,3,1000,1,25,Polished Breaker,203,1,7,1,2,1
+15721,3,1000,1,30,Polished Breaker,203,1,7,1,3,1
+15722,3,1000,1,35,Polished Breaker,203,1,7,1,4,1
+15723,3,20000,1,45,Arisen's Savior,203,1,7,4,0,1
+15724,3,20000,1,45,Arisen's Savior,203,1,7,4,1,1
+15725,3,20000,1,45,Arisen's Savior,203,1,7,4,2,1
+15726,3,20000,1,45,Arisen's Savior,203,1,7,4,3,1
+15727,3,20000,1,45,Arisen's Savior,203,1,7,4,4,1
+15728,3,20000,1,60,Blade of Radiance,203,1,7,4,0,1
+15729,3,20000,1,60,Blade of Radiance,203,1,7,4,1,1
+15730,3,20000,1,60,Blade of Radiance,203,1,7,4,2,1
+15731,3,20000,1,60,Blade of Radiance,203,1,7,4,3,1
+15732,3,20000,1,60,Blade of Radiance,203,1,7,4,4,1
 15733,3,100,1,1,Rusted Greatshield,204,1,5,1,0,1
 15734,3,100,1,1,Rusted Greatshield,204,1,5,1,1,1
 15735,3,100,1,1,Rusted Greatshield,204,1,5,1,2,1
 15736,3,100,1,1,Rusted Greatshield,204,1,5,1,3,1
 15737,3,100,1,1,Rusted Greatshield,204,1,5,1,4,1
-15738,3,1000,1,4,Polished Guard,204,1,5,1,0,1
-15739,3,1000,1,9,Polished Guard,204,1,5,1,1,1
-15740,3,1000,1,9,Polished Guard,204,1,5,1,2,1
-15741,3,1000,1,14,Polished Guard,204,1,5,1,3,1
-15742,3,1000,1,3,Polished Guard,204,1,5,1,4,1
-15743,3,20000,1,13,Arisen's Absorber,204,1,5,4,0,1
-15744,3,20000,1,13,Arisen's Absorber,204,1,5,4,1,1
-15745,3,20000,1,13,Arisen's Absorber,204,1,5,4,2,1
-15746,3,20000,1,13,Arisen's Absorber,204,1,5,4,3,1
-15747,3,20000,1,13,Arisen's Absorber,204,1,5,4,4,1
-15748,3,20000,1,12,Wall of Radiance,204,1,5,4,0,1
-15749,3,20000,1,12,Wall of Radiance,204,1,5,4,1,1
-15750,3,20000,1,12,Wall of Radiance,204,1,5,4,2,1
-15751,3,20000,1,12,Wall of Radiance,204,1,5,4,3,1
-15752,3,20000,1,12,Wall of Radiance,204,1,5,4,4,1
+15738,3,1000,1,20,Polished Guard,204,1,5,1,0,1
+15739,3,1000,1,25,Polished Guard,204,1,5,1,1,1
+15740,3,1000,1,25,Polished Guard,204,1,5,1,2,1
+15741,3,1000,1,30,Polished Guard,204,1,5,1,3,1
+15742,3,1000,1,35,Polished Guard,204,1,5,1,4,1
+15743,3,20000,1,45,Arisen's Absorber,204,1,5,4,0,1
+15744,3,20000,1,45,Arisen's Absorber,204,1,5,4,1,1
+15745,3,20000,1,45,Arisen's Absorber,204,1,5,4,2,1
+15746,3,20000,1,45,Arisen's Absorber,204,1,5,4,3,1
+15747,3,20000,1,45,Arisen's Absorber,204,1,5,4,4,1
+15748,3,20000,1,60,Wall of Radiance,204,1,5,4,0,1
+15749,3,20000,1,60,Wall of Radiance,204,1,5,4,1,1
+15750,3,20000,1,60,Wall of Radiance,204,1,5,4,2,1
+15751,3,20000,1,60,Wall of Radiance,204,1,5,4,3,1
+15752,3,20000,1,60,Wall of Radiance,204,1,5,4,4,1
 15773,3,100,1,1,Rusted Daggers,206,1,2,1,0,1
 15774,3,100,1,1,Rusted Daggers,206,1,2,1,1,1
 15775,3,100,1,1,Rusted Daggers,206,1,2,1,2,1
 15776,3,100,1,1,Rusted Daggers,206,1,2,1,3,1
 15777,3,100,1,1,Rusted Daggers,206,1,2,1,4,1
-15778,3,1000,1,4,Polished Daggers,206,1,2,1,0,1
-15779,3,1000,1,9,Polished Daggers,206,1,2,1,1,1
-15780,3,1000,1,9,Polished Daggers,206,1,2,1,2,1
-15781,3,1000,1,14,Polished Daggers,206,1,2,1,3,1
-15782,3,1000,1,3,Polished Daggers,206,1,2,1,4,1
-15783,3,20000,1,13,Arisen's Cleavers,206,1,2,4,0,1
-15784,3,20000,1,13,Arisen's Cleavers,206,1,2,4,1,1
-15785,3,20000,1,13,Arisen's Cleavers,206,1,2,4,2,1
-15786,3,20000,1,13,Arisen's Cleavers,206,1,2,4,3,1
-15787,3,20000,1,13,Arisen's Cleavers,206,1,2,4,4,1
-15788,3,20000,1,12,Daggers of Radiance,206,1,2,4,0,1
-15789,3,20000,1,12,Daggers of Radiance,206,1,2,4,1,1
-15790,3,20000,1,12,Daggers of Radiance,206,1,2,4,2,1
-15791,3,20000,1,12,Daggers of Radiance,206,1,2,4,3,1
-15792,3,20000,1,12,Daggers of Radiance,206,1,2,4,4,1
+15778,3,1000,1,20,Polished Daggers,206,1,2,1,0,1
+15779,3,1000,1,25,Polished Daggers,206,1,2,1,1,1
+15780,3,1000,1,25,Polished Daggers,206,1,2,1,2,1
+15781,3,1000,1,30,Polished Daggers,206,1,2,1,3,1
+15782,3,1000,1,35,Polished Daggers,206,1,2,1,4,1
+15783,3,20000,1,45,Arisen's Cleavers,206,1,2,4,0,1
+15784,3,20000,1,45,Arisen's Cleavers,206,1,2,4,1,1
+15785,3,20000,1,45,Arisen's Cleavers,206,1,2,4,2,1
+15786,3,20000,1,45,Arisen's Cleavers,206,1,2,4,3,1
+15787,3,20000,1,45,Arisen's Cleavers,206,1,2,4,4,1
+15788,3,20000,1,60,Daggers of Radiance,206,1,2,4,0,1
+15789,3,20000,1,60,Daggers of Radiance,206,1,2,4,1,1
+15790,3,20000,1,60,Daggers of Radiance,206,1,2,4,2,1
+15791,3,20000,1,60,Daggers of Radiance,206,1,2,4,3,1
+15792,3,20000,1,60,Daggers of Radiance,206,1,2,4,4,1
 15793,3,100,1,1,Rusted Bow,207,1,3,1,0,1
 15794,3,100,1,1,Rusted Bow,207,1,3,1,1,1
 15795,3,100,1,1,Rusted Bow,207,1,3,1,2,1
 15796,3,100,1,1,Rusted Bow,207,1,3,1,3,1
 15797,3,100,1,1,Rusted Bow,207,1,3,1,4,1
-15798,3,1000,1,4,Polished Bow,207,1,3,1,0,1
-15799,3,1000,1,9,Polished Bow,207,1,3,1,1,1
-15800,3,1000,1,9,Polished Bow,207,1,3,1,2,1
-15801,3,1000,1,14,Polished Bow,207,1,3,1,3,1
-15802,3,1000,1,3,Polished Bow,207,1,3,1,4,1
-15803,3,20000,1,13,Arisen's Piercer,207,1,3,4,0,1
-15804,3,20000,1,13,Arisen's Piercer,207,1,3,4,1,1
-15805,3,20000,1,13,Arisen's Piercer,207,1,3,4,2,1
-15806,3,20000,1,13,Arisen's Piercer,207,1,3,4,3,1
-15807,3,20000,1,13,Arisen's Piercer,207,1,3,4,4,1
-15808,3,20000,1,12,Bow of Radiance,207,1,3,4,0,1
-15809,3,20000,1,12,Bow of Radiance,207,1,3,4,1,1
-15810,3,20000,1,12,Bow of Radiance,207,1,3,4,2,1
-15811,3,20000,1,12,Bow of Radiance,207,1,3,4,3,1
-15812,3,20000,1,12,Bow of Radiance,207,1,3,4,4,1
+15798,3,1000,1,20,Polished Bow,207,1,3,1,0,1
+15799,3,1000,1,25,Polished Bow,207,1,3,1,1,1
+15800,3,1000,1,25,Polished Bow,207,1,3,1,2,1
+15801,3,1000,1,30,Polished Bow,207,1,3,1,3,1
+15802,3,1000,1,35,Polished Bow,207,1,3,1,4,1
+15803,3,20000,1,45,Arisen's Piercer,207,1,3,4,0,1
+15804,3,20000,1,45,Arisen's Piercer,207,1,3,4,1,1
+15805,3,20000,1,45,Arisen's Piercer,207,1,3,4,2,1
+15806,3,20000,1,45,Arisen's Piercer,207,1,3,4,3,1
+15807,3,20000,1,45,Arisen's Piercer,207,1,3,4,4,1
+15808,3,20000,1,60,Bow of Radiance,207,1,3,4,0,1
+15809,3,20000,1,60,Bow of Radiance,207,1,3,4,1,1
+15810,3,20000,1,60,Bow of Radiance,207,1,3,4,2,1
+15811,3,20000,1,60,Bow of Radiance,207,1,3,4,3,1
+15812,3,20000,1,60,Bow of Radiance,207,1,3,4,4,1
 15813,3,100,1,1,Rusted Magick Gauntlet,208,1,9,1,0,1
 15814,3,100,1,1,Rusted Magick Gauntlet,208,1,9,1,1,1
 15815,3,100,1,1,Rusted Magick Gauntlet,208,1,9,1,2,1
 15816,3,100,1,1,Rusted Magick Gauntlet,208,1,9,1,3,1
 15817,3,100,1,1,Rusted Magick Gauntlet,208,1,9,1,4,1
-15818,3,1000,1,4,Polished Gauntlet,208,1,9,1,0,1
-15819,3,1000,1,9,Polished Gauntlet,208,1,9,1,1,1
-15820,3,1000,1,9,Polished Gauntlet,208,1,9,1,2,1
-15821,3,1000,1,14,Polished Gauntlet,208,1,9,1,3,1
-15822,3,1000,1,3,Polished Gauntlet,208,1,9,1,4,1
-15823,3,20000,1,13,Arisen's Seizer,208,1,9,4,0,1
-15824,3,20000,1,13,Arisen's Seizer,208,1,9,4,1,1
-15825,3,20000,1,13,Arisen's Seizer,208,1,9,4,2,1
-15826,3,20000,1,13,Arisen's Seizer,208,1,9,4,3,1
-15827,3,20000,1,13,Arisen's Seizer,208,1,9,4,4,1
-15828,3,20000,1,12,Hands of Radiance,208,1,9,4,0,1
-15829,3,20000,1,12,Hands of Radiance,208,1,9,4,1,1
-15830,3,20000,1,12,Hands of Radiance,208,1,9,4,2,1
-15831,3,20000,1,12,Hands of Radiance,208,1,9,4,3,1
-15832,3,20000,1,12,Hands of Radiance,208,1,9,4,4,1
+15818,3,1000,1,20,Polished Gauntlet,208,1,9,1,0,1
+15819,3,1000,1,25,Polished Gauntlet,208,1,9,1,1,1
+15820,3,1000,1,25,Polished Gauntlet,208,1,9,1,2,1
+15821,3,1000,1,30,Polished Gauntlet,208,1,9,1,3,1
+15822,3,1000,1,35,Polished Gauntlet,208,1,9,1,4,1
+15823,3,20000,1,45,Arisen's Seizer,208,1,9,4,0,1
+15824,3,20000,1,45,Arisen's Seizer,208,1,9,4,1,1
+15825,3,20000,1,45,Arisen's Seizer,208,1,9,4,2,1
+15826,3,20000,1,45,Arisen's Seizer,208,1,9,4,3,1
+15827,3,20000,1,45,Arisen's Seizer,208,1,9,4,4,1
+15828,3,20000,1,60,Hands of Radiance,208,1,9,4,0,1
+15829,3,20000,1,60,Hands of Radiance,208,1,9,4,1,1
+15830,3,20000,1,60,Hands of Radiance,208,1,9,4,2,1
+15831,3,20000,1,60,Hands of Radiance,208,1,9,4,3,1
+15832,3,20000,1,60,Hands of Radiance,208,1,9,4,4,1
 15833,3,100,1,1,Rusted Magick Bow,209,1,8,1,0,1
 15834,3,100,1,1,Rusted Magick Bow,209,1,8,1,1,1
 15835,3,100,1,1,Rusted Magick Bow,209,1,8,1,2,1
 15836,3,100,1,1,Rusted Magick Bow,209,1,8,1,3,1
 15837,3,100,1,1,Rusted Magick Bow,209,1,8,1,4,1
-15838,3,1000,1,4,Polished Spell,209,1,8,1,0,1
-15839,3,1000,1,9,Polished Spell,209,1,8,1,1,1
-15840,3,1000,1,9,Polished Spell,209,1,8,1,2,1
-15841,3,1000,1,14,Polished Spell,209,1,8,1,3,1
-15842,3,1000,1,3,Polished Spell,209,1,8,1,4,1
-15843,3,20000,1,13,Arisen's Disturber,209,1,8,4,0,1
-15844,3,20000,1,13,Arisen's Disturber,209,1,8,4,1,1
-15845,3,20000,1,13,Arisen's Disturber,209,1,8,4,2,1
-15846,3,20000,1,13,Arisen's Disturber,209,1,8,4,3,1
-15847,3,20000,1,13,Arisen's Disturber,209,1,8,4,4,1
-15848,3,20000,1,12,Spell of Radiance,209,1,8,4,0,1
-15849,3,20000,1,12,Spell of Radiance,209,1,8,4,1,1
-15850,3,20000,1,12,Spell of Radiance,209,1,8,4,2,1
-15851,3,20000,1,12,Spell of Radiance,209,1,8,4,3,1
-15852,3,20000,1,12,Spell of Radiance,209,1,8,4,4,1
+15838,3,1000,1,20,Polished Spell,209,1,8,1,0,1
+15839,3,1000,1,25,Polished Spell,209,1,8,1,1,1
+15840,3,1000,1,25,Polished Spell,209,1,8,1,2,1
+15841,3,1000,1,30,Polished Spell,209,1,8,1,3,1
+15842,3,1000,1,35,Polished Spell,209,1,8,1,4,1
+15843,3,20000,1,45,Arisen's Disturber,209,1,8,4,0,1
+15844,3,20000,1,45,Arisen's Disturber,209,1,8,4,1,1
+15845,3,20000,1,45,Arisen's Disturber,209,1,8,4,2,1
+15846,3,20000,1,45,Arisen's Disturber,209,1,8,4,3,1
+15847,3,20000,1,45,Arisen's Disturber,209,1,8,4,4,1
+15848,3,20000,1,60,Spell of Radiance,209,1,8,4,0,1
+15849,3,20000,1,60,Spell of Radiance,209,1,8,4,1,1
+15850,3,20000,1,60,Spell of Radiance,209,1,8,4,2,1
+15851,3,20000,1,60,Spell of Radiance,209,1,8,4,3,1
+15852,3,20000,1,60,Spell of Radiance,209,1,8,4,4,1
 15853,3,100,1,1,Rusted Staff,211,1,4,1,0,1
 15854,3,100,1,1,Rusted Staff,211,1,4,1,1,1
 15855,3,100,1,1,Rusted Staff,211,1,4,1,2,1
 15856,3,100,1,1,Rusted Staff,211,1,4,1,3,1
 15857,3,100,1,1,Rusted Staff,211,1,4,1,4,1
-15858,3,1000,1,4,Polished Staff,211,1,4,1,0,1
-15859,3,1000,1,9,Polished Staff,211,1,4,1,1,1
-15860,3,1000,1,9,Polished Staff,211,1,4,1,2,1
-15861,3,1000,1,14,Polished Staff,211,1,4,1,3,1
-15862,3,1000,1,3,Polished Staff,211,1,4,1,4,1
-15863,3,20000,1,13,Arisen's Dispeller,211,1,4,4,0,1
-15864,3,20000,1,13,Arisen's Dispeller,211,1,4,4,1,1
-15865,3,20000,1,13,Arisen's Dispeller,211,1,4,4,2,1
-15866,3,20000,1,13,Arisen's Dispeller,211,1,4,4,3,1
-15867,3,20000,1,13,Arisen's Dispeller,211,1,4,4,4,1
-15868,3,20000,1,12,Staff of Radiance,211,1,4,4,0,1
-15869,3,20000,1,12,Staff of Radiance,211,1,4,4,1,1
-15870,3,20000,1,12,Staff of Radiance,211,1,4,4,2,1
-15871,3,20000,1,12,Staff of Radiance,211,1,4,4,3,1
-15872,3,20000,1,12,Staff of Radiance,211,1,4,4,4,1
+15858,3,1000,1,20,Polished Staff,211,1,4,1,0,1
+15859,3,1000,1,25,Polished Staff,211,1,4,1,1,1
+15860,3,1000,1,25,Polished Staff,211,1,4,1,2,1
+15861,3,1000,1,30,Polished Staff,211,1,4,1,3,1
+15862,3,1000,1,35,Polished Staff,211,1,4,1,4,1
+15863,3,20000,1,45,Arisen's Dispeller,211,1,4,4,0,1
+15864,3,20000,1,45,Arisen's Dispeller,211,1,4,4,1,1
+15865,3,20000,1,45,Arisen's Dispeller,211,1,4,4,2,1
+15866,3,20000,1,45,Arisen's Dispeller,211,1,4,4,3,1
+15867,3,20000,1,45,Arisen's Dispeller,211,1,4,4,4,1
+15868,3,20000,1,60,Staff of Radiance,211,1,4,4,0,1
+15869,3,20000,1,60,Staff of Radiance,211,1,4,4,1,1
+15870,3,20000,1,60,Staff of Radiance,211,1,4,4,2,1
+15871,3,20000,1,60,Staff of Radiance,211,1,4,4,3,1
+15872,3,20000,1,60,Staff of Radiance,211,1,4,4,4,1
 15873,3,100,1,1,Rusted Archistaff,212,1,6,1,0,1
 15874,3,100,1,1,Rusted Archistaff,212,1,6,1,1,1
 15875,3,100,1,1,Rusted Archistaff,212,1,6,1,2,1
 15876,3,100,1,1,Rusted Archistaff,212,1,6,1,3,1
 15877,3,100,1,1,Rusted Archistaff,212,1,6,1,4,1
-15878,3,1000,1,4,Polished Wand,212,1,6,1,0,1
-15879,3,1000,1,9,Polished Wand,212,1,6,1,1,1
-15880,3,1000,1,9,Polished Wand,212,1,6,1,2,1
-15881,3,1000,1,14,Polished Wand,212,1,6,1,3,1
-15882,3,1000,1,3,Polished Wand,212,1,6,1,4,1
-15883,3,20000,1,13,Arisen's Annihilator,212,1,6,4,0,1
-15884,3,20000,1,13,Arisen's Annihilator,212,1,6,4,1,1
-15885,3,20000,1,13,Arisen's Annihilator,212,1,6,4,2,1
-15886,3,20000,1,13,Arisen's Annihilator,212,1,6,4,3,1
-15887,3,20000,1,13,Arisen's Annihilator,212,1,6,4,4,1
-15888,3,20000,1,12,Wand of Radiance,212,1,6,4,0,1
-15889,3,20000,1,12,Wand of Radiance,212,1,6,4,1,1
-15890,3,20000,1,12,Wand of Radiance,212,1,6,4,2,1
-15891,3,20000,1,12,Wand of Radiance,212,1,6,4,3,1
-15892,3,20000,1,12,Wand of Radiance,212,1,6,4,4,1
+15878,3,1000,1,20,Polished Wand,212,1,6,1,0,1
+15879,3,1000,1,25,Polished Wand,212,1,6,1,1,1
+15880,3,1000,1,25,Polished Wand,212,1,6,1,2,1
+15881,3,1000,1,30,Polished Wand,212,1,6,1,3,1
+15882,3,1000,1,35,Polished Wand,212,1,6,1,4,1
+15883,3,20000,1,45,Arisen's Annihilator,212,1,6,4,0,1
+15884,3,20000,1,45,Arisen's Annihilator,212,1,6,4,1,1
+15885,3,20000,1,45,Arisen's Annihilator,212,1,6,4,2,1
+15886,3,20000,1,45,Arisen's Annihilator,212,1,6,4,3,1
+15887,3,20000,1,45,Arisen's Annihilator,212,1,6,4,4,1
+15888,3,20000,1,60,Wand of Radiance,212,1,6,4,0,1
+15889,3,20000,1,60,Wand of Radiance,212,1,6,4,1,1
+15890,3,20000,1,60,Wand of Radiance,212,1,6,4,2,1
+15891,3,20000,1,60,Wand of Radiance,212,1,6,4,3,1
+15892,3,20000,1,60,Wand of Radiance,212,1,6,4,4,1
 15893,3,100,1,1,Rusted Spirit Lance,213,1,10,1,0,1
 15894,3,100,1,1,Rusted Spirit Lance,213,1,10,1,1,1
 15895,3,100,1,1,Rusted Spirit Lance,213,1,10,1,2,1
 15896,3,100,1,1,Rusted Spirit Lance,213,1,10,1,3,1
 15897,3,100,1,1,Rusted Spirit Lance,213,1,10,1,4,1
-15898,3,1000,1,4,Polished Lance,213,1,10,1,0,1
-15899,3,1000,1,9,Polished Lance,213,1,10,1,1,1
-15900,3,1000,1,9,Polished Lance,213,1,10,1,2,1
-15901,3,1000,1,14,Polished Lance,213,1,10,1,3,1
-15902,3,1000,1,3,Polished Lance,213,1,10,1,4,1
-15903,3,20000,1,13,Arisen's Penetrator,213,1,10,4,0,1
-15904,3,20000,1,13,Arisen's Penetrator,213,1,10,4,1,1
-15905,3,20000,1,13,Arisen's Penetrator,213,1,10,4,2,1
-15906,3,20000,1,13,Arisen's Penetrator,213,1,10,4,3,1
-15907,3,20000,1,13,Arisen's Penetrator,213,1,10,4,4,1
-15908,3,20000,1,12,Spear of Radiance,213,1,10,4,0,1
-15909,3,20000,1,12,Spear of Radiance,213,1,10,4,1,1
-15910,3,20000,1,12,Spear of Radiance,213,1,10,4,2,1
-15911,3,20000,1,12,Spear of Radiance,213,1,10,4,3,1
-15912,3,20000,1,12,Spear of Radiance,213,1,10,4,4,1
-16144,3,10000,1,15,Adel's Greatsword,201,1,1,0,0,1
-16145,3,10000,1,15,Adel's Greatsword,201,1,1,0,1,1
-16146,3,10000,1,15,Adel's Greatsword,201,1,1,0,2,1
-16147,3,10000,1,15,Adel's Greatsword,201,1,1,0,3,1
-16148,3,10000,1,15,Adel's Greatsword,201,1,1,0,4,1
-16149,3,10000,1,15,Ice Sword,203,1,7,0,0,1
-16150,3,10000,1,15,Ice Sword,203,1,7,0,1,1
-16151,3,10000,1,15,Ice Sword,203,1,7,0,2,1
-16152,3,10000,1,15,Ice Sword,203,1,7,0,3,1
-16153,3,10000,1,15,Ice Sword,203,1,7,0,4,1
+15898,3,1000,1,20,Polished Lance,213,1,10,1,0,1
+15899,3,1000,1,25,Polished Lance,213,1,10,1,1,1
+15900,3,1000,1,25,Polished Lance,213,1,10,1,2,1
+15901,3,1000,1,30,Polished Lance,213,1,10,1,3,1
+15902,3,1000,1,35,Polished Lance,213,1,10,1,4,1
+15903,3,20000,1,45,Arisen's Penetrator,213,1,10,4,0,1
+15904,3,20000,1,45,Arisen's Penetrator,213,1,10,4,1,1
+15905,3,20000,1,45,Arisen's Penetrator,213,1,10,4,2,1
+15906,3,20000,1,45,Arisen's Penetrator,213,1,10,4,3,1
+15907,3,20000,1,45,Arisen's Penetrator,213,1,10,4,4,1
+15908,3,20000,1,60,Spear of Radiance,213,1,10,4,0,1
+15909,3,20000,1,60,Spear of Radiance,213,1,10,4,1,1
+15910,3,20000,1,60,Spear of Radiance,213,1,10,4,2,1
+15911,3,20000,1,60,Spear of Radiance,213,1,10,4,3,1
+15912,3,20000,1,60,Spear of Radiance,213,1,10,4,4,1
+16144,3,10000,1,31,Adel's Greatsword,201,1,1,0,0,1
+16145,3,10000,1,31,Adel's Greatsword,201,1,1,0,1,1
+16146,3,10000,1,31,Adel's Greatsword,201,1,1,0,2,1
+16147,3,10000,1,31,Adel's Greatsword,201,1,1,0,3,1
+16148,3,10000,1,31,Adel's Greatsword,201,1,1,0,4,1
+16149,3,10000,1,31,Ice Sword,203,1,7,0,0,1
+16150,3,10000,1,31,Ice Sword,203,1,7,0,1,1
+16151,3,10000,1,31,Ice Sword,203,1,7,0,2,1
+16152,3,10000,1,31,Ice Sword,203,1,7,0,3,1
+16153,3,10000,1,31,Ice Sword,203,1,7,0,4,1
 16472,3,100,1,1,Sacred Edge (Decoration),201,1,1,0,4,1
 16474,3,100,1,1,Noblesse Oblige (Decoration),203,1,7,0,4,1
 16475,3,100,1,1,Savior Fort (Decoration),204,1,5,0,4,1
@@ -8181,1736 +8181,1736 @@
 16480,3,100,1,1,Religious Beyond (Decoration),209,1,8,0,4,1
 16481,3,100,1,1,White Revelation (Decoration),211,1,4,0,4,1
 16482,3,100,1,1,Idealise (Decoration),212,1,6,0,4,1
-16502,3,20000,1,7,Roaring Blaze Scale Sword,201,70,1,4,4,1
-16503,3,20000,1,6,Tyrant Sword of Torn Light,201,75,1,4,4,1
-16504,3,20000,1,7,Roaring Blaze Scale Blade,203,70,7,4,4,1
-16505,3,20000,1,6,Tyrant Blade of Torn Light,203,75,7,4,4,1
-16506,3,20000,1,7,Roaring Blaze Scale Guard,204,70,5,4,4,1
-16507,3,20000,1,6,Tyrant Guard of Torn Light,204,75,5,4,4,1
-16508,3,20000,1,7,Roaring Blaze Scale Daggers,206,70,2,4,4,1
-16509,3,20000,1,6,Tyrant Daggers of Torn Light,206,75,2,4,4,1
-16510,3,20000,1,7,Roaring Blaze Scale Bow,207,70,3,4,4,1
-16511,3,20000,1,6,Tyrant Bow of Torn Light,207,75,3,4,4,1
-16512,3,20000,1,7,Roaring Blaze Scale Hands,208,70,9,4,4,1
-16513,3,20000,1,6,Tyrant Hands of Torn Light,208,75,9,4,4,1
-16514,3,20000,1,7,Roaring Blaze Scale Shooter,209,70,8,4,4,1
-16515,3,20000,1,6,Tyrant Spell of Torn Light,209,75,8,4,4,1
-16516,3,20000,1,7,Roaring Blaze Scale Staff,211,70,4,4,4,1
-16517,3,20000,1,6,Tyrant Staff of Torn Light,211,75,4,4,4,1
-16518,3,20000,1,7,Roaring Blaze Scale Wand,212,70,6,4,4,1
-16519,3,20000,1,6,Tyrant Wand of Torn Light,212,75,6,4,4,1
-16520,3,20000,1,7,Roaring Blaze Scale Spear,213,70,10,4,4,1
-16521,3,20000,1,6,Tyrant Spear of Torn Light,213,75,10,4,4,1
+16502,3,20000,1,55,Roaring Blaze Scale Sword,201,70,1,4,4,1
+16503,3,20000,1,70,Tyrant Sword of Torn Light,201,75,1,4,4,1
+16504,3,20000,1,55,Roaring Blaze Scale Blade,203,70,7,4,4,1
+16505,3,20000,1,70,Tyrant Blade of Torn Light,203,75,7,4,4,1
+16506,3,20000,1,55,Roaring Blaze Scale Guard,204,70,5,4,4,1
+16507,3,20000,1,70,Tyrant Guard of Torn Light,204,75,5,4,4,1
+16508,3,20000,1,55,Roaring Blaze Scale Daggers,206,70,2,4,4,1
+16509,3,20000,1,70,Tyrant Daggers of Torn Light,206,75,2,4,4,1
+16510,3,20000,1,55,Roaring Blaze Scale Bow,207,70,3,4,4,1
+16511,3,20000,1,70,Tyrant Bow of Torn Light,207,75,3,4,4,1
+16512,3,20000,1,55,Roaring Blaze Scale Hands,208,70,9,4,4,1
+16513,3,20000,1,70,Tyrant Hands of Torn Light,208,75,9,4,4,1
+16514,3,20000,1,55,Roaring Blaze Scale Shooter,209,70,8,4,4,1
+16515,3,20000,1,70,Tyrant Spell of Torn Light,209,75,8,4,4,1
+16516,3,20000,1,55,Roaring Blaze Scale Staff,211,70,4,4,4,1
+16517,3,20000,1,70,Tyrant Staff of Torn Light,211,75,4,4,4,1
+16518,3,20000,1,55,Roaring Blaze Scale Wand,212,70,6,4,4,1
+16519,3,20000,1,70,Tyrant Wand of Torn Light,212,75,6,4,4,1
+16520,3,20000,1,55,Roaring Blaze Scale Spear,213,70,10,4,4,1
+16521,3,20000,1,70,Tyrant Spear of Torn Light,213,75,10,4,4,1
 16523,3,200,1,3,Conspicuous Rusted One-handed Sword,201,1,1,1,0,1
 16524,3,200,1,3,Conspicuous Rusted One-handed Sword,201,1,1,1,1,1
 16525,3,200,1,3,Conspicuous Rusted One-handed Sword,201,1,1,1,2,1
 16526,3,200,1,3,Conspicuous Rusted One-handed Sword,201,1,1,1,3,1
 16527,3,200,1,3,Conspicuous Rusted One-handed Sword,201,1,1,1,4,1
-16528,3,20000,1,12,Rose Tones,201,1,1,1,0,1
-16529,3,20000,1,1,Rose Tones,201,1,1,1,1,1
-16530,3,20000,1,1,Rose Tones,201,1,1,1,2,1
-16531,3,20000,1,6,Rose Tones,201,1,1,1,3,1
-16532,3,20000,1,11,Rose Tones,201,1,1,1,4,1
+16528,3,20000,1,60,Rose Tones,201,1,1,1,0,1
+16529,3,20000,1,65,Rose Tones,201,1,1,1,1,1
+16530,3,20000,1,65,Rose Tones,201,1,1,1,2,1
+16531,3,20000,1,70,Rose Tones,201,1,1,1,3,1
+16532,3,20000,1,75,Rose Tones,201,1,1,1,4,1
 16536,3,200,1,3,Conspicuous Rusted Greatsword,203,1,7,1,0,1
 16537,3,200,1,3,Conspicuous Rusted Greatsword,203,1,7,1,1,1
 16538,3,200,1,3,Conspicuous Rusted Greatsword,203,1,7,1,2,1
 16539,3,200,1,3,Conspicuous Rusted Greatsword,203,1,7,1,3,1
 16540,3,200,1,3,Conspicuous Rusted Greatsword,203,1,7,1,4,1
-16541,3,20000,1,12,Wanted Heart,203,1,7,1,0,1
-16542,3,20000,1,1,Wanted Heart,203,1,7,1,1,1
-16543,3,20000,1,1,Wanted Heart,203,1,7,1,2,1
-16544,3,20000,1,6,Wanted Heart,203,1,7,1,3,1
-16545,3,20000,1,11,Wanted Heart,203,1,7,1,4,1
+16541,3,20000,1,60,Wanted Heart,203,1,7,1,0,1
+16542,3,20000,1,65,Wanted Heart,203,1,7,1,1,1
+16543,3,20000,1,65,Wanted Heart,203,1,7,1,2,1
+16544,3,20000,1,70,Wanted Heart,203,1,7,1,3,1
+16545,3,20000,1,75,Wanted Heart,203,1,7,1,4,1
 16546,3,200,1,3,Conspicuous Rusted Greatshield,204,1,5,1,0,1
 16547,3,200,1,3,Conspicuous Rusted Greatshield,204,1,5,1,1,1
 16548,3,200,1,3,Conspicuous Rusted Greatshield,204,1,5,1,2,1
 16549,3,200,1,3,Conspicuous Rusted Greatshield,204,1,5,1,3,1
 16550,3,200,1,3,Conspicuous Rusted Greatshield,204,1,5,1,4,1
-16551,3,20000,1,12,Dark Pavise,204,1,5,1,0,1
-16552,3,20000,1,1,Dark Pavise,204,1,5,1,1,1
-16553,3,20000,1,1,Dark Pavise,204,1,5,1,2,1
-16554,3,20000,1,6,Dark Pavise,204,1,5,1,3,1
-16555,3,20000,1,11,Dark Pavise,204,1,5,1,4,1
+16551,3,20000,1,60,Dark Pavise,204,1,5,1,0,1
+16552,3,20000,1,65,Dark Pavise,204,1,5,1,1,1
+16553,3,20000,1,65,Dark Pavise,204,1,5,1,2,1
+16554,3,20000,1,70,Dark Pavise,204,1,5,1,3,1
+16555,3,20000,1,75,Dark Pavise,204,1,5,1,4,1
 16556,3,200,1,3,Conspicuous Rusted Daggers,206,1,2,1,0,1
 16557,3,200,1,3,Conspicuous Rusted Daggers,206,1,2,1,1,1
 16558,3,200,1,3,Conspicuous Rusted Daggers,206,1,2,1,2,1
 16559,3,200,1,3,Conspicuous Rusted Daggers,206,1,2,1,3,1
 16560,3,200,1,3,Conspicuous Rusted Daggers,206,1,2,1,4,1
-16561,3,20000,1,12,Dark Parazonium,206,1,2,1,0,1
-16562,3,20000,1,1,Dark Parazonium,206,1,2,1,1,1
-16563,3,20000,1,1,Dark Parazonium,206,1,2,1,2,1
-16564,3,20000,1,6,Dark Parazonium,206,1,2,1,3,1
-16565,3,20000,1,11,Dark Parazonium,206,1,2,1,4,1
+16561,3,20000,1,60,Dark Parazonium,206,1,2,1,0,1
+16562,3,20000,1,65,Dark Parazonium,206,1,2,1,1,1
+16563,3,20000,1,65,Dark Parazonium,206,1,2,1,2,1
+16564,3,20000,1,70,Dark Parazonium,206,1,2,1,3,1
+16565,3,20000,1,75,Dark Parazonium,206,1,2,1,4,1
 16566,3,200,1,3,Conspicuous Rusted Bow,207,1,3,1,0,1
 16567,3,200,1,3,Conspicuous Rusted Bow,207,1,3,1,1,1
 16568,3,200,1,3,Conspicuous Rusted Bow,207,1,3,1,2,1
 16569,3,200,1,3,Conspicuous Rusted Bow,207,1,3,1,3,1
 16570,3,200,1,3,Conspicuous Rusted Bow,207,1,3,1,4,1
-16571,3,20000,1,12,Dragon's Blink,207,1,3,1,0,1
-16572,3,20000,1,1,Dragon's Blink,207,1,3,1,1,1
-16573,3,20000,1,1,Dragon's Blink,207,1,3,1,2,1
-16574,3,20000,1,6,Dragon's Blink,207,1,3,1,3,1
-16575,3,20000,1,11,Dragon's Blink,207,1,3,1,4,1
+16571,3,20000,1,60,Dragon's Blink,207,1,3,1,0,1
+16572,3,20000,1,65,Dragon's Blink,207,1,3,1,1,1
+16573,3,20000,1,65,Dragon's Blink,207,1,3,1,2,1
+16574,3,20000,1,70,Dragon's Blink,207,1,3,1,3,1
+16575,3,20000,1,75,Dragon's Blink,207,1,3,1,4,1
 16576,3,200,1,3,Conspicuous Rusted Magick Gauntlet,208,1,9,1,0,1
 16577,3,200,1,3,Conspicuous Rusted Magick Gauntlet,208,1,9,1,1,1
 16578,3,200,1,3,Conspicuous Rusted Magick Gauntlet,208,1,9,1,2,1
 16579,3,200,1,3,Conspicuous Rusted Magick Gauntlet,208,1,9,1,3,1
 16580,3,200,1,3,Conspicuous Rusted Magick Gauntlet,208,1,9,1,4,1
-16581,3,20000,1,12,Hidden Seiðr,208,1,9,1,0,1
-16582,3,20000,1,1,Hidden Seiðr,208,1,9,1,1,1
-16583,3,20000,1,1,Hidden Seiðr,208,1,9,1,2,1
-16584,3,20000,1,6,Hidden Seiðr,208,1,9,1,3,1
-16585,3,20000,1,11,Hidden Seiðr,208,1,9,1,4,1
+16581,3,20000,1,60,Hidden Seiðr,208,1,9,1,0,1
+16582,3,20000,1,65,Hidden Seiðr,208,1,9,1,1,1
+16583,3,20000,1,65,Hidden Seiðr,208,1,9,1,2,1
+16584,3,20000,1,70,Hidden Seiðr,208,1,9,1,3,1
+16585,3,20000,1,75,Hidden Seiðr,208,1,9,1,4,1
 16586,3,200,1,3,Conspicuous Rusted Magick Bow,209,1,8,1,0,1
 16587,3,200,1,3,Conspicuous Rusted Magick Bow,209,1,8,1,1,1
 16588,3,200,1,3,Conspicuous Rusted Magick Bow,209,1,8,1,2,1
 16589,3,200,1,3,Conspicuous Rusted Magick Bow,209,1,8,1,3,1
 16590,3,200,1,3,Conspicuous Rusted Magick Bow,209,1,8,1,4,1
-16591,3,20000,1,12,Dragon's Supreme,209,1,8,1,0,1
-16592,3,20000,1,1,Dragon's Supreme,209,1,8,1,1,1
-16593,3,20000,1,1,Dragon's Supreme,209,1,8,1,2,1
-16594,3,20000,1,6,Dragon's Supreme,209,1,8,1,3,1
-16595,3,20000,1,11,Dragon's Supreme,209,1,8,1,4,1
+16591,3,20000,1,60,Dragon's Supreme,209,1,8,1,0,1
+16592,3,20000,1,65,Dragon's Supreme,209,1,8,1,1,1
+16593,3,20000,1,65,Dragon's Supreme,209,1,8,1,2,1
+16594,3,20000,1,70,Dragon's Supreme,209,1,8,1,3,1
+16595,3,20000,1,75,Dragon's Supreme,209,1,8,1,4,1
 16596,3,200,1,3,Conspicuous Rusted Staff,211,1,4,1,0,1
 16597,3,200,1,3,Conspicuous Rusted Staff,211,1,4,1,1,1
 16598,3,200,1,3,Conspicuous Rusted Staff,211,1,4,1,2,1
 16599,3,200,1,3,Conspicuous Rusted Staff,211,1,4,1,3,1
 16600,3,200,1,3,Conspicuous Rusted Staff,211,1,4,1,4,1
-16601,3,20000,1,12,Chilly Cane,211,1,4,1,0,1
-16602,3,20000,1,1,Chilly Cane,211,1,4,1,1,1
-16603,3,20000,1,1,Chilly Cane,211,1,4,1,2,1
-16604,3,20000,1,6,Chilly Cane,211,1,4,1,3,1
-16605,3,20000,1,11,Chilly Cane,211,1,4,1,4,1
+16601,3,20000,1,60,Chilly Cane,211,1,4,1,0,1
+16602,3,20000,1,65,Chilly Cane,211,1,4,1,1,1
+16603,3,20000,1,65,Chilly Cane,211,1,4,1,2,1
+16604,3,20000,1,70,Chilly Cane,211,1,4,1,3,1
+16605,3,20000,1,75,Chilly Cane,211,1,4,1,4,1
 16606,3,200,1,3,Conspicuous Rusted Archistaff,212,1,6,1,0,1
 16607,3,200,1,3,Conspicuous Rusted Archistaff,212,1,6,1,1,1
 16608,3,200,1,3,Conspicuous Rusted Archistaff,212,1,6,1,2,1
 16609,3,200,1,3,Conspicuous Rusted Archistaff,212,1,6,1,3,1
 16610,3,200,1,3,Conspicuous Rusted Archistaff,212,1,6,1,4,1
-16611,3,20000,1,12,Road to Hades,212,1,6,1,0,1
-16612,3,20000,1,1,Road to Hades,212,1,6,1,1,1
-16613,3,20000,1,1,Road to Hades,212,1,6,1,2,1
-16614,3,20000,1,6,Road to Hades,212,1,6,1,3,1
-16615,3,20000,1,11,Road to Hades,212,1,6,1,4,1
+16611,3,20000,1,60,Road to Hades,212,1,6,1,0,1
+16612,3,20000,1,65,Road to Hades,212,1,6,1,1,1
+16613,3,20000,1,65,Road to Hades,212,1,6,1,2,1
+16614,3,20000,1,70,Road to Hades,212,1,6,1,3,1
+16615,3,20000,1,75,Road to Hades,212,1,6,1,4,1
 16616,3,200,1,3,Conspicuous Rusted Spirit Lance,213,1,10,1,0,1
 16617,3,200,1,3,Conspicuous Rusted Spirit Lance,213,1,10,1,1,1
 16618,3,200,1,3,Conspicuous Rusted Spirit Lance,213,1,10,1,2,1
 16619,3,200,1,3,Conspicuous Rusted Spirit Lance,213,1,10,1,3,1
 16620,3,200,1,3,Conspicuous Rusted Spirit Lance,213,1,10,1,4,1
-16621,3,20000,1,12,Everlance,213,1,10,1,0,1
-16622,3,20000,1,1,Everlance,213,1,10,1,1,1
-16623,3,20000,1,1,Everlance,213,1,10,1,2,1
-16624,3,20000,1,6,Everlance,213,1,10,1,3,1
-16625,3,20000,1,11,Everlance,213,1,10,1,4,1
-16633,3,5000,1,12,Olfring Sword (Blue-green),201,1,1,4,0,1
-16634,3,5000,1,12,Olfring Sword (Blue-green),201,1,1,4,1,1
-16635,3,5000,1,12,Olfring Sword (Blue-green),201,1,1,4,2,1
-16636,3,5000,1,12,Olfring Sword (Blue-green),201,1,1,4,3,1
-16637,3,5000,1,12,Olfring Sword (Blue-green),201,1,1,4,4,1
-16638,3,5000,1,2,Olfring Sword+ (Heaven),201,1,1,4,0,1
-16639,3,5000,1,2,Olfring Sword+ (Heaven),201,1,1,4,1,1
-16640,3,5000,1,2,Olfring Sword+ (Heaven),201,1,1,4,2,1
-16641,3,5000,1,2,Olfring Sword+ (Heaven),201,1,1,4,3,1
-16642,3,5000,1,2,Olfring Sword+ (Heaven),201,1,1,4,4,1
-16643,3,5000,1,1,Ceremonial Daggers+ (Heaven),201,1,1,4,0,1
-16644,3,5000,1,1,Ceremonial Daggers+ (Heaven),201,1,1,4,1,1
-16645,3,5000,1,1,Ceremonial Daggers+ (Heaven),201,1,1,4,2,1
-16646,3,5000,1,1,Ceremonial Daggers+ (Heaven),201,1,1,4,3,1
-16647,3,5000,1,1,Ceremonial Daggers+ (Heaven),201,1,1,4,4,1
-16663,3,5000,1,2,Olfring Guard+ (Red),204,1,5,4,0,1
-16664,3,5000,1,2,Olfring Guard+ (Red),204,1,5,4,1,1
-16665,3,5000,1,2,Olfring Guard+ (Red),204,1,5,4,2,1
-16666,3,5000,1,2,Olfring Guard+ (Red),204,1,5,4,3,1
-16667,3,5000,1,2,Olfring Guard+ (Red),204,1,5,4,4,1
-16668,3,5000,1,1,Ceremonial Guard+ (Red),204,1,5,4,0,1
-16669,3,5000,1,1,Ceremonial Guard+ (Red),204,1,5,4,1,1
-16670,3,5000,1,1,Ceremonial Guard+ (Red),204,1,5,4,2,1
-16671,3,5000,1,1,Ceremonial Guard+ (Red),204,1,5,4,3,1
-16672,3,5000,1,1,Ceremonial Guard+ (Red),204,1,5,4,4,1
-16683,3,5000,1,2,Olfring Bow+ (Earth),207,1,3,4,0,1
-16684,3,5000,1,2,Olfring Bow+ (Earth),207,1,3,4,1,1
-16685,3,5000,1,2,Olfring Bow+ (Earth),207,1,3,4,2,1
-16686,3,5000,1,2,Olfring Bow+ (Earth),207,1,3,4,3,1
-16687,3,5000,1,2,Olfring Bow+ (Earth),207,1,3,4,4,1
-16688,3,5000,1,1,Ceremonial Bow+ (Earth),207,1,3,4,0,1
-16689,3,5000,1,1,Ceremonial Bow+ (Earth),207,1,3,4,1,1
-16690,3,5000,1,1,Ceremonial Bow+ (Earth),207,1,3,4,2,1
-16691,3,5000,1,1,Ceremonial Bow+ (Earth),207,1,3,4,3,1
-16692,3,5000,1,1,Ceremonial Bow+ (Earth),207,1,3,4,4,1
-16693,3,5000,1,12,Olfring Cane (Blue-green),211,1,4,4,0,1
-16694,3,5000,1,12,Olfring Cane (Blue-green),211,1,4,4,1,1
-16695,3,5000,1,12,Olfring Cane (Blue-green),211,1,4,4,2,1
-16696,3,5000,1,12,Olfring Cane (Blue-green),211,1,4,4,3,1
-16697,3,5000,1,12,Olfring Cane (Blue-green),211,1,4,4,4,1
-16764,3,214,1,13,Melty Sword,201,1,1,4,4,1
-16765,3,314,1,13,Sincere Sword,201,1,1,4,4,1
-16768,3,214,1,13,Melty Blade,203,1,7,4,4,1
-16769,3,314,1,13,Sincere Blade,203,1,7,4,4,1
-16770,3,214,1,13,Melty Wall,204,1,5,4,4,1
-16771,3,314,1,13,Sincere Wall,204,1,5,4,4,1
-16774,3,214,1,13,Melty Daggers,206,1,2,4,4,1
-16775,3,314,1,13,Sincere Daggers,206,1,2,4,4,1
-16776,3,214,1,13,Melty Bow,207,1,3,4,4,1
-16777,3,314,1,13,Sincere Bow,207,1,3,4,4,1
-16778,3,214,1,13,Melty Seiðr,208,1,9,4,4,1
-16779,3,314,1,13,Sincere Seiðr,208,1,9,4,4,1
-16780,3,214,1,13,Melty Shooter,209,1,8,4,4,1
-16781,3,314,1,13,Sincere Shooter,209,1,8,4,4,1
-16782,3,214,1,13,Melty Staff,211,1,4,4,4,1
-16783,3,314,1,13,Sincere Staff,211,1,4,4,4,1
-16784,3,214,1,13,Melty Wand,212,1,6,4,4,1
-16785,3,314,1,13,Sincere Wand,212,1,6,4,4,1
-16786,3,214,1,13,Melty Spear,213,1,10,4,4,1
-16787,3,314,1,13,Sincere Spear,213,1,10,4,4,1
+16621,3,20000,1,60,Everlance,213,1,10,1,0,1
+16622,3,20000,1,65,Everlance,213,1,10,1,1,1
+16623,3,20000,1,65,Everlance,213,1,10,1,2,1
+16624,3,20000,1,70,Everlance,213,1,10,1,3,1
+16625,3,20000,1,75,Everlance,213,1,10,1,4,1
+16633,3,5000,1,60,Olfring Sword (Blue-green),201,1,1,4,0,1
+16634,3,5000,1,60,Olfring Sword (Blue-green),201,1,1,4,1,1
+16635,3,5000,1,60,Olfring Sword (Blue-green),201,1,1,4,2,1
+16636,3,5000,1,60,Olfring Sword (Blue-green),201,1,1,4,3,1
+16637,3,5000,1,60,Olfring Sword (Blue-green),201,1,1,4,4,1
+16638,3,5000,1,50,Olfring Sword+ (Heaven),201,1,1,4,0,1
+16639,3,5000,1,50,Olfring Sword+ (Heaven),201,1,1,4,1,1
+16640,3,5000,1,50,Olfring Sword+ (Heaven),201,1,1,4,2,1
+16641,3,5000,1,50,Olfring Sword+ (Heaven),201,1,1,4,3,1
+16642,3,5000,1,50,Olfring Sword+ (Heaven),201,1,1,4,4,1
+16643,3,5000,1,65,Ceremonial Daggers+ (Heaven),201,1,1,4,0,1
+16644,3,5000,1,65,Ceremonial Daggers+ (Heaven),201,1,1,4,1,1
+16645,3,5000,1,65,Ceremonial Daggers+ (Heaven),201,1,1,4,2,1
+16646,3,5000,1,65,Ceremonial Daggers+ (Heaven),201,1,1,4,3,1
+16647,3,5000,1,65,Ceremonial Daggers+ (Heaven),201,1,1,4,4,1
+16663,3,5000,1,50,Olfring Guard+ (Red),204,1,5,4,0,1
+16664,3,5000,1,50,Olfring Guard+ (Red),204,1,5,4,1,1
+16665,3,5000,1,50,Olfring Guard+ (Red),204,1,5,4,2,1
+16666,3,5000,1,50,Olfring Guard+ (Red),204,1,5,4,3,1
+16667,3,5000,1,50,Olfring Guard+ (Red),204,1,5,4,4,1
+16668,3,5000,1,65,Ceremonial Guard+ (Red),204,1,5,4,0,1
+16669,3,5000,1,65,Ceremonial Guard+ (Red),204,1,5,4,1,1
+16670,3,5000,1,65,Ceremonial Guard+ (Red),204,1,5,4,2,1
+16671,3,5000,1,65,Ceremonial Guard+ (Red),204,1,5,4,3,1
+16672,3,5000,1,65,Ceremonial Guard+ (Red),204,1,5,4,4,1
+16683,3,5000,1,50,Olfring Bow+ (Earth),207,1,3,4,0,1
+16684,3,5000,1,50,Olfring Bow+ (Earth),207,1,3,4,1,1
+16685,3,5000,1,50,Olfring Bow+ (Earth),207,1,3,4,2,1
+16686,3,5000,1,50,Olfring Bow+ (Earth),207,1,3,4,3,1
+16687,3,5000,1,50,Olfring Bow+ (Earth),207,1,3,4,4,1
+16688,3,5000,1,65,Ceremonial Bow+ (Earth),207,1,3,4,0,1
+16689,3,5000,1,65,Ceremonial Bow+ (Earth),207,1,3,4,1,1
+16690,3,5000,1,65,Ceremonial Bow+ (Earth),207,1,3,4,2,1
+16691,3,5000,1,65,Ceremonial Bow+ (Earth),207,1,3,4,3,1
+16692,3,5000,1,65,Ceremonial Bow+ (Earth),207,1,3,4,4,1
+16693,3,5000,1,60,Olfring Cane (Blue-green),211,1,4,4,0,1
+16694,3,5000,1,60,Olfring Cane (Blue-green),211,1,4,4,1,1
+16695,3,5000,1,60,Olfring Cane (Blue-green),211,1,4,4,2,1
+16696,3,5000,1,60,Olfring Cane (Blue-green),211,1,4,4,3,1
+16697,3,5000,1,60,Olfring Cane (Blue-green),211,1,4,4,4,1
+16764,3,214,1,45,Melty Sword,201,1,1,4,4,1
+16765,3,314,1,45,Sincere Sword,201,1,1,4,4,1
+16768,3,214,1,45,Melty Blade,203,1,7,4,4,1
+16769,3,314,1,45,Sincere Blade,203,1,7,4,4,1
+16770,3,214,1,45,Melty Wall,204,1,5,4,4,1
+16771,3,314,1,45,Sincere Wall,204,1,5,4,4,1
+16774,3,214,1,45,Melty Daggers,206,1,2,4,4,1
+16775,3,314,1,45,Sincere Daggers,206,1,2,4,4,1
+16776,3,214,1,45,Melty Bow,207,1,3,4,4,1
+16777,3,314,1,45,Sincere Bow,207,1,3,4,4,1
+16778,3,214,1,45,Melty Seiðr,208,1,9,4,4,1
+16779,3,314,1,45,Sincere Seiðr,208,1,9,4,4,1
+16780,3,214,1,45,Melty Shooter,209,1,8,4,4,1
+16781,3,314,1,45,Sincere Shooter,209,1,8,4,4,1
+16782,3,214,1,45,Melty Staff,211,1,4,4,4,1
+16783,3,314,1,45,Sincere Staff,211,1,4,4,4,1
+16784,3,214,1,45,Melty Wand,212,1,6,4,4,1
+16785,3,314,1,45,Sincere Wand,212,1,6,4,4,1
+16786,3,214,1,45,Melty Spear,213,1,10,4,4,1
+16787,3,314,1,45,Sincere Spear,213,1,10,4,4,1
 16859,3,200,1,1,Conspicuous Rusted One-handed Sword,201,1,1,1,0,1
 16860,3,200,1,1,Conspicuous Rusted One-handed Sword,201,1,1,1,1,1
 16861,3,200,1,1,Conspicuous Rusted One-handed Sword,201,1,1,1,2,1
 16862,3,200,1,1,Conspicuous Rusted One-handed Sword,201,1,1,1,3,1
 16863,3,200,1,1,Conspicuous Rusted One-handed Sword,201,1,1,1,4,1
-16864,3,20000,1,2,Rose Tones,201,1,1,1,0,1
-16865,3,20000,1,7,Rose Tones,201,1,1,1,1,1
-16866,3,20000,1,7,Rose Tones,201,1,1,1,2,1
-16867,3,20000,1,12,Rose Tones,201,1,1,1,3,1
-16868,3,20000,1,1,Rose Tones,201,1,1,1,4,1
+16864,3,20000,1,50,Rose Tones,201,1,1,1,0,1
+16865,3,20000,1,55,Rose Tones,201,1,1,1,1,1
+16866,3,20000,1,55,Rose Tones,201,1,1,1,2,1
+16867,3,20000,1,60,Rose Tones,201,1,1,1,3,1
+16868,3,20000,1,65,Rose Tones,201,1,1,1,4,1
 16869,3,200,1,2,Conspicuous Rusted One-handed Sword,201,1,1,1,0,1
 16870,3,200,1,2,Conspicuous Rusted One-handed Sword,201,1,1,1,1,1
 16871,3,200,1,2,Conspicuous Rusted One-handed Sword,201,1,1,1,2,1
 16872,3,200,1,2,Conspicuous Rusted One-handed Sword,201,1,1,1,3,1
 16873,3,200,1,2,Conspicuous Rusted One-handed Sword,201,1,1,1,4,1
-16874,3,20000,1,7,Rose Tones,201,1,1,1,0,1
-16875,3,20000,1,12,Rose Tones,201,1,1,1,1,1
-16876,3,20000,1,12,Rose Tones,201,1,1,1,2,1
-16877,3,20000,1,1,Rose Tones,201,1,1,1,3,1
-16878,3,20000,1,6,Rose Tones,201,1,1,1,4,1
+16874,3,20000,1,55,Rose Tones,201,1,1,1,0,1
+16875,3,20000,1,60,Rose Tones,201,1,1,1,1,1
+16876,3,20000,1,60,Rose Tones,201,1,1,1,2,1
+16877,3,20000,1,65,Rose Tones,201,1,1,1,3,1
+16878,3,20000,1,70,Rose Tones,201,1,1,1,4,1
 16879,3,200,1,1,Conspicuous Rusted Greatsword,203,1,7,1,0,1
 16880,3,200,1,1,Conspicuous Rusted Greatsword,203,1,7,1,1,1
 16881,3,200,1,1,Conspicuous Rusted Greatsword,203,1,7,1,2,1
 16882,3,200,1,1,Conspicuous Rusted Greatsword,203,1,7,1,3,1
 16883,3,200,1,1,Conspicuous Rusted Greatsword,203,1,7,1,4,1
-16884,3,20000,1,2,Wanted Heart,203,1,7,1,0,1
-16885,3,20000,1,7,Wanted Heart,203,1,7,1,1,1
-16886,3,20000,1,7,Wanted Heart,203,1,7,1,2,1
-16887,3,20000,1,12,Wanted Heart,203,1,7,1,3,1
-16888,3,20000,1,1,Wanted Heart,203,1,7,1,4,1
+16884,3,20000,1,50,Wanted Heart,203,1,7,1,0,1
+16885,3,20000,1,55,Wanted Heart,203,1,7,1,1,1
+16886,3,20000,1,55,Wanted Heart,203,1,7,1,2,1
+16887,3,20000,1,60,Wanted Heart,203,1,7,1,3,1
+16888,3,20000,1,65,Wanted Heart,203,1,7,1,4,1
 16889,3,200,1,2,Conspicuous Rusted Greatsword,203,1,7,1,0,1
 16890,3,200,1,2,Conspicuous Rusted Greatsword,203,1,7,1,1,1
 16891,3,200,1,2,Conspicuous Rusted Greatsword,203,1,7,1,2,1
 16892,3,200,1,2,Conspicuous Rusted Greatsword,203,1,7,1,3,1
 16893,3,200,1,2,Conspicuous Rusted Greatsword,203,1,7,1,4,1
-16894,3,20000,1,7,Wanted Heart,203,1,7,1,0,1
-16895,3,20000,1,12,Wanted Heart,203,1,7,1,1,1
-16896,3,20000,1,12,Wanted Heart,203,1,7,1,2,1
-16897,3,20000,1,1,Wanted Heart,203,1,7,1,3,1
-16898,3,20000,1,6,Wanted Heart,203,1,7,1,4,1
+16894,3,20000,1,55,Wanted Heart,203,1,7,1,0,1
+16895,3,20000,1,60,Wanted Heart,203,1,7,1,1,1
+16896,3,20000,1,60,Wanted Heart,203,1,7,1,2,1
+16897,3,20000,1,65,Wanted Heart,203,1,7,1,3,1
+16898,3,20000,1,70,Wanted Heart,203,1,7,1,4,1
 16899,3,200,1,1,Conspicuous Rusted Greatshield,204,1,5,1,0,1
 16900,3,200,1,1,Conspicuous Rusted Greatshield,204,1,5,1,1,1
 16901,3,200,1,1,Conspicuous Rusted Greatshield,204,1,5,1,2,1
 16902,3,200,1,1,Conspicuous Rusted Greatshield,204,1,5,1,3,1
 16903,3,200,1,1,Conspicuous Rusted Greatshield,204,1,5,1,4,1
-16904,3,20000,1,2,Dark Pavise,204,1,5,1,0,1
-16905,3,20000,1,7,Dark Pavise,204,1,5,1,1,1
-16906,3,20000,1,7,Dark Pavise,204,1,5,1,2,1
-16907,3,20000,1,12,Dark Pavise,204,1,5,1,3,1
-16908,3,20000,1,1,Dark Pavise,204,1,5,1,4,1
+16904,3,20000,1,50,Dark Pavise,204,1,5,1,0,1
+16905,3,20000,1,55,Dark Pavise,204,1,5,1,1,1
+16906,3,20000,1,55,Dark Pavise,204,1,5,1,2,1
+16907,3,20000,1,60,Dark Pavise,204,1,5,1,3,1
+16908,3,20000,1,65,Dark Pavise,204,1,5,1,4,1
 16909,3,200,1,2,Conspicuous Rusted Greatshield,204,1,5,1,0,1
 16910,3,200,1,2,Conspicuous Rusted Greatshield,204,1,5,1,1,1
 16911,3,200,1,2,Conspicuous Rusted Greatshield,204,1,5,1,2,1
 16912,3,200,1,2,Conspicuous Rusted Greatshield,204,1,5,1,3,1
 16913,3,200,1,2,Conspicuous Rusted Greatshield,204,1,5,1,4,1
-16914,3,20000,1,7,Dark Pavise,204,1,5,1,0,1
-16915,3,20000,1,12,Dark Pavise,204,1,5,1,1,1
-16916,3,20000,1,12,Dark Pavise,204,1,5,1,2,1
-16917,3,20000,1,1,Dark Pavise,204,1,5,1,3,1
-16918,3,20000,1,6,Dark Pavise,204,1,5,1,4,1
+16914,3,20000,1,55,Dark Pavise,204,1,5,1,0,1
+16915,3,20000,1,60,Dark Pavise,204,1,5,1,1,1
+16916,3,20000,1,60,Dark Pavise,204,1,5,1,2,1
+16917,3,20000,1,65,Dark Pavise,204,1,5,1,3,1
+16918,3,20000,1,70,Dark Pavise,204,1,5,1,4,1
 16919,3,200,1,1,Conspicuous Rusted Daggers,206,1,2,1,0,1
 16920,3,200,1,1,Conspicuous Rusted Daggers,206,1,2,1,1,1
 16921,3,200,1,1,Conspicuous Rusted Daggers,206,1,2,1,2,1
 16922,3,200,1,1,Conspicuous Rusted Daggers,206,1,2,1,3,1
 16923,3,200,1,1,Conspicuous Rusted Daggers,206,1,2,1,4,1
-16924,3,20000,1,2,Dark Parazonium,206,1,2,1,0,1
-16925,3,20000,1,7,Dark Parazonium,206,1,2,1,1,1
-16926,3,20000,1,7,Dark Parazonium,206,1,2,1,2,1
-16927,3,20000,1,12,Dark Parazonium,206,1,2,1,3,1
-16928,3,20000,1,1,Dark Parazonium,206,1,2,1,4,1
+16924,3,20000,1,50,Dark Parazonium,206,1,2,1,0,1
+16925,3,20000,1,55,Dark Parazonium,206,1,2,1,1,1
+16926,3,20000,1,55,Dark Parazonium,206,1,2,1,2,1
+16927,3,20000,1,60,Dark Parazonium,206,1,2,1,3,1
+16928,3,20000,1,65,Dark Parazonium,206,1,2,1,4,1
 16929,3,200,1,2,Conspicuous Rusted Daggers,206,1,2,1,0,1
 16930,3,200,1,2,Conspicuous Rusted Daggers,206,1,2,1,1,1
 16931,3,200,1,2,Conspicuous Rusted Daggers,206,1,2,1,2,1
 16932,3,200,1,2,Conspicuous Rusted Daggers,206,1,2,1,3,1
 16933,3,200,1,2,Conspicuous Rusted Daggers,206,1,2,1,4,1
-16934,3,20000,1,7,Dark Parazonium,206,1,2,1,0,1
-16935,3,20000,1,12,Dark Parazonium,206,1,2,1,1,1
-16936,3,20000,1,12,Dark Parazonium,206,1,2,1,2,1
-16937,3,20000,1,1,Dark Parazonium,206,1,2,1,3,1
-16938,3,20000,1,6,Dark Parazonium,206,1,2,1,4,1
+16934,3,20000,1,55,Dark Parazonium,206,1,2,1,0,1
+16935,3,20000,1,60,Dark Parazonium,206,1,2,1,1,1
+16936,3,20000,1,60,Dark Parazonium,206,1,2,1,2,1
+16937,3,20000,1,65,Dark Parazonium,206,1,2,1,3,1
+16938,3,20000,1,70,Dark Parazonium,206,1,2,1,4,1
 16939,3,200,1,1,Conspicuous Rusted Bow,207,1,3,1,0,1
 16940,3,200,1,1,Conspicuous Rusted Bow,207,1,3,1,1,1
 16941,3,200,1,1,Conspicuous Rusted Bow,207,1,3,1,2,1
 16942,3,200,1,1,Conspicuous Rusted Bow,207,1,3,1,3,1
 16943,3,200,1,1,Conspicuous Rusted Bow,207,1,3,1,4,1
-16944,3,20000,1,2,Dragon's Blink,207,1,3,1,0,1
-16945,3,20000,1,7,Dragon's Blink,207,1,3,1,1,1
-16946,3,20000,1,7,Dragon's Blink,207,1,3,1,2,1
-16947,3,20000,1,12,Dragon's Blink,207,1,3,1,3,1
-16948,3,20000,1,1,Dragon's Blink,207,1,3,1,4,1
+16944,3,20000,1,50,Dragon's Blink,207,1,3,1,0,1
+16945,3,20000,1,55,Dragon's Blink,207,1,3,1,1,1
+16946,3,20000,1,55,Dragon's Blink,207,1,3,1,2,1
+16947,3,20000,1,60,Dragon's Blink,207,1,3,1,3,1
+16948,3,20000,1,65,Dragon's Blink,207,1,3,1,4,1
 16949,3,200,1,2,Conspicuous Rusted Bow,207,1,3,1,0,1
 16950,3,200,1,2,Conspicuous Rusted Bow,207,1,3,1,1,1
 16951,3,200,1,2,Conspicuous Rusted Bow,207,1,3,1,2,1
 16952,3,200,1,2,Conspicuous Rusted Bow,207,1,3,1,3,1
 16953,3,200,1,2,Conspicuous Rusted Bow,207,1,3,1,4,1
-16954,3,20000,1,7,Dragon's Blink,207,1,3,1,0,1
-16955,3,20000,1,12,Dragon's Blink,207,1,3,1,1,1
-16956,3,20000,1,12,Dragon's Blink,207,1,3,1,2,1
-16957,3,20000,1,1,Dragon's Blink,207,1,3,1,3,1
-16958,3,20000,1,6,Dragon's Blink,207,1,3,1,4,1
+16954,3,20000,1,55,Dragon's Blink,207,1,3,1,0,1
+16955,3,20000,1,60,Dragon's Blink,207,1,3,1,1,1
+16956,3,20000,1,60,Dragon's Blink,207,1,3,1,2,1
+16957,3,20000,1,65,Dragon's Blink,207,1,3,1,3,1
+16958,3,20000,1,70,Dragon's Blink,207,1,3,1,4,1
 16959,3,200,1,1,Conspicuous Rusted Magick Gauntlet,208,1,9,1,0,1
 16960,3,200,1,1,Conspicuous Rusted Magick Gauntlet,208,1,9,1,1,1
 16961,3,200,1,1,Conspicuous Rusted Magick Gauntlet,208,1,9,1,2,1
 16962,3,200,1,1,Conspicuous Rusted Magick Gauntlet,208,1,9,1,3,1
 16963,3,200,1,1,Conspicuous Rusted Magick Gauntlet,208,1,9,1,4,1
-16964,3,20000,1,2,Hidden Seiðr,208,1,9,1,0,1
-16965,3,20000,1,7,Hidden Seiðr,208,1,9,1,1,1
-16966,3,20000,1,7,Hidden Seiðr,208,1,9,1,2,1
-16967,3,20000,1,12,Hidden Seiðr,208,1,9,1,3,1
-16968,3,20000,1,1,Hidden Seiðr,208,1,9,1,4,1
+16964,3,20000,1,50,Hidden Seiðr,208,1,9,1,0,1
+16965,3,20000,1,55,Hidden Seiðr,208,1,9,1,1,1
+16966,3,20000,1,55,Hidden Seiðr,208,1,9,1,2,1
+16967,3,20000,1,60,Hidden Seiðr,208,1,9,1,3,1
+16968,3,20000,1,65,Hidden Seiðr,208,1,9,1,4,1
 16969,3,200,1,2,Conspicuous Rusted Magick Gauntlet,208,1,9,1,0,1
 16970,3,200,1,2,Conspicuous Rusted Magick Gauntlet,208,1,9,1,1,1
 16971,3,200,1,2,Conspicuous Rusted Magick Gauntlet,208,1,9,1,2,1
 16972,3,200,1,2,Conspicuous Rusted Magick Gauntlet,208,1,9,1,3,1
 16973,3,200,1,2,Conspicuous Rusted Magick Gauntlet,208,1,9,1,4,1
-16974,3,20000,1,7,Hidden Seiðr,208,1,9,1,0,1
-16975,3,20000,1,12,Hidden Seiðr,208,1,9,1,1,1
-16976,3,20000,1,12,Hidden Seiðr,208,1,9,1,2,1
-16977,3,20000,1,1,Hidden Seiðr,208,1,9,1,3,1
-16978,3,20000,1,6,Hidden Seiðr,208,1,9,1,4,1
+16974,3,20000,1,55,Hidden Seiðr,208,1,9,1,0,1
+16975,3,20000,1,60,Hidden Seiðr,208,1,9,1,1,1
+16976,3,20000,1,60,Hidden Seiðr,208,1,9,1,2,1
+16977,3,20000,1,65,Hidden Seiðr,208,1,9,1,3,1
+16978,3,20000,1,70,Hidden Seiðr,208,1,9,1,4,1
 16979,3,200,1,1,Conspicuous Rusted Magick Bow,209,1,8,1,0,1
 16980,3,200,1,1,Conspicuous Rusted Magick Bow,209,1,8,1,1,1
 16981,3,200,1,1,Conspicuous Rusted Magick Bow,209,1,8,1,2,1
 16982,3,200,1,1,Conspicuous Rusted Magick Bow,209,1,8,1,3,1
 16983,3,200,1,1,Conspicuous Rusted Magick Bow,209,1,8,1,4,1
-16984,3,20000,1,2,Dragon's Supreme,209,1,8,1,0,1
-16985,3,20000,1,7,Dragon's Supreme,209,1,8,1,1,1
-16986,3,20000,1,7,Dragon's Supreme,209,1,8,1,2,1
-16987,3,20000,1,12,Dragon's Supreme,209,1,8,1,3,1
-16988,3,20000,1,1,Dragon's Supreme,209,1,8,1,4,1
+16984,3,20000,1,50,Dragon's Supreme,209,1,8,1,0,1
+16985,3,20000,1,55,Dragon's Supreme,209,1,8,1,1,1
+16986,3,20000,1,55,Dragon's Supreme,209,1,8,1,2,1
+16987,3,20000,1,60,Dragon's Supreme,209,1,8,1,3,1
+16988,3,20000,1,65,Dragon's Supreme,209,1,8,1,4,1
 16989,3,200,1,2,Conspicuous Rusted Magick Bow,209,1,8,1,0,1
 16990,3,200,1,2,Conspicuous Rusted Magick Bow,209,1,8,1,1,1
 16991,3,200,1,2,Conspicuous Rusted Magick Bow,209,1,8,1,2,1
 16992,3,200,1,2,Conspicuous Rusted Magick Bow,209,1,8,1,3,1
 16993,3,200,1,2,Conspicuous Rusted Magick Bow,209,1,8,1,4,1
-16994,3,20000,1,7,Dragon's Supreme,209,1,8,1,0,1
-16995,3,20000,1,12,Dragon's Supreme,209,1,8,1,1,1
-16996,3,20000,1,12,Dragon's Supreme,209,1,8,1,2,1
-16997,3,20000,1,1,Dragon's Supreme,209,1,8,1,3,1
-16998,3,20000,1,6,Dragon's Supreme,209,1,8,1,4,1
+16994,3,20000,1,55,Dragon's Supreme,209,1,8,1,0,1
+16995,3,20000,1,60,Dragon's Supreme,209,1,8,1,1,1
+16996,3,20000,1,60,Dragon's Supreme,209,1,8,1,2,1
+16997,3,20000,1,65,Dragon's Supreme,209,1,8,1,3,1
+16998,3,20000,1,70,Dragon's Supreme,209,1,8,1,4,1
 16999,3,200,1,1,Conspicuous Rusted Staff,211,1,4,1,0,1
 17000,3,200,1,1,Conspicuous Rusted Staff,211,1,4,1,1,1
 17001,3,200,1,1,Conspicuous Rusted Staff,211,1,4,1,2,1
 17002,3,200,1,1,Conspicuous Rusted Staff,211,1,4,1,3,1
 17003,3,200,1,1,Conspicuous Rusted Staff,211,1,4,1,4,1
-17004,3,20000,1,2,Chilly Cane,211,1,4,1,0,1
-17005,3,20000,1,7,Chilly Cane,211,1,4,1,1,1
-17006,3,20000,1,7,Chilly Cane,211,1,4,1,2,1
-17007,3,20000,1,12,Chilly Cane,211,1,4,1,3,1
-17008,3,20000,1,1,Chilly Cane,211,1,4,1,4,1
+17004,3,20000,1,50,Chilly Cane,211,1,4,1,0,1
+17005,3,20000,1,55,Chilly Cane,211,1,4,1,1,1
+17006,3,20000,1,55,Chilly Cane,211,1,4,1,2,1
+17007,3,20000,1,60,Chilly Cane,211,1,4,1,3,1
+17008,3,20000,1,65,Chilly Cane,211,1,4,1,4,1
 17009,3,200,1,2,Conspicuous Rusted Staff,211,1,4,1,0,1
 17010,3,200,1,2,Conspicuous Rusted Staff,211,1,4,1,1,1
 17011,3,200,1,2,Conspicuous Rusted Staff,211,1,4,1,2,1
 17012,3,200,1,2,Conspicuous Rusted Staff,211,1,4,1,3,1
 17013,3,200,1,2,Conspicuous Rusted Staff,211,1,4,1,4,1
-17014,3,20000,1,7,Chilly Cane,211,1,4,1,0,1
-17015,3,20000,1,12,Chilly Cane,211,1,4,1,1,1
-17016,3,20000,1,12,Chilly Cane,211,1,4,1,2,1
-17017,3,20000,1,1,Chilly Cane,211,1,4,1,3,1
-17018,3,20000,1,6,Chilly Cane,211,1,4,1,4,1
+17014,3,20000,1,55,Chilly Cane,211,1,4,1,0,1
+17015,3,20000,1,60,Chilly Cane,211,1,4,1,1,1
+17016,3,20000,1,60,Chilly Cane,211,1,4,1,2,1
+17017,3,20000,1,65,Chilly Cane,211,1,4,1,3,1
+17018,3,20000,1,70,Chilly Cane,211,1,4,1,4,1
 17019,3,200,1,1,Conspicuous Rusted Archistaff,212,1,6,1,0,1
 17020,3,200,1,1,Conspicuous Rusted Archistaff,212,1,6,1,1,1
 17021,3,200,1,1,Conspicuous Rusted Archistaff,212,1,6,1,2,1
 17022,3,200,1,1,Conspicuous Rusted Archistaff,212,1,6,1,3,1
 17023,3,200,1,1,Conspicuous Rusted Archistaff,212,1,6,1,4,1
-17024,3,20000,1,2,Road to Hades,212,1,6,1,0,1
-17025,3,20000,1,7,Road to Hades,212,1,6,1,1,1
-17026,3,20000,1,7,Road to Hades,212,1,6,1,2,1
-17027,3,20000,1,12,Road to Hades,212,1,6,1,3,1
-17028,3,20000,1,1,Road to Hades,212,1,6,1,4,1
+17024,3,20000,1,50,Road to Hades,212,1,6,1,0,1
+17025,3,20000,1,55,Road to Hades,212,1,6,1,1,1
+17026,3,20000,1,55,Road to Hades,212,1,6,1,2,1
+17027,3,20000,1,60,Road to Hades,212,1,6,1,3,1
+17028,3,20000,1,65,Road to Hades,212,1,6,1,4,1
 17029,3,200,1,2,Conspicuous Rusted Archistaff,212,1,6,1,0,1
 17030,3,200,1,2,Conspicuous Rusted Archistaff,212,1,6,1,1,1
 17031,3,200,1,2,Conspicuous Rusted Archistaff,212,1,6,1,2,1
 17032,3,200,1,2,Conspicuous Rusted Archistaff,212,1,6,1,3,1
 17033,3,200,1,2,Conspicuous Rusted Archistaff,212,1,6,1,4,1
-17034,3,20000,1,7,Road to Hades,212,1,6,1,0,1
-17035,3,20000,1,12,Road to Hades,212,1,6,1,1,1
-17036,3,20000,1,12,Road to Hades,212,1,6,1,2,1
-17037,3,20000,1,1,Road to Hades,212,1,6,1,3,1
-17038,3,20000,1,6,Road to Hades,212,1,6,1,4,1
+17034,3,20000,1,55,Road to Hades,212,1,6,1,0,1
+17035,3,20000,1,60,Road to Hades,212,1,6,1,1,1
+17036,3,20000,1,60,Road to Hades,212,1,6,1,2,1
+17037,3,20000,1,65,Road to Hades,212,1,6,1,3,1
+17038,3,20000,1,70,Road to Hades,212,1,6,1,4,1
 17039,3,200,1,1,Conspicuous Rusted Spirit Lance,213,1,10,1,0,1
 17040,3,200,1,1,Conspicuous Rusted Spirit Lance,213,1,10,1,1,1
 17041,3,200,1,1,Conspicuous Rusted Spirit Lance,213,1,10,1,2,1
 17042,3,200,1,1,Conspicuous Rusted Spirit Lance,213,1,10,1,3,1
 17043,3,200,1,1,Conspicuous Rusted Spirit Lance,213,1,10,1,4,1
-17044,3,20000,1,2,Everlance,213,1,10,1,0,1
-17045,3,20000,1,7,Everlance,213,1,10,1,1,1
-17046,3,20000,1,7,Everlance,213,1,10,1,2,1
-17047,3,20000,1,12,Everlance,213,1,10,1,3,1
-17048,3,20000,1,1,Everlance,213,1,10,1,4,1
+17044,3,20000,1,50,Everlance,213,1,10,1,0,1
+17045,3,20000,1,55,Everlance,213,1,10,1,1,1
+17046,3,20000,1,55,Everlance,213,1,10,1,2,1
+17047,3,20000,1,60,Everlance,213,1,10,1,3,1
+17048,3,20000,1,65,Everlance,213,1,10,1,4,1
 17049,3,200,1,2,Conspicuous Rusted Spirit Lance,213,1,10,1,0,1
 17050,3,200,1,2,Conspicuous Rusted Spirit Lance,213,1,10,1,1,1
 17051,3,200,1,2,Conspicuous Rusted Spirit Lance,213,1,10,1,2,1
 17052,3,200,1,2,Conspicuous Rusted Spirit Lance,213,1,10,1,3,1
 17053,3,200,1,2,Conspicuous Rusted Spirit Lance,213,1,10,1,4,1
-17054,3,20000,1,7,Everlance,213,1,10,1,0,1
-17055,3,20000,1,12,Everlance,213,1,10,1,1,1
-17056,3,20000,1,12,Everlance,213,1,10,1,2,1
-17057,3,20000,1,1,Everlance,213,1,10,1,3,1
-17058,3,20000,1,6,Everlance,213,1,10,1,4,1
-17391,3,25574,1,0,Nobility's Estoc,201,80,1,1,0,1
-17392,3,25574,1,0,Nobility's Estoc,201,80,1,1,1,1
-17393,3,25574,1,0,Nobility's Estoc,201,80,1,1,2,1
-17394,3,25574,1,0,Nobility's Estoc,201,80,1,1,3,1
-17395,3,25574,1,0,Nobility's Estoc,201,80,1,1,4,1
-17396,3,27416,1,5,Lupus Savior,201,83,1,1,0,1
-17397,3,27416,1,5,Lupus Savior,201,83,1,1,1,1
-17398,3,27416,1,5,Lupus Savior,201,83,1,1,2,1
-17399,3,27416,1,5,Lupus Savior,201,83,1,1,3,1
-17400,3,27416,1,5,Lupus Savior,201,83,1,1,4,1
-17401,3,28644,1,10,Shamshir-e Morad,201,85,1,1,0,1
-17402,3,28644,1,10,Shamshir-e Morad,201,85,1,1,1,1
-17403,3,28644,1,10,Shamshir-e Morad,201,85,1,1,2,1
-17404,3,28644,1,10,Shamshir-e Morad,201,85,1,1,3,1
-17405,3,28644,1,10,Shamshir-e Morad,201,85,1,1,4,1
-17421,3,31968,1,0,Nobility's Saber,203,80,7,1,0,1
-17422,3,31968,1,0,Nobility's Saber,203,80,7,1,1,1
-17423,3,31968,1,0,Nobility's Saber,203,80,7,1,2,1
-17424,3,31968,1,0,Nobility's Saber,203,80,7,1,3,1
-17425,3,31968,1,0,Nobility's Saber,203,80,7,1,4,1
-17426,3,34270,1,5,Taurus Breaker,203,83,7,1,0,1
-17427,3,34270,1,5,Taurus Breaker,203,83,7,1,1,1
-17428,3,34270,1,5,Taurus Breaker,203,83,7,1,2,1
-17429,3,34270,1,5,Taurus Breaker,203,83,7,1,3,1
-17430,3,34270,1,5,Taurus Breaker,203,83,7,1,4,1
-17431,3,35805,1,10,Yekta-Kavi,203,85,7,1,0,1
-17432,3,35805,1,10,Yekta-Kavi,203,85,7,1,1,1
-17433,3,35805,1,10,Yekta-Kavi,203,85,7,1,2,1
-17434,3,35805,1,10,Yekta-Kavi,203,85,7,1,3,1
-17435,3,35805,1,10,Yekta-Kavi,203,85,7,1,4,1
-17436,3,25574,1,0,Nobility's Fort,204,80,5,1,0,1
-17437,3,25574,1,0,Nobility's Fort,204,80,5,1,1,1
-17438,3,25574,1,0,Nobility's Fort,204,80,5,1,2,1
-17439,3,25574,1,0,Nobility's Fort,204,80,5,1,3,1
-17440,3,25574,1,0,Nobility's Fort,204,80,5,1,4,1
-17441,3,27416,1,5,Scutum Wall,204,83,5,1,0,1
-17442,3,27416,1,5,Scutum Wall,204,83,5,1,1,1
-17443,3,27416,1,5,Scutum Wall,204,83,5,1,2,1
-17444,3,27416,1,5,Scutum Wall,204,83,5,1,3,1
-17445,3,27416,1,5,Scutum Wall,204,83,5,1,4,1
-17446,3,28644,1,10,Dival-e-Hami,204,85,5,1,0,1
-17447,3,28644,1,10,Dival-e-Hami,204,85,5,1,1,1
-17448,3,28644,1,10,Dival-e-Hami,204,85,5,1,2,1
-17449,3,28644,1,10,Dival-e-Hami,204,85,5,1,3,1
-17450,3,28644,1,10,Dival-e-Hami,204,85,5,1,4,1
-17466,3,35805,1,10,Farid,206,85,2,1,0,1
-17467,3,35805,1,10,Farid,206,85,2,1,1,1
-17468,3,35805,1,10,Farid,206,85,2,1,2,1
-17469,3,35805,1,10,Farid,206,85,2,1,3,1
-17470,3,35805,1,10,Farid,206,85,2,1,4,1
-17471,3,31968,1,0,Nobility's Daggers,206,80,2,1,0,1
-17472,3,31968,1,0,Nobility's Daggers,206,80,2,1,1,1
-17473,3,31968,1,0,Nobility's Daggers,206,80,2,1,2,1
-17474,3,31968,1,0,Nobility's Daggers,206,80,2,1,3,1
-17475,3,31968,1,0,Nobility's Daggers,206,80,2,1,4,1
-17476,3,34270,1,5,Gemini Edge,206,83,2,1,0,1
-17477,3,34270,1,5,Gemini Edge,206,83,2,1,1,1
-17478,3,34270,1,5,Gemini Edge,206,83,2,1,2,1
-17479,3,34270,1,5,Gemini Edge,206,83,2,1,3,1
-17480,3,34270,1,5,Gemini Edge,206,83,2,1,4,1
-17481,3,31968,1,0,Nobility's Bow,207,80,3,1,0,1
-17482,3,31968,1,0,Nobility's Bow,207,80,3,1,1,1
-17483,3,31968,1,0,Nobility's Bow,207,80,3,1,2,1
-17484,3,31968,1,0,Nobility's Bow,207,80,3,1,3,1
-17485,3,31968,1,0,Nobility's Bow,207,80,3,1,4,1
-17486,3,34270,1,5,Corvus Bow,207,83,3,1,0,1
-17487,3,34270,1,5,Corvus Bow,207,83,3,1,1,1
-17488,3,34270,1,5,Corvus Bow,207,83,3,1,2,1
-17489,3,34270,1,5,Corvus Bow,207,83,3,1,3,1
-17490,3,34270,1,5,Corvus Bow,207,83,3,1,4,1
-17491,3,35805,1,10,Rakhshan,207,85,3,1,0,1
-17492,3,35805,1,10,Rakhshan,207,85,3,1,1,1
-17493,3,35805,1,10,Rakhshan,207,85,3,1,2,1
-17494,3,35805,1,10,Rakhshan,207,85,3,1,3,1
-17495,3,35805,1,10,Rakhshan,207,85,3,1,4,1
-17496,3,31968,1,0,Nobility's Gauntlet,208,80,9,1,0,1
-17497,3,31968,1,0,Nobility's Gauntlet,208,80,9,1,1,1
-17498,3,31968,1,0,Nobility's Gauntlet,208,80,9,1,2,1
-17499,3,31968,1,0,Nobility's Gauntlet,208,80,9,1,3,1
-17500,3,31968,1,0,Nobility's Gauntlet,208,80,9,1,4,1
-17501,3,34270,1,5,Circinus Arm,208,83,9,1,0,1
-17502,3,34270,1,5,Circinus Arm,208,83,9,1,1,1
-17503,3,34270,1,5,Circinus Arm,208,83,9,1,2,1
-17504,3,34270,1,5,Circinus Arm,208,83,9,1,3,1
-17505,3,34270,1,5,Circinus Arm,208,83,9,1,4,1
-17506,3,35805,1,10,Hushyar,208,85,9,1,0,1
-17507,3,35805,1,10,Hushyar,208,85,9,1,1,1
-17508,3,35805,1,10,Hushyar,208,85,9,1,2,1
-17509,3,35805,1,10,Hushyar,208,85,9,1,3,1
-17510,3,35805,1,10,Hushyar,208,85,9,1,4,1
-17511,3,31968,1,0,Nobility's Spell,209,80,8,1,0,1
-17512,3,31968,1,0,Nobility's Spell,209,80,8,1,1,1
-17513,3,31968,1,0,Nobility's Spell,209,80,8,1,2,1
-17514,3,31968,1,0,Nobility's Spell,209,80,8,1,3,1
-17515,3,31968,1,0,Nobility's Spell,209,80,8,1,4,1
-17516,3,34270,1,5,Lacerta Shooter,209,83,8,1,0,1
-17517,3,34270,1,5,Lacerta Shooter,209,83,8,1,1,1
-17518,3,34270,1,5,Lacerta Shooter,209,83,8,1,2,1
-17519,3,34270,1,5,Lacerta Shooter,209,83,8,1,3,1
-17520,3,34270,1,5,Lacerta Shooter,209,83,8,1,4,1
-17521,3,35805,1,10,Parto,209,85,8,1,0,1
-17522,3,35805,1,10,Parto,209,85,8,1,1,1
-17523,3,35805,1,10,Parto,209,85,8,1,2,1
-17524,3,35805,1,10,Parto,209,85,8,1,3,1
-17525,3,35805,1,10,Parto,209,85,8,1,4,1
-17526,3,31968,1,0,Nobility's Staff,211,80,4,1,0,1
-17527,3,31968,1,0,Nobility's Staff,211,80,4,1,1,1
-17528,3,31968,1,0,Nobility's Staff,211,80,4,1,2,1
-17529,3,31968,1,0,Nobility's Staff,211,80,4,1,3,1
-17530,3,31968,1,0,Nobility's Staff,211,80,4,1,4,1
-17531,3,34270,1,5,Ara Cane,211,83,4,1,0,1
-17532,3,34270,1,5,Ara Cane,211,83,4,1,1,1
-17533,3,34270,1,5,Ara Cane,211,83,4,1,2,1
-17534,3,34270,1,5,Ara Cane,211,83,4,1,3,1
-17535,3,34270,1,5,Ara Cane,211,83,4,1,4,1
-17536,3,35805,1,10,Nuri-e Sepehr,211,85,4,1,0,1
-17537,3,35805,1,10,Nuri-e Sepehr,211,85,4,1,1,1
-17538,3,35805,1,10,Nuri-e Sepehr,211,85,4,1,2,1
-17539,3,35805,1,10,Nuri-e Sepehr,211,85,4,1,3,1
-17540,3,35805,1,10,Nuri-e Sepehr,211,85,4,1,4,1
-17541,3,31968,1,0,Nobility's Wand,212,80,6,1,0,1
-17542,3,31968,1,0,Nobility's Wand,212,80,6,1,1,1
-17543,3,31968,1,0,Nobility's Wand,212,80,6,1,2,1
-17544,3,31968,1,0,Nobility's Wand,212,80,6,1,3,1
-17545,3,31968,1,0,Nobility's Wand,212,80,6,1,4,1
-17546,3,34270,1,5,Tucana Wand,212,83,6,1,0,1
-17547,3,34270,1,5,Tucana Wand,212,83,6,1,1,1
-17548,3,34270,1,5,Tucana Wand,212,83,6,1,2,1
-17549,3,34270,1,5,Tucana Wand,212,83,6,1,3,1
-17550,3,34270,1,5,Tucana Wand,212,83,6,1,4,1
-17551,3,35805,1,10,Mahasti,212,85,6,1,0,1
-17552,3,35805,1,10,Mahasti,212,85,6,1,1,1
-17553,3,35805,1,10,Mahasti,212,85,6,1,2,1
-17554,3,35805,1,10,Mahasti,212,85,6,1,3,1
-17555,3,35805,1,10,Mahasti,212,85,6,1,4,1
-17556,3,31968,1,0,Nobility's Spear,213,80,10,1,0,1
-17557,3,31968,1,0,Nobility's Spear,213,80,10,1,1,1
-17558,3,31968,1,0,Nobility's Spear,213,80,10,1,2,1
-17559,3,31968,1,0,Nobility's Spear,213,80,10,1,3,1
-17560,3,31968,1,0,Nobility's Spear,213,80,10,1,4,1
-17561,3,34270,1,5,Carina Spear,213,83,10,1,0,1
-17562,3,34270,1,5,Carina Spear,213,83,10,1,1,1
-17563,3,34270,1,5,Carina Spear,213,83,10,1,2,1
-17564,3,34270,1,5,Carina Spear,213,83,10,1,3,1
-17565,3,34270,1,5,Carina Spear,213,83,10,1,4,1
-17566,3,35805,1,10,Arsalan Milad,213,85,10,1,0,1
-17567,3,35805,1,10,Arsalan Milad,213,85,10,1,1,1
-17568,3,35805,1,10,Arsalan Milad,213,85,10,1,2,1
-17569,3,35805,1,10,Arsalan Milad,213,85,10,1,3,1
-17570,3,35805,1,10,Arsalan Milad,213,85,10,1,4,1
+17054,3,20000,1,55,Everlance,213,1,10,1,0,1
+17055,3,20000,1,60,Everlance,213,1,10,1,1,1
+17056,3,20000,1,60,Everlance,213,1,10,1,2,1
+17057,3,20000,1,65,Everlance,213,1,10,1,3,1
+17058,3,20000,1,70,Everlance,213,1,10,1,4,1
+17391,3,25574,1,80,Nobility's Estoc,201,80,1,1,0,1
+17392,3,25574,1,80,Nobility's Estoc,201,80,1,1,1,1
+17393,3,25574,1,80,Nobility's Estoc,201,80,1,1,2,1
+17394,3,25574,1,80,Nobility's Estoc,201,80,1,1,3,1
+17395,3,25574,1,80,Nobility's Estoc,201,80,1,1,4,1
+17396,3,27416,1,85,Lupus Savior,201,83,1,1,0,1
+17397,3,27416,1,85,Lupus Savior,201,83,1,1,1,1
+17398,3,27416,1,85,Lupus Savior,201,83,1,1,2,1
+17399,3,27416,1,85,Lupus Savior,201,83,1,1,3,1
+17400,3,27416,1,85,Lupus Savior,201,83,1,1,4,1
+17401,3,28644,1,90,Shamshir-e Morad,201,85,1,1,0,1
+17402,3,28644,1,90,Shamshir-e Morad,201,85,1,1,1,1
+17403,3,28644,1,90,Shamshir-e Morad,201,85,1,1,2,1
+17404,3,28644,1,90,Shamshir-e Morad,201,85,1,1,3,1
+17405,3,28644,1,90,Shamshir-e Morad,201,85,1,1,4,1
+17421,3,31968,1,80,Nobility's Saber,203,80,7,1,0,1
+17422,3,31968,1,80,Nobility's Saber,203,80,7,1,1,1
+17423,3,31968,1,80,Nobility's Saber,203,80,7,1,2,1
+17424,3,31968,1,80,Nobility's Saber,203,80,7,1,3,1
+17425,3,31968,1,80,Nobility's Saber,203,80,7,1,4,1
+17426,3,34270,1,85,Taurus Breaker,203,83,7,1,0,1
+17427,3,34270,1,85,Taurus Breaker,203,83,7,1,1,1
+17428,3,34270,1,85,Taurus Breaker,203,83,7,1,2,1
+17429,3,34270,1,85,Taurus Breaker,203,83,7,1,3,1
+17430,3,34270,1,85,Taurus Breaker,203,83,7,1,4,1
+17431,3,35805,1,90,Yekta-Kavi,203,85,7,1,0,1
+17432,3,35805,1,90,Yekta-Kavi,203,85,7,1,1,1
+17433,3,35805,1,90,Yekta-Kavi,203,85,7,1,2,1
+17434,3,35805,1,90,Yekta-Kavi,203,85,7,1,3,1
+17435,3,35805,1,90,Yekta-Kavi,203,85,7,1,4,1
+17436,3,25574,1,80,Nobility's Fort,204,80,5,1,0,1
+17437,3,25574,1,80,Nobility's Fort,204,80,5,1,1,1
+17438,3,25574,1,80,Nobility's Fort,204,80,5,1,2,1
+17439,3,25574,1,80,Nobility's Fort,204,80,5,1,3,1
+17440,3,25574,1,80,Nobility's Fort,204,80,5,1,4,1
+17441,3,27416,1,85,Scutum Wall,204,83,5,1,0,1
+17442,3,27416,1,85,Scutum Wall,204,83,5,1,1,1
+17443,3,27416,1,85,Scutum Wall,204,83,5,1,2,1
+17444,3,27416,1,85,Scutum Wall,204,83,5,1,3,1
+17445,3,27416,1,85,Scutum Wall,204,83,5,1,4,1
+17446,3,28644,1,90,Dival-e-Hami,204,85,5,1,0,1
+17447,3,28644,1,90,Dival-e-Hami,204,85,5,1,1,1
+17448,3,28644,1,90,Dival-e-Hami,204,85,5,1,2,1
+17449,3,28644,1,90,Dival-e-Hami,204,85,5,1,3,1
+17450,3,28644,1,90,Dival-e-Hami,204,85,5,1,4,1
+17466,3,35805,1,90,Farid,206,85,2,1,0,1
+17467,3,35805,1,90,Farid,206,85,2,1,1,1
+17468,3,35805,1,90,Farid,206,85,2,1,2,1
+17469,3,35805,1,90,Farid,206,85,2,1,3,1
+17470,3,35805,1,90,Farid,206,85,2,1,4,1
+17471,3,31968,1,80,Nobility's Daggers,206,80,2,1,0,1
+17472,3,31968,1,80,Nobility's Daggers,206,80,2,1,1,1
+17473,3,31968,1,80,Nobility's Daggers,206,80,2,1,2,1
+17474,3,31968,1,80,Nobility's Daggers,206,80,2,1,3,1
+17475,3,31968,1,80,Nobility's Daggers,206,80,2,1,4,1
+17476,3,34270,1,85,Gemini Edge,206,83,2,1,0,1
+17477,3,34270,1,85,Gemini Edge,206,83,2,1,1,1
+17478,3,34270,1,85,Gemini Edge,206,83,2,1,2,1
+17479,3,34270,1,85,Gemini Edge,206,83,2,1,3,1
+17480,3,34270,1,85,Gemini Edge,206,83,2,1,4,1
+17481,3,31968,1,80,Nobility's Bow,207,80,3,1,0,1
+17482,3,31968,1,80,Nobility's Bow,207,80,3,1,1,1
+17483,3,31968,1,80,Nobility's Bow,207,80,3,1,2,1
+17484,3,31968,1,80,Nobility's Bow,207,80,3,1,3,1
+17485,3,31968,1,80,Nobility's Bow,207,80,3,1,4,1
+17486,3,34270,1,85,Corvus Bow,207,83,3,1,0,1
+17487,3,34270,1,85,Corvus Bow,207,83,3,1,1,1
+17488,3,34270,1,85,Corvus Bow,207,83,3,1,2,1
+17489,3,34270,1,85,Corvus Bow,207,83,3,1,3,1
+17490,3,34270,1,85,Corvus Bow,207,83,3,1,4,1
+17491,3,35805,1,90,Rakhshan,207,85,3,1,0,1
+17492,3,35805,1,90,Rakhshan,207,85,3,1,1,1
+17493,3,35805,1,90,Rakhshan,207,85,3,1,2,1
+17494,3,35805,1,90,Rakhshan,207,85,3,1,3,1
+17495,3,35805,1,90,Rakhshan,207,85,3,1,4,1
+17496,3,31968,1,80,Nobility's Gauntlet,208,80,9,1,0,1
+17497,3,31968,1,80,Nobility's Gauntlet,208,80,9,1,1,1
+17498,3,31968,1,80,Nobility's Gauntlet,208,80,9,1,2,1
+17499,3,31968,1,80,Nobility's Gauntlet,208,80,9,1,3,1
+17500,3,31968,1,80,Nobility's Gauntlet,208,80,9,1,4,1
+17501,3,34270,1,85,Circinus Arm,208,83,9,1,0,1
+17502,3,34270,1,85,Circinus Arm,208,83,9,1,1,1
+17503,3,34270,1,85,Circinus Arm,208,83,9,1,2,1
+17504,3,34270,1,85,Circinus Arm,208,83,9,1,3,1
+17505,3,34270,1,85,Circinus Arm,208,83,9,1,4,1
+17506,3,35805,1,90,Hushyar,208,85,9,1,0,1
+17507,3,35805,1,90,Hushyar,208,85,9,1,1,1
+17508,3,35805,1,90,Hushyar,208,85,9,1,2,1
+17509,3,35805,1,90,Hushyar,208,85,9,1,3,1
+17510,3,35805,1,90,Hushyar,208,85,9,1,4,1
+17511,3,31968,1,80,Nobility's Spell,209,80,8,1,0,1
+17512,3,31968,1,80,Nobility's Spell,209,80,8,1,1,1
+17513,3,31968,1,80,Nobility's Spell,209,80,8,1,2,1
+17514,3,31968,1,80,Nobility's Spell,209,80,8,1,3,1
+17515,3,31968,1,80,Nobility's Spell,209,80,8,1,4,1
+17516,3,34270,1,85,Lacerta Shooter,209,83,8,1,0,1
+17517,3,34270,1,85,Lacerta Shooter,209,83,8,1,1,1
+17518,3,34270,1,85,Lacerta Shooter,209,83,8,1,2,1
+17519,3,34270,1,85,Lacerta Shooter,209,83,8,1,3,1
+17520,3,34270,1,85,Lacerta Shooter,209,83,8,1,4,1
+17521,3,35805,1,90,Parto,209,85,8,1,0,1
+17522,3,35805,1,90,Parto,209,85,8,1,1,1
+17523,3,35805,1,90,Parto,209,85,8,1,2,1
+17524,3,35805,1,90,Parto,209,85,8,1,3,1
+17525,3,35805,1,90,Parto,209,85,8,1,4,1
+17526,3,31968,1,80,Nobility's Staff,211,80,4,1,0,1
+17527,3,31968,1,80,Nobility's Staff,211,80,4,1,1,1
+17528,3,31968,1,80,Nobility's Staff,211,80,4,1,2,1
+17529,3,31968,1,80,Nobility's Staff,211,80,4,1,3,1
+17530,3,31968,1,80,Nobility's Staff,211,80,4,1,4,1
+17531,3,34270,1,85,Ara Cane,211,83,4,1,0,1
+17532,3,34270,1,85,Ara Cane,211,83,4,1,1,1
+17533,3,34270,1,85,Ara Cane,211,83,4,1,2,1
+17534,3,34270,1,85,Ara Cane,211,83,4,1,3,1
+17535,3,34270,1,85,Ara Cane,211,83,4,1,4,1
+17536,3,35805,1,90,Nuri-e Sepehr,211,85,4,1,0,1
+17537,3,35805,1,90,Nuri-e Sepehr,211,85,4,1,1,1
+17538,3,35805,1,90,Nuri-e Sepehr,211,85,4,1,2,1
+17539,3,35805,1,90,Nuri-e Sepehr,211,85,4,1,3,1
+17540,3,35805,1,90,Nuri-e Sepehr,211,85,4,1,4,1
+17541,3,31968,1,80,Nobility's Wand,212,80,6,1,0,1
+17542,3,31968,1,80,Nobility's Wand,212,80,6,1,1,1
+17543,3,31968,1,80,Nobility's Wand,212,80,6,1,2,1
+17544,3,31968,1,80,Nobility's Wand,212,80,6,1,3,1
+17545,3,31968,1,80,Nobility's Wand,212,80,6,1,4,1
+17546,3,34270,1,85,Tucana Wand,212,83,6,1,0,1
+17547,3,34270,1,85,Tucana Wand,212,83,6,1,1,1
+17548,3,34270,1,85,Tucana Wand,212,83,6,1,2,1
+17549,3,34270,1,85,Tucana Wand,212,83,6,1,3,1
+17550,3,34270,1,85,Tucana Wand,212,83,6,1,4,1
+17551,3,35805,1,90,Mahasti,212,85,6,1,0,1
+17552,3,35805,1,90,Mahasti,212,85,6,1,1,1
+17553,3,35805,1,90,Mahasti,212,85,6,1,2,1
+17554,3,35805,1,90,Mahasti,212,85,6,1,3,1
+17555,3,35805,1,90,Mahasti,212,85,6,1,4,1
+17556,3,31968,1,80,Nobility's Spear,213,80,10,1,0,1
+17557,3,31968,1,80,Nobility's Spear,213,80,10,1,1,1
+17558,3,31968,1,80,Nobility's Spear,213,80,10,1,2,1
+17559,3,31968,1,80,Nobility's Spear,213,80,10,1,3,1
+17560,3,31968,1,80,Nobility's Spear,213,80,10,1,4,1
+17561,3,34270,1,85,Carina Spear,213,83,10,1,0,1
+17562,3,34270,1,85,Carina Spear,213,83,10,1,1,1
+17563,3,34270,1,85,Carina Spear,213,83,10,1,2,1
+17564,3,34270,1,85,Carina Spear,213,83,10,1,3,1
+17565,3,34270,1,85,Carina Spear,213,83,10,1,4,1
+17566,3,35805,1,90,Arsalan Milad,213,85,10,1,0,1
+17567,3,35805,1,90,Arsalan Milad,213,85,10,1,1,1
+17568,3,35805,1,90,Arsalan Milad,213,85,10,1,2,1
+17569,3,35805,1,90,Arsalan Milad,213,85,10,1,3,1
+17570,3,35805,1,90,Arsalan Milad,213,85,10,1,4,1
 19100,3,30000,1,5,Snap Blade,206,1,2,4,0,1
 19101,3,30000,1,8,Snap Blade,206,1,2,4,1,1
 19102,3,30000,1,12,Snap Blade,206,1,2,4,2,1
-19103,3,30000,1,13,Snap Blade,206,1,2,4,3,1
-19104,3,30000,1,11,Snap Blade,206,1,2,4,4,1
+19103,3,30000,1,45,Snap Blade,206,1,2,4,3,1
+19104,3,30000,1,75,Snap Blade,206,1,2,4,4,1
 19110,3,30000,1,5,One-handed Snap Blade,201,1,1,4,0,1
 19111,3,30000,1,8,One-handed Snap Blade,201,1,1,4,1,1
 19112,3,30000,1,12,One-handed Snap Blade,201,1,1,4,2,1
-19113,3,30000,1,13,One-handed Snap Blade,201,1,1,4,3,1
-19114,3,30000,1,11,One-handed Snap Blade,201,1,1,4,4,1
-17961,3,35805,1,10,Spike Mace of Resentment,201,85,1,1,0,1
-17962,3,35805,1,10,Spike Mace of Resentment,201,85,1,1,1,1
-17963,3,35805,1,10,Spike Mace of Resentment,201,85,1,1,2,1
-17964,3,35805,1,10,Spike Mace of Resentment,201,85,1,1,3,1
-17965,3,35805,1,10,Spike Mace of Resentment,201,85,1,1,4,1
-17966,3,37794,1,15,Rapier of Deev,201,88,1,1,0,1
-17967,3,37794,1,15,Rapier of Deev,201,88,1,1,1,1
-17968,3,37794,1,15,Rapier of Deev,201,88,1,1,2,1
-17969,3,37794,1,15,Rapier of Deev,201,88,1,1,3,1
-17970,3,37794,1,15,Rapier of Deev,201,88,1,1,4,1
-17971,3,39783,1,2,Zarrin-dokht Axe,201,90,1,1,0,1
-17972,3,39783,1,2,Zarrin-dokht Axe,201,90,1,1,1,1
-17973,3,39783,1,2,Zarrin-dokht Axe,201,90,1,1,2,1
-17974,3,39783,1,2,Zarrin-dokht Axe,201,90,1,1,3,1
-17975,3,39783,1,2,Zarrin-dokht Axe,201,90,1,1,4,1
-17991,3,35805,1,10,Saw Blade of Resentment,203,85,7,1,0,1
-17992,3,35805,1,10,Saw Blade of Resentment,203,85,7,1,1,1
-17993,3,35805,1,10,Saw Blade of Resentment,203,85,7,1,2,1
-17994,3,35805,1,10,Saw Blade of Resentment,203,85,7,1,3,1
-17995,3,35805,1,10,Saw Blade of Resentment,203,85,7,1,4,1
-17996,3,37794,1,15,Edge of Aslan,203,88,7,1,0,1
-17997,3,37794,1,15,Edge of Aslan,203,88,7,1,1,1
-17998,3,37794,1,15,Edge of Aslan,203,88,7,1,2,1
-17999,3,37794,1,15,Edge of Aslan,203,88,7,1,3,1
-18000,3,37794,1,15,Edge of Aslan,203,88,7,1,4,1
-18001,3,39783,1,2,Sholeha Blade,203,90,7,1,0,1
-18002,3,39783,1,2,Sholeha Blade,203,90,7,1,1,1
-18003,3,39783,1,2,Sholeha Blade,203,90,7,1,2,1
-18004,3,39783,1,2,Sholeha Blade,203,90,7,1,3,1
-18005,3,39783,1,2,Sholeha Blade,203,90,7,1,4,1
-18006,3,35805,1,10,Chained Wall of Resentment,204,85,5,1,0,1
-18007,3,35805,1,10,Chained Wall of Resentment,204,85,5,1,1,1
-18008,3,35805,1,10,Chained Wall of Resentment,204,85,5,1,2,1
-18009,3,35805,1,10,Chained Wall of Resentment,204,85,5,1,3,1
-18010,3,35805,1,10,Chained Wall of Resentment,204,85,5,1,4,1
-18011,3,37794,1,15,Fort of Ferey,204,88,5,1,0,1
-18012,3,37794,1,15,Fort of Ferey,204,88,5,1,1,1
-18013,3,37794,1,15,Fort of Ferey,204,88,5,1,2,1
-18014,3,37794,1,15,Fort of Ferey,204,88,5,1,3,1
-18015,3,37794,1,15,Fort of Ferey,204,88,5,1,4,1
-18016,3,39783,1,2,Taraneh Wall,204,90,5,1,0,1
-18017,3,39783,1,2,Taraneh Wall,204,90,5,1,1,1
-18018,3,39783,1,2,Taraneh Wall,204,90,5,1,2,1
-18019,3,39783,1,2,Taraneh Wall,204,90,5,1,3,1
-18020,3,39783,1,2,Taraneh Wall,204,90,5,1,4,1
-18036,3,35805,1,10,Guillotine Edge of Resentment,206,85,2,1,0,1
-18037,3,35805,1,10,Guillotine Edge of Resentment,206,85,2,1,1,1
-18038,3,35805,1,10,Guillotine Edge of Resentment,206,85,2,1,2,1
-18039,3,35805,1,10,Guillotine Edge of Resentment,206,85,2,1,3,1
-18040,3,35805,1,10,Guillotine Edge of Resentment,206,85,2,1,4,1
-18041,3,37794,1,15,Dagger of Vashak,206,88,2,1,0,1
-18042,3,37794,1,15,Dagger of Vashak,206,88,2,1,1,1
-18043,3,37794,1,15,Dagger of Vashak,206,88,2,1,2,1
-18044,3,37794,1,15,Dagger of Vashak,206,88,2,1,3,1
-18045,3,37794,1,15,Dagger of Vashak,206,88,2,1,4,1
-18046,3,39783,1,2,Sanaz Scramaseax,206,90,2,1,0,1
-18047,3,39783,1,2,Sanaz Scramaseax,206,90,2,1,1,1
-18048,3,39783,1,2,Sanaz Scramaseax,206,90,2,1,2,1
-18049,3,39783,1,2,Sanaz Scramaseax,206,90,2,1,3,1
-18050,3,39783,1,2,Sanaz Scramaseax,206,90,2,1,4,1
-18051,3,35805,1,10,Shortbow of Resentment,207,85,3,1,0,1
-18052,3,35805,1,10,Shortbow of Resentment,207,85,3,1,1,1
-18053,3,35805,1,10,Shortbow of Resentment,207,85,3,1,2,1
-18054,3,35805,1,10,Shortbow of Resentment,207,85,3,1,3,1
-18055,3,35805,1,10,Shortbow of Resentment,207,85,3,1,4,1
-18056,3,37794,1,15,Aim of Kal Tal,207,88,3,1,0,1
-18057,3,37794,1,15,Aim of Kal Tal,207,88,3,1,1,1
-18058,3,37794,1,15,Aim of Kal Tal,207,88,3,1,2,1
-18059,3,37794,1,15,Aim of Kal Tal,207,88,3,1,3,1
-18060,3,37794,1,15,Aim of Kal Tal,207,88,3,1,4,1
-18061,3,39783,1,2,Roshni Bow,207,90,3,1,0,1
-18062,3,39783,1,2,Roshni Bow,207,90,3,1,1,1
-18063,3,39783,1,2,Roshni Bow,207,90,3,1,2,1
-18064,3,39783,1,2,Roshni Bow,207,90,3,1,3,1
-18065,3,39783,1,2,Roshni Bow,207,90,3,1,4,1
-18066,3,35805,1,10,Spinel Arm of Resentment,208,85,9,1,0,1
-18067,3,35805,1,10,Spinel Arm of Resentment,208,85,9,1,1,1
-18068,3,35805,1,10,Spinel Arm of Resentment,208,85,9,1,2,1
-18069,3,35805,1,10,Spinel Arm of Resentment,208,85,9,1,3,1
-18070,3,35805,1,10,Spinel Arm of Resentment,208,85,9,1,4,1
-18071,3,37794,1,15,Hand of Kurts,208,88,9,1,0,1
-18072,3,37794,1,15,Hand of Kurts,208,88,9,1,1,1
-18073,3,37794,1,15,Hand of Kurts,208,88,9,1,2,1
-18074,3,37794,1,15,Hand of Kurts,208,88,9,1,3,1
-18075,3,37794,1,15,Hand of Kurts,208,88,9,1,4,1
-18076,3,39783,1,2,Setareh Gauntlet,208,90,9,1,0,1
-18077,3,39783,1,2,Setareh Gauntlet,208,90,9,1,1,1
-18078,3,39783,1,2,Setareh Gauntlet,208,90,9,1,2,1
-18079,3,39783,1,2,Setareh Gauntlet,208,90,9,1,3,1
-18080,3,39783,1,2,Setareh Gauntlet,208,90,9,1,4,1
-18081,3,35805,1,10,Tri-Spell of Resentment,209,85,8,1,0,1
-18082,3,35805,1,10,Tri-Spell of Resentment,209,85,8,1,1,1
-18083,3,35805,1,10,Tri-Spell of Resentment,209,85,8,1,2,1
-18084,3,35805,1,10,Tri-Spell of Resentment,209,85,8,1,3,1
-18085,3,35805,1,10,Tri-Spell of Resentment,209,85,8,1,4,1
-18086,3,37794,1,15,Spell of Youran,209,88,8,1,0,1
-18087,3,37794,1,15,Spell of Youran,209,88,8,1,1,1
-18088,3,37794,1,15,Spell of Youran,209,88,8,1,2,1
-18089,3,37794,1,15,Spell of Youran,209,88,8,1,3,1
-18090,3,37794,1,15,Spell of Youran,209,88,8,1,4,1
-18091,3,39783,1,2,Shams Shooter,209,90,8,1,0,1
-18092,3,39783,1,2,Shams Shooter,209,90,8,1,1,1
-18093,3,39783,1,2,Shams Shooter,209,90,8,1,2,1
-18094,3,39783,1,2,Shams Shooter,209,90,8,1,3,1
-18095,3,39783,1,2,Shams Shooter,209,90,8,1,4,1
-18096,3,35805,1,10,Kinky Cane of Resentment,211,85,4,1,0,1
-18097,3,35805,1,10,Kinky Cane of Resentment,211,85,4,1,1,1
-18098,3,35805,1,10,Kinky Cane of Resentment,211,85,4,1,2,1
-18099,3,35805,1,10,Kinky Cane of Resentment,211,85,4,1,3,1
-18100,3,35805,1,10,Kinky Cane of Resentment,211,85,4,1,4,1
-18101,3,37794,1,15,Staff of Younes,211,88,4,1,0,1
-18102,3,37794,1,15,Staff of Younes,211,88,4,1,1,1
-18103,3,37794,1,15,Staff of Younes,211,88,4,1,2,1
-18104,3,37794,1,15,Staff of Younes,211,88,4,1,3,1
-18105,3,37794,1,15,Staff of Younes,211,88,4,1,4,1
-18106,3,39783,1,2,Shahnaz Sceptre,211,90,4,1,0,1
-18107,3,39783,1,2,Shahnaz Sceptre,211,90,4,1,1,1
-18108,3,39783,1,2,Shahnaz Sceptre,211,90,4,1,2,1
-18109,3,39783,1,2,Shahnaz Sceptre,211,90,4,1,3,1
-18110,3,39783,1,2,Shahnaz Sceptre,211,90,4,1,4,1
-18111,3,35805,1,10,Sphene Wand of Resentment,212,85,6,1,0,1
-18112,3,35805,1,10,Sphene Wand of Resentment,212,85,6,1,1,1
-18113,3,35805,1,10,Sphene Wand of Resentment,212,85,6,1,2,1
-18114,3,35805,1,10,Sphene Wand of Resentment,212,85,6,1,3,1
-18115,3,35805,1,10,Sphene Wand of Resentment,212,85,6,1,4,1
-18116,3,37794,1,15,Wand of Ejderha,212,88,6,1,0,1
-18117,3,37794,1,15,Wand of Ejderha,212,88,6,1,1,1
-18118,3,37794,1,15,Wand of Ejderha,212,88,6,1,2,1
-18119,3,37794,1,15,Wand of Ejderha,212,88,6,1,3,1
-18120,3,37794,1,15,Wand of Ejderha,212,88,6,1,4,1
-18121,3,39783,1,2,Delbar Wand,212,90,6,1,0,1
-18122,3,39783,1,2,Delbar Wand,212,90,6,1,1,1
-18123,3,39783,1,2,Delbar Wand,212,90,6,1,2,1
-18124,3,39783,1,2,Delbar Wand,212,90,6,1,3,1
-18125,3,39783,1,2,Delbar Wand,212,90,6,1,4,1
-18126,3,35805,1,10,Iron Glaive of Resentment,213,85,10,1,0,1
-18127,3,35805,1,10,Iron Glaive of Resentment,213,85,10,1,1,1
-18128,3,35805,1,10,Iron Glaive of Resentment,213,85,10,1,2,1
-18129,3,35805,1,10,Iron Glaive of Resentment,213,85,10,1,3,1
-18130,3,35805,1,10,Iron Glaive of Resentment,213,85,10,1,4,1
-18131,3,37794,1,15,Lance of Kapran,213,88,10,1,0,1
-18132,3,37794,1,15,Lance of Kapran,213,88,10,1,1,1
-18133,3,37794,1,15,Lance of Kapran,213,88,10,1,2,1
-18134,3,37794,1,15,Lance of Kapran,213,88,10,1,3,1
-18135,3,37794,1,15,Lance of Kapran,213,88,10,1,4,1
-18136,3,39783,1,2,Dina Soliferreum,213,90,10,1,0,1
-18137,3,39783,1,2,Dina Soliferreum,213,90,10,1,1,1
-18138,3,39783,1,2,Dina Soliferreum,213,90,10,1,2,1
-18139,3,39783,1,2,Dina Soliferreum,213,90,10,1,3,1
-18140,3,39783,1,2,Dina Soliferreum,213,90,10,1,4,1
-18515,3,24000,1,13,Black Venom Sword,201,1,1,4,0,1
-18516,3,24000,1,2,Black Venom Sword,201,1,1,4,1,1
-18517,3,24000,1,7,Black Venom Sword,201,1,1,4,2,1
-18518,3,24000,1,12,Black Venom Sword,201,1,1,4,3,1
-18519,3,24000,1,6,Black Venom Sword,201,1,1,4,4,1
-18525,3,30000,1,13,Black Venom Blade,203,1,7,4,0,1
-18526,3,30000,1,2,Black Venom Blade,203,1,7,4,1,1
-18527,3,30000,1,7,Black Venom Blade,203,1,7,4,2,1
-18528,3,30000,1,12,Black Venom Blade,203,1,7,4,3,1
-18529,3,30000,1,6,Black Venom Blade,203,1,7,4,4,1
-18530,3,24000,1,13,Black Venom Wall,204,1,5,4,0,1
-18531,3,24000,1,2,Black Venom Wall,204,1,5,4,1,1
-18532,3,24000,1,7,Black Venom Wall,204,1,5,4,2,1
-18533,3,24000,1,12,Black Venom Wall,204,1,5,4,3,1
-18534,3,24000,1,6,Black Venom Wall,204,1,5,4,4,1
-18540,3,30000,1,13,Black Venom Daggers,206,1,2,4,0,1
-18541,3,30000,1,2,Black Venom Daggers,206,1,2,4,1,1
-18542,3,30000,1,7,Black Venom Daggers,206,1,2,4,2,1
-18543,3,30000,1,12,Black Venom Daggers,206,1,2,4,3,1
-18544,3,30000,1,6,Black Venom Daggers,206,1,2,4,4,1
-18545,3,30000,1,13,Black Venom Bow,207,1,3,4,0,1
-18546,3,30000,1,2,Black Venom Bow,207,1,3,4,1,1
-18547,3,30000,1,7,Black Venom Bow,207,1,3,4,2,1
-18548,3,30000,1,12,Black Venom Bow,207,1,3,4,3,1
-18549,3,30000,1,6,Black Venom Bow,207,1,3,4,4,1
-18550,3,30000,1,13,Black Venom Gauntlet,208,1,9,4,0,1
-18551,3,30000,1,2,Black Venom Gauntlet,208,1,9,4,1,1
-18552,3,30000,1,7,Black Venom Gauntlet,208,1,9,4,2,1
-18553,3,30000,1,12,Black Venom Gauntlet,208,1,9,4,3,1
-18554,3,30000,1,6,Black Venom Gauntlet,208,1,9,4,4,1
-18555,3,30000,1,13,Black Venom Spell,209,1,8,4,0,1
-18556,3,30000,1,2,Black Venom Spell,209,1,8,4,1,1
-18557,3,30000,1,7,Black Venom Spell,209,1,8,4,2,1
-18558,3,30000,1,12,Black Venom Spell,209,1,8,4,3,1
-18559,3,30000,1,6,Black Venom Spell,209,1,8,4,4,1
-18560,3,30000,1,13,Black Venom Staff,211,1,4,4,0,1
-18561,3,30000,1,2,Black Venom Staff,211,1,4,4,1,1
-18562,3,30000,1,7,Black Venom Staff,211,1,4,4,2,1
-18563,3,30000,1,12,Black Venom Staff,211,1,4,4,3,1
-18564,3,30000,1,6,Black Venom Staff,211,1,4,4,4,1
-18565,3,30000,1,13,Black Venom Wand,212,1,6,4,0,1
-18566,3,30000,1,2,Black Venom Wand,212,1,6,4,1,1
-18567,3,30000,1,7,Black Venom Wand,212,1,6,4,2,1
-18568,3,30000,1,12,Black Venom Wand,212,1,6,4,3,1
-18569,3,30000,1,6,Black Venom Wand,212,1,6,4,4,1
-18570,3,30000,1,13,Black Venom Spear,213,1,10,4,0,1
-18571,3,30000,1,2,Black Venom Spear,213,1,10,4,1,1
-18572,3,30000,1,7,Black Venom Spear,213,1,10,4,2,1
-18573,3,30000,1,12,Black Venom Spear,213,1,10,4,3,1
-18574,3,30000,1,6,Black Venom Spear,213,1,10,4,4,1
-18665,3,28644,1,10,Verethragna,201,85,1,1,0,1
-18666,3,28644,1,10,Verethragna,201,85,1,1,1,1
-18667,3,28644,1,10,Verethragna,201,85,1,1,2,1
-18668,3,28644,1,10,Verethragna,201,85,1,1,3,1
-18669,3,28644,1,10,Verethragna,201,85,1,1,4,1
-18675,3,35805,1,10,Mithras Bastard,203,85,7,1,0,1
-18676,3,35805,1,10,Mithras Bastard,203,85,7,1,1,1
-18677,3,35805,1,10,Mithras Bastard,203,85,7,1,2,1
-18678,3,35805,1,10,Mithras Bastard,203,85,7,1,3,1
-18679,3,35805,1,10,Mithras Bastard,203,85,7,1,4,1
-18680,3,28644,1,10,Numaniya,204,85,5,1,0,1
-18681,3,28644,1,10,Numaniya,204,85,5,1,1,1
-18682,3,28644,1,10,Numaniya,204,85,5,1,2,1
-18683,3,28644,1,10,Numaniya,204,85,5,1,3,1
-18684,3,28644,1,10,Numaniya,204,85,5,1,4,1
-18690,3,35805,1,10,Atar's Edge,206,85,2,1,0,1
-18691,3,35805,1,10,Atar's Edge,206,85,2,1,1,1
-18692,3,35805,1,10,Atar's Edge,206,85,2,1,2,1
-18693,3,35805,1,10,Atar's Edge,206,85,2,1,3,1
-18694,3,35805,1,10,Atar's Edge,206,85,2,1,4,1
-18695,3,35805,1,10,Sraosha,207,85,3,1,0,1
-18696,3,35805,1,10,Sraosha,207,85,3,1,1,1
-18697,3,35805,1,10,Sraosha,207,85,3,1,2,1
-18698,3,35805,1,10,Sraosha,207,85,3,1,3,1
-18699,3,35805,1,10,Sraosha,207,85,3,1,4,1
-18700,3,35805,1,10,Wataz Glove,208,85,9,1,0,1
-18701,3,35805,1,10,Wataz Glove,208,85,9,1,1,1
-18702,3,35805,1,10,Wataz Glove,208,85,9,1,2,1
-18703,3,35805,1,10,Wataz Glove,208,85,9,1,3,1
-18704,3,35805,1,10,Wataz Glove,208,85,9,1,4,1
-18705,3,35805,1,10,Tishtrya,209,85,8,1,0,1
-18706,3,35805,1,10,Tishtrya,209,85,8,1,1,1
-18707,3,35805,1,10,Tishtrya,209,85,8,1,2,1
-18708,3,35805,1,10,Tishtrya,209,85,8,1,3,1
-18709,3,35805,1,10,Tishtrya,209,85,8,1,4,1
-18710,3,35805,1,10,Anahita,211,85,4,1,0,1
-18711,3,35805,1,10,Anahita,211,85,4,1,1,1
-18712,3,35805,1,10,Anahita,211,85,4,1,2,1
-18713,3,35805,1,10,Anahita,211,85,4,1,3,1
-18714,3,35805,1,10,Anahita,211,85,4,1,4,1
-18715,3,35805,1,10,Hvare-Khshaeta,212,85,6,1,0,1
-18716,3,35805,1,10,Hvare-Khshaeta,212,85,6,1,1,1
-18717,3,35805,1,10,Hvare-Khshaeta,212,85,6,1,2,1
-18718,3,35805,1,10,Hvare-Khshaeta,212,85,6,1,3,1
-18719,3,35805,1,10,Hvare-Khshaeta,212,85,6,1,4,1
-18720,3,35805,1,10,Rashnu,213,85,10,1,0,1
-18721,3,35805,1,10,Rashnu,213,85,10,1,1,1
-18722,3,35805,1,10,Rashnu,213,85,10,1,2,1
-18723,3,35805,1,10,Rashnu,213,85,10,1,3,1
-18724,3,35805,1,10,Rashnu,213,85,10,1,4,1
-19095,3,35805,1,10,True Everlance,213,1,10,1,0,1
-19096,3,35805,1,2,True Everlance,213,1,10,1,1,1
-19097,3,35805,1,12,True Everlance,213,1,10,1,2,1
-19098,3,35805,1,6,True Everlance,213,1,10,1,3,1
-19099,3,35805,1,0,True Everlance,213,1,10,1,4,1
-18900,3,25604,1,6,True Polished Sword,201,1,1,1,0,1
-18901,3,25604,1,0,True Polished Sword,201,1,1,1,1,1
-18902,3,25604,1,10,True Polished Sword,201,1,1,1,2,1
-18903,3,25604,1,4,True Polished Sword,201,1,1,1,3,1
-18904,3,25604,1,14,True Polished Sword,201,1,1,1,4,1
-18905,3,25574,1,0,True Rose Tones,201,1,1,1,0,1
-18906,3,25574,1,10,True Rose Tones,201,1,1,1,1,1
-18907,3,25574,1,4,True Rose Tones,201,1,1,1,2,1
-18908,3,25574,1,14,True Rose Tones,201,1,1,1,3,1
-18909,3,25574,1,8,True Rose Tones,201,1,1,1,4,1
-18910,3,27416,1,5,True Rose Tones,201,1,1,1,0,1
-18911,3,27416,1,15,True Rose Tones,201,1,1,1,1,1
-18912,3,27416,1,9,True Rose Tones,201,1,1,1,2,1
-18913,3,27416,1,3,True Rose Tones,201,1,1,1,3,1
-18914,3,27416,1,13,True Rose Tones,201,1,1,1,4,1
-18915,3,28644,1,10,True Rose Tones,201,1,1,1,0,1
-18916,3,28644,1,2,True Rose Tones,201,1,1,1,1,1
-18917,3,28644,1,12,True Rose Tones,201,1,1,1,2,1
-18918,3,28644,1,6,True Rose Tones,201,1,1,1,3,1
-18919,3,28644,1,0,True Rose Tones,201,1,1,1,4,1
-18920,3,32005,1,6,True Polished Breaker,203,1,7,1,0,1
-18921,3,32005,1,0,True Polished Breaker,203,1,7,1,1,1
-18922,3,32005,1,10,True Polished Breaker,203,1,7,1,2,1
-18923,3,32005,1,4,True Polished Breaker,203,1,7,1,3,1
-18924,3,32005,1,14,True Polished Breaker,203,1,7,1,4,1
-18925,3,31968,1,0,True Wanted Heart,203,1,7,1,0,1
-18926,3,31968,1,10,True Wanted Heart,203,1,7,1,1,1
-18927,3,31968,1,4,True Wanted Heart,203,1,7,1,2,1
-18928,3,31968,1,14,True Wanted Heart,203,1,7,1,3,1
-18929,3,31968,1,8,True Wanted Heart,203,1,7,1,4,1
-18930,3,34270,1,5,True Wanted Heart,203,1,7,1,0,1
-18931,3,34270,1,15,True Wanted Heart,203,1,7,1,1,1
-18932,3,34270,1,9,True Wanted Heart,203,1,7,1,2,1
-18933,3,34270,1,3,True Wanted Heart,203,1,7,1,3,1
-18934,3,34270,1,13,True Wanted Heart,203,1,7,1,4,1
-18935,3,35805,1,10,True Wanted Heart,203,1,7,1,0,1
-18936,3,35805,1,2,True Wanted Heart,203,1,7,1,1,1
-18937,3,35805,1,12,True Wanted Heart,203,1,7,1,2,1
-18938,3,35805,1,6,True Wanted Heart,203,1,7,1,3,1
-18939,3,35805,1,0,True Wanted Heart,203,1,7,1,4,1
-18940,3,25604,1,6,True Polished Guard,204,1,5,1,0,1
-18941,3,25604,1,0,True Polished Guard,204,1,5,1,1,1
-18942,3,25604,1,10,True Polished Guard,204,1,5,1,2,1
-18943,3,25604,1,4,True Polished Guard,204,1,5,1,3,1
-18944,3,25604,1,14,True Polished Guard,204,1,5,1,4,1
-18945,3,25574,1,0,True Dark Pavise,204,1,5,1,0,1
-18946,3,25574,1,10,True Dark Pavise,204,1,5,1,1,1
-18947,3,25574,1,4,True Dark Pavise,204,1,5,1,2,1
-18948,3,25574,1,14,True Dark Pavise,204,1,5,1,3,1
-18949,3,25574,1,8,True Dark Pavise,204,1,5,1,4,1
-18950,3,27416,1,5,True Dark Pavise,204,1,5,1,0,1
-18951,3,27416,1,15,True Dark Pavise,204,1,5,1,1,1
-18952,3,27416,1,9,True Dark Pavise,204,1,5,1,2,1
-18953,3,27416,1,3,True Dark Pavise,204,1,5,1,3,1
-18954,3,27416,1,13,True Dark Pavise,204,1,5,1,4,1
-18955,3,28644,1,10,True Dark Pavise,204,1,5,1,0,1
-18956,3,28644,1,2,True Dark Pavise,204,1,5,1,1,1
-18957,3,28644,1,12,True Dark Pavise,204,1,5,1,2,1
-18958,3,28644,1,6,True Dark Pavise,204,1,5,1,3,1
-18959,3,28644,1,0,True Dark Pavise,204,1,5,1,4,1
-18960,3,32005,1,6,True Polished Daggers,206,1,2,1,0,1
-18961,3,32005,1,0,True Polished Daggers,206,1,2,1,1,1
-18962,3,32005,1,10,True Polished Daggers,206,1,2,1,2,1
-18963,3,32005,1,4,True Polished Daggers,206,1,2,1,3,1
-18964,3,32005,1,14,True Polished Daggers,206,1,2,1,4,1
-18965,3,31968,1,0,True Dark Parazonium,206,1,2,1,0,1
-18966,3,31968,1,10,True Dark Parazonium,206,1,2,1,1,1
-18967,3,31968,1,4,True Dark Parazonium,206,1,2,1,2,1
-18968,3,31968,1,14,True Dark Parazonium,206,1,2,1,3,1
-18969,3,31968,1,8,True Dark Parazonium,206,1,2,1,4,1
-18970,3,34270,1,5,True Dark Parazonium,206,1,2,1,0,1
-18971,3,34270,1,15,True Dark Parazonium,206,1,2,1,1,1
-18972,3,34270,1,9,True Dark Parazonium,206,1,2,1,2,1
-18973,3,34270,1,3,True Dark Parazonium,206,1,2,1,3,1
-18974,3,34270,1,13,True Dark Parazonium,206,1,2,1,4,1
-18975,3,35805,1,10,True Dark Parazonium,206,1,2,1,0,1
-18976,3,35805,1,2,True Dark Parazonium,206,1,2,1,1,1
-18977,3,35805,1,12,True Dark Parazonium,206,1,2,1,2,1
-18978,3,35805,1,6,True Dark Parazonium,206,1,2,1,3,1
-18979,3,35805,1,0,True Dark Parazonium,206,1,2,1,4,1
-18980,3,32005,1,6,True Polished Bow,207,1,3,1,0,1
-18981,3,32005,1,0,True Polished Bow,207,1,3,1,1,1
-18982,3,32005,1,10,True Polished Bow,207,1,3,1,2,1
-18983,3,32005,1,4,True Polished Bow,207,1,3,1,3,1
-18984,3,32005,1,14,True Polished Bow,207,1,3,1,4,1
-18985,3,31968,1,0,True Dragon's Blink,207,1,3,1,0,1
-18986,3,31968,1,10,True Dragon's Blink,207,1,3,1,1,1
-18987,3,31968,1,4,True Dragon's Blink,207,1,3,1,2,1
-18988,3,31968,1,14,True Dragon's Blink,207,1,3,1,3,1
-18989,3,31968,1,8,True Dragon's Blink,207,1,3,1,4,1
-18990,3,34270,1,5,True Dragon's Blink,207,1,3,1,0,1
-18991,3,34270,1,15,True Dragon's Blink,207,1,3,1,1,1
-18992,3,34270,1,9,True Dragon's Blink,207,1,3,1,2,1
-18993,3,34270,1,3,True Dragon's Blink,207,1,3,1,3,1
-18994,3,34270,1,13,True Dragon's Blink,207,1,3,1,4,1
-18995,3,35805,1,10,True Dragon's Blink,207,1,3,1,0,1
-18996,3,35805,1,2,True Dragon's Blink,207,1,3,1,1,1
-18997,3,35805,1,12,True Dragon's Blink,207,1,3,1,2,1
-18998,3,35805,1,6,True Dragon's Blink,207,1,3,1,3,1
-18999,3,35805,1,0,True Dragon's Blink,207,1,3,1,4,1
-19000,3,32005,1,6,True Polished Gauntlet,208,1,9,1,0,1
-19001,3,32005,1,0,True Polished Gauntlet,208,1,9,1,1,1
-19002,3,32005,1,10,True Polished Gauntlet,208,1,9,3,2,1
-19003,3,32005,1,4,True Polished Gauntlet,208,1,9,1,3,1
-19004,3,32005,1,14,True Polished Gauntlet,208,1,9,1,4,1
-19005,3,31968,1,0,True Hidden Seiðr,208,1,9,1,0,1
-19006,3,31968,1,10,True Hidden Seiðr,208,1,9,1,1,1
-19007,3,31968,1,4,True Hidden Seiðr,208,1,9,1,2,1
-19008,3,31968,1,14,True Hidden Seiðr,208,1,9,1,3,1
-19009,3,31968,1,8,True Hidden Seiðr,208,1,9,1,4,1
-19010,3,34270,1,5,True Hidden Seiðr,208,1,9,1,0,1
-19011,3,34270,1,15,True Hidden Seiðr,208,1,9,1,1,1
-19012,3,34270,1,9,True Hidden Seiðr,208,1,9,1,2,1
-19013,3,34270,1,3,True Hidden Seiðr,208,1,9,1,3,1
-19014,3,34270,1,13,True Hidden Seiðr,208,1,9,1,4,1
-19015,3,35805,1,10,True Hidden Seiðr,208,1,9,1,0,1
-19016,3,35805,1,2,True Hidden Seiðr,208,1,9,1,1,1
-19017,3,35805,1,12,True Hidden Seiðr,208,1,9,1,2,1
-19018,3,35805,1,6,True Hidden Seiðr,208,1,9,1,3,1
-19019,3,35805,1,0,True Hidden Seiðr,208,1,9,1,4,1
-19020,3,32005,1,6,True Polished Spell,209,1,8,1,0,1
-19021,3,32005,1,0,True Polished Spell,209,1,8,1,1,1
-19022,3,32005,1,10,True Polished Spell,209,1,8,1,2,1
-19023,3,32005,1,4,True Polished Spell,209,1,8,1,3,1
-19024,3,32005,1,14,True Polished Spell,209,1,8,1,4,1
-19025,3,31968,1,0,True Dragon's Supreme,209,1,8,1,0,1
-19026,3,31968,1,10,True Dragon's Supreme,209,1,8,1,1,1
-19027,3,31968,1,4,True Dragon's Supreme,209,1,8,1,2,1
-19028,3,31968,1,14,True Dragon's Supreme,209,1,8,1,3,1
-19029,3,31968,1,8,True Dragon's Supreme,209,1,8,1,4,1
-19030,3,34270,1,5,True Dragon's Supreme,209,1,8,1,0,1
-19031,3,34270,1,15,True Dragon's Supreme,209,1,8,1,1,1
-19032,3,34270,1,9,True Dragon's Supreme,209,1,8,1,2,1
-19033,3,34270,1,3,True Dragon's Supreme,209,1,8,1,3,1
-19034,3,34270,1,13,True Dragon's Supreme,209,1,8,1,4,1
-19035,3,35805,1,10,True Dragon's Supreme,209,1,8,1,0,1
-19036,3,35805,1,2,True Dragon's Supreme,209,1,8,1,1,1
-19037,3,35805,1,12,True Dragon's Supreme,209,1,8,1,2,1
-19038,3,35805,1,6,True Dragon's Supreme,209,1,8,1,3,1
-19039,3,35805,1,0,True Dragon's Supreme,209,1,8,1,4,1
-19040,3,32005,1,6,True Polished Staff,211,1,4,1,0,1
-19041,3,32005,1,0,True Polished Staff,211,1,4,1,1,1
-19042,3,32005,1,10,True Polished Staff,211,1,4,1,2,1
-19043,3,32005,1,4,True Polished Staff,211,1,4,1,3,1
-19044,3,32005,1,14,True Polished Staff,211,1,4,1,4,1
-19045,3,31968,1,0,True Chilly Cane,211,1,4,1,0,1
-19046,3,31968,1,10,True Chilly Cane,211,1,4,1,1,1
-19047,3,31968,1,4,True Chilly Cane,211,1,4,1,2,1
-19048,3,31968,1,14,True Chilly Cane,211,1,4,1,3,1
-19049,3,31968,1,8,True Chilly Cane,211,1,4,1,4,1
-19050,3,34270,1,5,True Chilly Cane,211,1,4,1,0,1
-19051,3,34270,1,15,True Chilly Cane,211,1,4,1,1,1
-19052,3,34270,1,9,True Chilly Cane,211,1,4,1,2,1
-19053,3,34270,1,3,True Chilly Cane,211,1,4,1,3,1
-19054,3,34270,1,13,True Chilly Cane,211,1,4,1,4,1
-19055,3,35805,1,10,True Chilly Cane,211,1,4,1,0,1
-19056,3,35805,1,2,True Chilly Cane,211,1,4,1,1,1
-19057,3,35805,1,12,True Chilly Cane,211,1,4,1,2,1
-19058,3,35805,1,6,True Chilly Cane,211,1,4,1,3,1
-19059,3,35805,1,0,True Chilly Cane,211,1,4,1,4,1
-19060,3,32005,1,6,True Polished Wand,212,1,6,1,0,1
-19061,3,32005,1,0,True Polished Wand,212,1,6,1,1,1
-19062,3,32005,1,10,True Polished Wand,212,1,6,1,2,1
-19063,3,32005,1,4,True Polished Wand,212,1,6,1,3,1
-19064,3,32005,1,14,True Polished Wand,212,1,6,1,4,1
-19065,3,31968,1,0,True Road to Hades,212,1,6,1,0,1
-19066,3,31968,1,10,True Road to Hades,212,1,6,1,1,1
-19067,3,31968,1,4,True Road to Hades,212,1,6,1,2,1
-19068,3,31968,1,14,True Road to Hades,212,1,6,1,3,1
-19069,3,31968,1,8,True Road to Hades,212,1,6,1,4,1
-19070,3,34270,1,5,True Road to Hades,212,1,6,1,0,1
-19071,3,34270,1,15,True Road to Hades,212,1,6,1,1,1
-19072,3,34270,1,9,True Road to Hades,212,1,6,1,2,1
-19073,3,34270,1,3,True Road to Hades,212,1,6,1,3,1
-19074,3,34270,1,13,True Road to Hades,212,1,6,1,4,1
-19075,3,35805,1,10,True Road to Hades,212,1,6,1,0,1
-19076,3,35805,1,2,True Road to Hades,212,1,6,1,1,1
-19077,3,35805,1,12,True Road to Hades,212,1,6,1,2,1
-19078,3,35805,1,6,True Road to Hades,212,1,6,1,3,1
-19079,3,35805,1,0,True Road to Hades,212,1,6,1,4,1
-19080,3,32005,1,6,True Polished Lance,213,1,10,1,0,1
-19081,3,32005,1,0,True Polished Lance,213,1,10,1,1,1
-19082,3,32005,1,10,True Polished Lance,213,1,10,1,2,1
-19083,3,32005,1,4,True Polished Lance,213,1,10,1,3,1
-19084,3,32005,1,14,True Polished Lance,213,1,10,1,4,1
-19085,3,31968,1,0,True Everlance,213,1,10,1,0,1
-19086,3,31968,1,10,True Everlance,213,1,10,1,1,1
-19087,3,31968,1,4,True Everlance,213,1,10,1,2,1
-19088,3,31968,1,14,True Everlance,213,1,10,1,3,1
-19089,3,31968,1,8,True Everlance,213,1,10,1,4,1
-19090,3,34270,1,5,True Everlance,213,1,10,1,0,1
-19091,3,34270,1,15,True Everlance,213,1,10,1,1,1
-19092,3,34270,1,9,True Everlance,213,1,10,1,2,1
-19093,3,34270,1,3,True Everlance,213,1,10,1,3,1
-19094,3,34270,1,13,True Everlance,213,1,10,1,4,1
-19149,3,25604,1,11,Crimson Sword,201,80,1,1,0,1
-19150,3,25604,1,11,Crimson Sword,201,80,1,1,1,1
-19151,3,25604,1,11,Crimson Sword,201,80,1,1,2,1
-19152,3,25604,1,11,Crimson Sword,201,80,1,1,3,1
-19153,3,25604,1,11,Crimson Sword,201,80,1,1,4,1
-19154,3,32005,1,11,Crimson Blade,203,80,7,1,0,1
-19155,3,32005,1,11,Crimson Blade,203,80,7,1,1,1
-19156,3,32005,1,11,Crimson Blade,203,80,7,1,2,1
-19157,3,32005,1,11,Crimson Blade,203,80,7,1,3,1
-19158,3,32005,1,11,Crimson Blade,203,80,7,1,4,1
-19159,3,25604,1,11,Crimson Wall,204,80,5,1,0,1
-19160,3,25604,1,11,Crimson Wall,204,80,5,1,1,1
-19161,3,25604,1,11,Crimson Wall,204,80,5,1,2,1
-19162,3,25604,1,11,Crimson Wall,204,80,5,1,3,1
-19163,3,25604,1,11,Crimson Wall,204,80,5,1,4,1
-19164,3,32005,1,11,Crimson Daggers,206,80,2,1,0,1
-19165,3,32005,1,11,Crimson Daggers,206,80,2,1,1,1
-19166,3,32005,1,11,Crimson Daggers,206,80,2,1,2,1
-19167,3,32005,1,11,Crimson Daggers,206,80,2,1,3,1
-19168,3,32005,1,11,Crimson Daggers,206,80,2,1,4,1
-19169,3,32005,1,11,Crimson Bow,207,80,3,1,0,1
-19170,3,32005,1,11,Crimson Bow,207,80,3,1,1,1
-19171,3,32005,1,11,Crimson Bow,207,80,3,1,2,1
-19172,3,32005,1,11,Crimson Bow,207,80,3,1,3,1
-19173,3,32005,1,11,Crimson Bow,207,80,3,1,4,1
-19174,3,32005,1,11,Crimson Gauntlet,208,80,9,1,0,1
-19175,3,32005,1,11,Crimson Gauntlet,208,80,9,1,1,1
-19176,3,32005,1,11,Crimson Gauntlet,208,80,9,1,2,1
-19177,3,32005,1,11,Crimson Gauntlet,208,80,9,1,3,1
-19178,3,32005,1,11,Crimson Gauntlet,208,80,9,1,4,1
-19179,3,32005,1,11,Crimson Spell,209,80,8,1,0,1
-19180,3,32005,1,11,Crimson Spell,209,80,8,1,1,1
-19181,3,32005,1,11,Crimson Spell,209,80,8,1,2,1
-19182,3,32005,1,11,Crimson Spell,209,80,8,1,3,1
-19183,3,32005,1,11,Crimson Spell,209,80,8,1,4,1
-19184,3,32005,1,11,Crimson Staff,211,80,4,1,0,1
-19185,3,32005,1,11,Crimson Staff,211,80,4,1,1,1
-19186,3,32005,1,11,Crimson Staff,211,80,4,1,2,1
-19187,3,32005,1,11,Crimson Staff,211,80,4,1,3,1
-19188,3,32005,1,11,Crimson Staff,211,80,4,1,4,1
-19189,3,32005,1,11,Crimson Wand,212,80,6,1,0,1
-19190,3,32005,1,11,Crimson Wand,212,80,6,1,1,1
-19191,3,32005,1,11,Crimson Wand,212,80,6,1,2,1
-19192,3,32005,1,11,Crimson Wand,212,80,6,1,3,1
-19193,3,32005,1,11,Crimson Wand,212,80,6,1,4,1
-19194,3,32005,1,11,Crimson Spear,213,80,10,1,0,1
-19195,3,32005,1,11,Crimson Spear,213,80,10,1,1,1
-19196,3,32005,1,11,Crimson Spear,213,80,10,1,2,1
-19197,3,32005,1,11,Crimson Spear,213,80,10,1,3,1
-19198,3,32005,1,11,Crimson Spear,213,80,10,1,4,1
+19113,3,30000,1,45,One-handed Snap Blade,201,1,1,4,3,1
+19114,3,30000,1,75,One-handed Snap Blade,201,1,1,4,4,1
+17961,3,35805,1,90,Spike Mace of Resentment,201,85,1,1,0,1
+17962,3,35805,1,90,Spike Mace of Resentment,201,85,1,1,1,1
+17963,3,35805,1,90,Spike Mace of Resentment,201,85,1,1,2,1
+17964,3,35805,1,90,Spike Mace of Resentment,201,85,1,1,3,1
+17965,3,35805,1,90,Spike Mace of Resentment,201,85,1,1,4,1
+17966,3,37794,1,95,Rapier of Deev,201,88,1,1,0,1
+17967,3,37794,1,95,Rapier of Deev,201,88,1,1,1,1
+17968,3,37794,1,95,Rapier of Deev,201,88,1,1,2,1
+17969,3,37794,1,95,Rapier of Deev,201,88,1,1,3,1
+17970,3,37794,1,95,Rapier of Deev,201,88,1,1,4,1
+17971,3,39783,1,98,Zarrin-dokht Axe,201,90,1,1,0,1
+17972,3,39783,1,98,Zarrin-dokht Axe,201,90,1,1,1,1
+17973,3,39783,1,98,Zarrin-dokht Axe,201,90,1,1,2,1
+17974,3,39783,1,98,Zarrin-dokht Axe,201,90,1,1,3,1
+17975,3,39783,1,98,Zarrin-dokht Axe,201,90,1,1,4,1
+17991,3,35805,1,90,Saw Blade of Resentment,203,85,7,1,0,1
+17992,3,35805,1,90,Saw Blade of Resentment,203,85,7,1,1,1
+17993,3,35805,1,90,Saw Blade of Resentment,203,85,7,1,2,1
+17994,3,35805,1,90,Saw Blade of Resentment,203,85,7,1,3,1
+17995,3,35805,1,90,Saw Blade of Resentment,203,85,7,1,4,1
+17996,3,37794,1,95,Edge of Aslan,203,88,7,1,0,1
+17997,3,37794,1,95,Edge of Aslan,203,88,7,1,1,1
+17998,3,37794,1,95,Edge of Aslan,203,88,7,1,2,1
+17999,3,37794,1,95,Edge of Aslan,203,88,7,1,3,1
+18000,3,37794,1,95,Edge of Aslan,203,88,7,1,4,1
+18001,3,39783,1,98,Sholeha Blade,203,90,7,1,0,1
+18002,3,39783,1,98,Sholeha Blade,203,90,7,1,1,1
+18003,3,39783,1,98,Sholeha Blade,203,90,7,1,2,1
+18004,3,39783,1,98,Sholeha Blade,203,90,7,1,3,1
+18005,3,39783,1,98,Sholeha Blade,203,90,7,1,4,1
+18006,3,35805,1,90,Chained Wall of Resentment,204,85,5,1,0,1
+18007,3,35805,1,90,Chained Wall of Resentment,204,85,5,1,1,1
+18008,3,35805,1,90,Chained Wall of Resentment,204,85,5,1,2,1
+18009,3,35805,1,90,Chained Wall of Resentment,204,85,5,1,3,1
+18010,3,35805,1,90,Chained Wall of Resentment,204,85,5,1,4,1
+18011,3,37794,1,95,Fort of Ferey,204,88,5,1,0,1
+18012,3,37794,1,95,Fort of Ferey,204,88,5,1,1,1
+18013,3,37794,1,95,Fort of Ferey,204,88,5,1,2,1
+18014,3,37794,1,95,Fort of Ferey,204,88,5,1,3,1
+18015,3,37794,1,95,Fort of Ferey,204,88,5,1,4,1
+18016,3,39783,1,98,Taraneh Wall,204,90,5,1,0,1
+18017,3,39783,1,98,Taraneh Wall,204,90,5,1,1,1
+18018,3,39783,1,98,Taraneh Wall,204,90,5,1,2,1
+18019,3,39783,1,98,Taraneh Wall,204,90,5,1,3,1
+18020,3,39783,1,98,Taraneh Wall,204,90,5,1,4,1
+18036,3,35805,1,90,Guillotine Edge of Resentment,206,85,2,1,0,1
+18037,3,35805,1,90,Guillotine Edge of Resentment,206,85,2,1,1,1
+18038,3,35805,1,90,Guillotine Edge of Resentment,206,85,2,1,2,1
+18039,3,35805,1,90,Guillotine Edge of Resentment,206,85,2,1,3,1
+18040,3,35805,1,90,Guillotine Edge of Resentment,206,85,2,1,4,1
+18041,3,37794,1,95,Dagger of Vashak,206,88,2,1,0,1
+18042,3,37794,1,95,Dagger of Vashak,206,88,2,1,1,1
+18043,3,37794,1,95,Dagger of Vashak,206,88,2,1,2,1
+18044,3,37794,1,95,Dagger of Vashak,206,88,2,1,3,1
+18045,3,37794,1,95,Dagger of Vashak,206,88,2,1,4,1
+18046,3,39783,1,98,Sanaz Scramaseax,206,90,2,1,0,1
+18047,3,39783,1,98,Sanaz Scramaseax,206,90,2,1,1,1
+18048,3,39783,1,98,Sanaz Scramaseax,206,90,2,1,2,1
+18049,3,39783,1,98,Sanaz Scramaseax,206,90,2,1,3,1
+18050,3,39783,1,98,Sanaz Scramaseax,206,90,2,1,4,1
+18051,3,35805,1,90,Shortbow of Resentment,207,85,3,1,0,1
+18052,3,35805,1,90,Shortbow of Resentment,207,85,3,1,1,1
+18053,3,35805,1,90,Shortbow of Resentment,207,85,3,1,2,1
+18054,3,35805,1,90,Shortbow of Resentment,207,85,3,1,3,1
+18055,3,35805,1,90,Shortbow of Resentment,207,85,3,1,4,1
+18056,3,37794,1,95,Aim of Kal Tal,207,88,3,1,0,1
+18057,3,37794,1,95,Aim of Kal Tal,207,88,3,1,1,1
+18058,3,37794,1,95,Aim of Kal Tal,207,88,3,1,2,1
+18059,3,37794,1,95,Aim of Kal Tal,207,88,3,1,3,1
+18060,3,37794,1,95,Aim of Kal Tal,207,88,3,1,4,1
+18061,3,39783,1,98,Roshni Bow,207,90,3,1,0,1
+18062,3,39783,1,98,Roshni Bow,207,90,3,1,1,1
+18063,3,39783,1,98,Roshni Bow,207,90,3,1,2,1
+18064,3,39783,1,98,Roshni Bow,207,90,3,1,3,1
+18065,3,39783,1,98,Roshni Bow,207,90,3,1,4,1
+18066,3,35805,1,90,Spinel Arm of Resentment,208,85,9,1,0,1
+18067,3,35805,1,90,Spinel Arm of Resentment,208,85,9,1,1,1
+18068,3,35805,1,90,Spinel Arm of Resentment,208,85,9,1,2,1
+18069,3,35805,1,90,Spinel Arm of Resentment,208,85,9,1,3,1
+18070,3,35805,1,90,Spinel Arm of Resentment,208,85,9,1,4,1
+18071,3,37794,1,95,Hand of Kurts,208,88,9,1,0,1
+18072,3,37794,1,95,Hand of Kurts,208,88,9,1,1,1
+18073,3,37794,1,95,Hand of Kurts,208,88,9,1,2,1
+18074,3,37794,1,95,Hand of Kurts,208,88,9,1,3,1
+18075,3,37794,1,95,Hand of Kurts,208,88,9,1,4,1
+18076,3,39783,1,98,Setareh Gauntlet,208,90,9,1,0,1
+18077,3,39783,1,98,Setareh Gauntlet,208,90,9,1,1,1
+18078,3,39783,1,98,Setareh Gauntlet,208,90,9,1,2,1
+18079,3,39783,1,98,Setareh Gauntlet,208,90,9,1,3,1
+18080,3,39783,1,98,Setareh Gauntlet,208,90,9,1,4,1
+18081,3,35805,1,90,Tri-Spell of Resentment,209,85,8,1,0,1
+18082,3,35805,1,90,Tri-Spell of Resentment,209,85,8,1,1,1
+18083,3,35805,1,90,Tri-Spell of Resentment,209,85,8,1,2,1
+18084,3,35805,1,90,Tri-Spell of Resentment,209,85,8,1,3,1
+18085,3,35805,1,90,Tri-Spell of Resentment,209,85,8,1,4,1
+18086,3,37794,1,95,Spell of Youran,209,88,8,1,0,1
+18087,3,37794,1,95,Spell of Youran,209,88,8,1,1,1
+18088,3,37794,1,95,Spell of Youran,209,88,8,1,2,1
+18089,3,37794,1,95,Spell of Youran,209,88,8,1,3,1
+18090,3,37794,1,95,Spell of Youran,209,88,8,1,4,1
+18091,3,39783,1,98,Shams Shooter,209,90,8,1,0,1
+18092,3,39783,1,98,Shams Shooter,209,90,8,1,1,1
+18093,3,39783,1,98,Shams Shooter,209,90,8,1,2,1
+18094,3,39783,1,98,Shams Shooter,209,90,8,1,3,1
+18095,3,39783,1,98,Shams Shooter,209,90,8,1,4,1
+18096,3,35805,1,90,Kinky Cane of Resentment,211,85,4,1,0,1
+18097,3,35805,1,90,Kinky Cane of Resentment,211,85,4,1,1,1
+18098,3,35805,1,90,Kinky Cane of Resentment,211,85,4,1,2,1
+18099,3,35805,1,90,Kinky Cane of Resentment,211,85,4,1,3,1
+18100,3,35805,1,90,Kinky Cane of Resentment,211,85,4,1,4,1
+18101,3,37794,1,95,Staff of Younes,211,88,4,1,0,1
+18102,3,37794,1,95,Staff of Younes,211,88,4,1,1,1
+18103,3,37794,1,95,Staff of Younes,211,88,4,1,2,1
+18104,3,37794,1,95,Staff of Younes,211,88,4,1,3,1
+18105,3,37794,1,95,Staff of Younes,211,88,4,1,4,1
+18106,3,39783,1,98,Shahnaz Sceptre,211,90,4,1,0,1
+18107,3,39783,1,98,Shahnaz Sceptre,211,90,4,1,1,1
+18108,3,39783,1,98,Shahnaz Sceptre,211,90,4,1,2,1
+18109,3,39783,1,98,Shahnaz Sceptre,211,90,4,1,3,1
+18110,3,39783,1,98,Shahnaz Sceptre,211,90,4,1,4,1
+18111,3,35805,1,90,Sphene Wand of Resentment,212,85,6,1,0,1
+18112,3,35805,1,90,Sphene Wand of Resentment,212,85,6,1,1,1
+18113,3,35805,1,90,Sphene Wand of Resentment,212,85,6,1,2,1
+18114,3,35805,1,90,Sphene Wand of Resentment,212,85,6,1,3,1
+18115,3,35805,1,90,Sphene Wand of Resentment,212,85,6,1,4,1
+18116,3,37794,1,95,Wand of Ejderha,212,88,6,1,0,1
+18117,3,37794,1,95,Wand of Ejderha,212,88,6,1,1,1
+18118,3,37794,1,95,Wand of Ejderha,212,88,6,1,2,1
+18119,3,37794,1,95,Wand of Ejderha,212,88,6,1,3,1
+18120,3,37794,1,95,Wand of Ejderha,212,88,6,1,4,1
+18121,3,39783,1,98,Delbar Wand,212,90,6,1,0,1
+18122,3,39783,1,98,Delbar Wand,212,90,6,1,1,1
+18123,3,39783,1,98,Delbar Wand,212,90,6,1,2,1
+18124,3,39783,1,98,Delbar Wand,212,90,6,1,3,1
+18125,3,39783,1,98,Delbar Wand,212,90,6,1,4,1
+18126,3,35805,1,90,Iron Glaive of Resentment,213,85,10,1,0,1
+18127,3,35805,1,90,Iron Glaive of Resentment,213,85,10,1,1,1
+18128,3,35805,1,90,Iron Glaive of Resentment,213,85,10,1,2,1
+18129,3,35805,1,90,Iron Glaive of Resentment,213,85,10,1,3,1
+18130,3,35805,1,90,Iron Glaive of Resentment,213,85,10,1,4,1
+18131,3,37794,1,95,Lance of Kapran,213,88,10,1,0,1
+18132,3,37794,1,95,Lance of Kapran,213,88,10,1,1,1
+18133,3,37794,1,95,Lance of Kapran,213,88,10,1,2,1
+18134,3,37794,1,95,Lance of Kapran,213,88,10,1,3,1
+18135,3,37794,1,95,Lance of Kapran,213,88,10,1,4,1
+18136,3,39783,1,98,Dina Soliferreum,213,90,10,1,0,1
+18137,3,39783,1,98,Dina Soliferreum,213,90,10,1,1,1
+18138,3,39783,1,98,Dina Soliferreum,213,90,10,1,2,1
+18139,3,39783,1,98,Dina Soliferreum,213,90,10,1,3,1
+18140,3,39783,1,98,Dina Soliferreum,213,90,10,1,4,1
+18515,3,24000,1,45,Black Venom Sword,201,1,1,4,0,1
+18516,3,24000,1,50,Black Venom Sword,201,1,1,4,1,1
+18517,3,24000,1,55,Black Venom Sword,201,1,1,4,2,1
+18518,3,24000,1,60,Black Venom Sword,201,1,1,4,3,1
+18519,3,24000,1,70,Black Venom Sword,201,1,1,4,4,1
+18525,3,30000,1,45,Black Venom Blade,203,1,7,4,0,1
+18526,3,30000,1,50,Black Venom Blade,203,1,7,4,1,1
+18527,3,30000,1,55,Black Venom Blade,203,1,7,4,2,1
+18528,3,30000,1,60,Black Venom Blade,203,1,7,4,3,1
+18529,3,30000,1,70,Black Venom Blade,203,1,7,4,4,1
+18530,3,24000,1,45,Black Venom Wall,204,1,5,4,0,1
+18531,3,24000,1,50,Black Venom Wall,204,1,5,4,1,1
+18532,3,24000,1,55,Black Venom Wall,204,1,5,4,2,1
+18533,3,24000,1,60,Black Venom Wall,204,1,5,4,3,1
+18534,3,24000,1,70,Black Venom Wall,204,1,5,4,4,1
+18540,3,30000,1,45,Black Venom Daggers,206,1,2,4,0,1
+18541,3,30000,1,50,Black Venom Daggers,206,1,2,4,1,1
+18542,3,30000,1,55,Black Venom Daggers,206,1,2,4,2,1
+18543,3,30000,1,60,Black Venom Daggers,206,1,2,4,3,1
+18544,3,30000,1,70,Black Venom Daggers,206,1,2,4,4,1
+18545,3,30000,1,45,Black Venom Bow,207,1,3,4,0,1
+18546,3,30000,1,50,Black Venom Bow,207,1,3,4,1,1
+18547,3,30000,1,55,Black Venom Bow,207,1,3,4,2,1
+18548,3,30000,1,60,Black Venom Bow,207,1,3,4,3,1
+18549,3,30000,1,70,Black Venom Bow,207,1,3,4,4,1
+18550,3,30000,1,45,Black Venom Gauntlet,208,1,9,4,0,1
+18551,3,30000,1,50,Black Venom Gauntlet,208,1,9,4,1,1
+18552,3,30000,1,55,Black Venom Gauntlet,208,1,9,4,2,1
+18553,3,30000,1,60,Black Venom Gauntlet,208,1,9,4,3,1
+18554,3,30000,1,70,Black Venom Gauntlet,208,1,9,4,4,1
+18555,3,30000,1,45,Black Venom Spell,209,1,8,4,0,1
+18556,3,30000,1,50,Black Venom Spell,209,1,8,4,1,1
+18557,3,30000,1,55,Black Venom Spell,209,1,8,4,2,1
+18558,3,30000,1,60,Black Venom Spell,209,1,8,4,3,1
+18559,3,30000,1,70,Black Venom Spell,209,1,8,4,4,1
+18560,3,30000,1,45,Black Venom Staff,211,1,4,4,0,1
+18561,3,30000,1,50,Black Venom Staff,211,1,4,4,1,1
+18562,3,30000,1,55,Black Venom Staff,211,1,4,4,2,1
+18563,3,30000,1,60,Black Venom Staff,211,1,4,4,3,1
+18564,3,30000,1,70,Black Venom Staff,211,1,4,4,4,1
+18565,3,30000,1,45,Black Venom Wand,212,1,6,4,0,1
+18566,3,30000,1,50,Black Venom Wand,212,1,6,4,1,1
+18567,3,30000,1,55,Black Venom Wand,212,1,6,4,2,1
+18568,3,30000,1,60,Black Venom Wand,212,1,6,4,3,1
+18569,3,30000,1,70,Black Venom Wand,212,1,6,4,4,1
+18570,3,30000,1,45,Black Venom Spear,213,1,10,4,0,1
+18571,3,30000,1,50,Black Venom Spear,213,1,10,4,1,1
+18572,3,30000,1,55,Black Venom Spear,213,1,10,4,2,1
+18573,3,30000,1,60,Black Venom Spear,213,1,10,4,3,1
+18574,3,30000,1,70,Black Venom Spear,213,1,10,4,4,1
+18665,3,28644,1,90,Verethragna,201,85,1,1,0,1
+18666,3,28644,1,90,Verethragna,201,85,1,1,1,1
+18667,3,28644,1,90,Verethragna,201,85,1,1,2,1
+18668,3,28644,1,90,Verethragna,201,85,1,1,3,1
+18669,3,28644,1,90,Verethragna,201,85,1,1,4,1
+18675,3,35805,1,90,Mithras Bastard,203,85,7,1,0,1
+18676,3,35805,1,90,Mithras Bastard,203,85,7,1,1,1
+18677,3,35805,1,90,Mithras Bastard,203,85,7,1,2,1
+18678,3,35805,1,90,Mithras Bastard,203,85,7,1,3,1
+18679,3,35805,1,90,Mithras Bastard,203,85,7,1,4,1
+18680,3,28644,1,90,Numaniya,204,85,5,1,0,1
+18681,3,28644,1,90,Numaniya,204,85,5,1,1,1
+18682,3,28644,1,90,Numaniya,204,85,5,1,2,1
+18683,3,28644,1,90,Numaniya,204,85,5,1,3,1
+18684,3,28644,1,90,Numaniya,204,85,5,1,4,1
+18690,3,35805,1,90,Atar's Edge,206,85,2,1,0,1
+18691,3,35805,1,90,Atar's Edge,206,85,2,1,1,1
+18692,3,35805,1,90,Atar's Edge,206,85,2,1,2,1
+18693,3,35805,1,90,Atar's Edge,206,85,2,1,3,1
+18694,3,35805,1,90,Atar's Edge,206,85,2,1,4,1
+18695,3,35805,1,90,Sraosha,207,85,3,1,0,1
+18696,3,35805,1,90,Sraosha,207,85,3,1,1,1
+18697,3,35805,1,90,Sraosha,207,85,3,1,2,1
+18698,3,35805,1,90,Sraosha,207,85,3,1,3,1
+18699,3,35805,1,90,Sraosha,207,85,3,1,4,1
+18700,3,35805,1,90,Wataz Glove,208,85,9,1,0,1
+18701,3,35805,1,90,Wataz Glove,208,85,9,1,1,1
+18702,3,35805,1,90,Wataz Glove,208,85,9,1,2,1
+18703,3,35805,1,90,Wataz Glove,208,85,9,1,3,1
+18704,3,35805,1,90,Wataz Glove,208,85,9,1,4,1
+18705,3,35805,1,90,Tishtrya,209,85,8,1,0,1
+18706,3,35805,1,90,Tishtrya,209,85,8,1,1,1
+18707,3,35805,1,90,Tishtrya,209,85,8,1,2,1
+18708,3,35805,1,90,Tishtrya,209,85,8,1,3,1
+18709,3,35805,1,90,Tishtrya,209,85,8,1,4,1
+18710,3,35805,1,90,Anahita,211,85,4,1,0,1
+18711,3,35805,1,90,Anahita,211,85,4,1,1,1
+18712,3,35805,1,90,Anahita,211,85,4,1,2,1
+18713,3,35805,1,90,Anahita,211,85,4,1,3,1
+18714,3,35805,1,90,Anahita,211,85,4,1,4,1
+18715,3,35805,1,90,Hvare-Khshaeta,212,85,6,1,0,1
+18716,3,35805,1,90,Hvare-Khshaeta,212,85,6,1,1,1
+18717,3,35805,1,90,Hvare-Khshaeta,212,85,6,1,2,1
+18718,3,35805,1,90,Hvare-Khshaeta,212,85,6,1,3,1
+18719,3,35805,1,90,Hvare-Khshaeta,212,85,6,1,4,1
+18720,3,35805,1,90,Rashnu,213,85,10,1,0,1
+18721,3,35805,1,90,Rashnu,213,85,10,1,1,1
+18722,3,35805,1,90,Rashnu,213,85,10,1,2,1
+18723,3,35805,1,90,Rashnu,213,85,10,1,3,1
+18724,3,35805,1,90,Rashnu,213,85,10,1,4,1
+19095,3,35805,1,90,True Everlance,213,1,10,1,0,1
+19096,3,35805,1,98,True Everlance,213,1,10,1,1,1
+19097,3,35805,1,108,True Everlance,213,1,10,1,2,1
+19098,3,35805,1,118,True Everlance,213,1,10,1,3,1
+19099,3,35805,1,128,True Everlance,213,1,10,1,4,1
+18900,3,25604,1,70,True Polished Sword,201,1,1,1,0,1
+18901,3,25604,1,80,True Polished Sword,201,1,1,1,1,1
+18902,3,25604,1,90,True Polished Sword,201,1,1,1,2,1
+18903,3,25604,1,100,True Polished Sword,201,1,1,1,3,1
+18904,3,25604,1,110,True Polished Sword,201,1,1,1,4,1
+18905,3,25574,1,80,True Rose Tones,201,1,1,1,0,1
+18906,3,25574,1,90,True Rose Tones,201,1,1,1,1,1
+18907,3,25574,1,100,True Rose Tones,201,1,1,1,2,1
+18908,3,25574,1,110,True Rose Tones,201,1,1,1,3,1
+18909,3,25574,1,120,True Rose Tones,201,1,1,1,4,1
+18910,3,27416,1,85,True Rose Tones,201,1,1,1,0,1
+18911,3,27416,1,95,True Rose Tones,201,1,1,1,1,1
+18912,3,27416,1,105,True Rose Tones,201,1,1,1,2,1
+18913,3,27416,1,115,True Rose Tones,201,1,1,1,3,1
+18914,3,27416,1,125,True Rose Tones,201,1,1,1,4,1
+18915,3,28644,1,90,True Rose Tones,201,1,1,1,0,1
+18916,3,28644,1,98,True Rose Tones,201,1,1,1,1,1
+18917,3,28644,1,108,True Rose Tones,201,1,1,1,2,1
+18918,3,28644,1,118,True Rose Tones,201,1,1,1,3,1
+18919,3,28644,1,128,True Rose Tones,201,1,1,1,4,1
+18920,3,32005,1,70,True Polished Breaker,203,1,7,1,0,1
+18921,3,32005,1,80,True Polished Breaker,203,1,7,1,1,1
+18922,3,32005,1,90,True Polished Breaker,203,1,7,1,2,1
+18923,3,32005,1,100,True Polished Breaker,203,1,7,1,3,1
+18924,3,32005,1,110,True Polished Breaker,203,1,7,1,4,1
+18925,3,31968,1,80,True Wanted Heart,203,1,7,1,0,1
+18926,3,31968,1,90,True Wanted Heart,203,1,7,1,1,1
+18927,3,31968,1,100,True Wanted Heart,203,1,7,1,2,1
+18928,3,31968,1,110,True Wanted Heart,203,1,7,1,3,1
+18929,3,31968,1,120,True Wanted Heart,203,1,7,1,4,1
+18930,3,34270,1,85,True Wanted Heart,203,1,7,1,0,1
+18931,3,34270,1,95,True Wanted Heart,203,1,7,1,1,1
+18932,3,34270,1,105,True Wanted Heart,203,1,7,1,2,1
+18933,3,34270,1,115,True Wanted Heart,203,1,7,1,3,1
+18934,3,34270,1,125,True Wanted Heart,203,1,7,1,4,1
+18935,3,35805,1,90,True Wanted Heart,203,1,7,1,0,1
+18936,3,35805,1,98,True Wanted Heart,203,1,7,1,1,1
+18937,3,35805,1,108,True Wanted Heart,203,1,7,1,2,1
+18938,3,35805,1,118,True Wanted Heart,203,1,7,1,3,1
+18939,3,35805,1,128,True Wanted Heart,203,1,7,1,4,1
+18940,3,25604,1,70,True Polished Guard,204,1,5,1,0,1
+18941,3,25604,1,80,True Polished Guard,204,1,5,1,1,1
+18942,3,25604,1,90,True Polished Guard,204,1,5,1,2,1
+18943,3,25604,1,100,True Polished Guard,204,1,5,1,3,1
+18944,3,25604,1,110,True Polished Guard,204,1,5,1,4,1
+18945,3,25574,1,80,True Dark Pavise,204,1,5,1,0,1
+18946,3,25574,1,90,True Dark Pavise,204,1,5,1,1,1
+18947,3,25574,1,100,True Dark Pavise,204,1,5,1,2,1
+18948,3,25574,1,110,True Dark Pavise,204,1,5,1,3,1
+18949,3,25574,1,120,True Dark Pavise,204,1,5,1,4,1
+18950,3,27416,1,85,True Dark Pavise,204,1,5,1,0,1
+18951,3,27416,1,95,True Dark Pavise,204,1,5,1,1,1
+18952,3,27416,1,105,True Dark Pavise,204,1,5,1,2,1
+18953,3,27416,1,115,True Dark Pavise,204,1,5,1,3,1
+18954,3,27416,1,125,True Dark Pavise,204,1,5,1,4,1
+18955,3,28644,1,90,True Dark Pavise,204,1,5,1,0,1
+18956,3,28644,1,98,True Dark Pavise,204,1,5,1,1,1
+18957,3,28644,1,108,True Dark Pavise,204,1,5,1,2,1
+18958,3,28644,1,118,True Dark Pavise,204,1,5,1,3,1
+18959,3,28644,1,128,True Dark Pavise,204,1,5,1,4,1
+18960,3,32005,1,70,True Polished Daggers,206,1,2,1,0,1
+18961,3,32005,1,80,True Polished Daggers,206,1,2,1,1,1
+18962,3,32005,1,90,True Polished Daggers,206,1,2,1,2,1
+18963,3,32005,1,100,True Polished Daggers,206,1,2,1,3,1
+18964,3,32005,1,110,True Polished Daggers,206,1,2,1,4,1
+18965,3,31968,1,80,True Dark Parazonium,206,1,2,1,0,1
+18966,3,31968,1,90,True Dark Parazonium,206,1,2,1,1,1
+18967,3,31968,1,100,True Dark Parazonium,206,1,2,1,2,1
+18968,3,31968,1,110,True Dark Parazonium,206,1,2,1,3,1
+18969,3,31968,1,120,True Dark Parazonium,206,1,2,1,4,1
+18970,3,34270,1,85,True Dark Parazonium,206,1,2,1,0,1
+18971,3,34270,1,95,True Dark Parazonium,206,1,2,1,1,1
+18972,3,34270,1,105,True Dark Parazonium,206,1,2,1,2,1
+18973,3,34270,1,115,True Dark Parazonium,206,1,2,1,3,1
+18974,3,34270,1,125,True Dark Parazonium,206,1,2,1,4,1
+18975,3,35805,1,90,True Dark Parazonium,206,1,2,1,0,1
+18976,3,35805,1,98,True Dark Parazonium,206,1,2,1,1,1
+18977,3,35805,1,108,True Dark Parazonium,206,1,2,1,2,1
+18978,3,35805,1,118,True Dark Parazonium,206,1,2,1,3,1
+18979,3,35805,1,128,True Dark Parazonium,206,1,2,1,4,1
+18980,3,32005,1,70,True Polished Bow,207,1,3,1,0,1
+18981,3,32005,1,80,True Polished Bow,207,1,3,1,1,1
+18982,3,32005,1,90,True Polished Bow,207,1,3,1,2,1
+18983,3,32005,1,100,True Polished Bow,207,1,3,1,3,1
+18984,3,32005,1,110,True Polished Bow,207,1,3,1,4,1
+18985,3,31968,1,80,True Dragon's Blink,207,1,3,1,0,1
+18986,3,31968,1,90,True Dragon's Blink,207,1,3,1,1,1
+18987,3,31968,1,100,True Dragon's Blink,207,1,3,1,2,1
+18988,3,31968,1,110,True Dragon's Blink,207,1,3,1,3,1
+18989,3,31968,1,120,True Dragon's Blink,207,1,3,1,4,1
+18990,3,34270,1,85,True Dragon's Blink,207,1,3,1,0,1
+18991,3,34270,1,95,True Dragon's Blink,207,1,3,1,1,1
+18992,3,34270,1,105,True Dragon's Blink,207,1,3,1,2,1
+18993,3,34270,1,115,True Dragon's Blink,207,1,3,1,3,1
+18994,3,34270,1,125,True Dragon's Blink,207,1,3,1,4,1
+18995,3,35805,1,90,True Dragon's Blink,207,1,3,1,0,1
+18996,3,35805,1,98,True Dragon's Blink,207,1,3,1,1,1
+18997,3,35805,1,108,True Dragon's Blink,207,1,3,1,2,1
+18998,3,35805,1,118,True Dragon's Blink,207,1,3,1,3,1
+18999,3,35805,1,128,True Dragon's Blink,207,1,3,1,4,1
+19000,3,32005,1,70,True Polished Gauntlet,208,1,9,1,0,1
+19001,3,32005,1,80,True Polished Gauntlet,208,1,9,1,1,1
+19002,3,32005,1,90,True Polished Gauntlet,208,1,9,3,2,1
+19003,3,32005,1,100,True Polished Gauntlet,208,1,9,1,3,1
+19004,3,32005,1,110,True Polished Gauntlet,208,1,9,1,4,1
+19005,3,31968,1,80,True Hidden Seiðr,208,1,9,1,0,1
+19006,3,31968,1,90,True Hidden Seiðr,208,1,9,1,1,1
+19007,3,31968,1,100,True Hidden Seiðr,208,1,9,1,2,1
+19008,3,31968,1,110,True Hidden Seiðr,208,1,9,1,3,1
+19009,3,31968,1,120,True Hidden Seiðr,208,1,9,1,4,1
+19010,3,34270,1,85,True Hidden Seiðr,208,1,9,1,0,1
+19011,3,34270,1,95,True Hidden Seiðr,208,1,9,1,1,1
+19012,3,34270,1,105,True Hidden Seiðr,208,1,9,1,2,1
+19013,3,34270,1,115,True Hidden Seiðr,208,1,9,1,3,1
+19014,3,34270,1,125,True Hidden Seiðr,208,1,9,1,4,1
+19015,3,35805,1,90,True Hidden Seiðr,208,1,9,1,0,1
+19016,3,35805,1,98,True Hidden Seiðr,208,1,9,1,1,1
+19017,3,35805,1,108,True Hidden Seiðr,208,1,9,1,2,1
+19018,3,35805,1,118,True Hidden Seiðr,208,1,9,1,3,1
+19019,3,35805,1,128,True Hidden Seiðr,208,1,9,1,4,1
+19020,3,32005,1,70,True Polished Spell,209,1,8,1,0,1
+19021,3,32005,1,80,True Polished Spell,209,1,8,1,1,1
+19022,3,32005,1,90,True Polished Spell,209,1,8,1,2,1
+19023,3,32005,1,100,True Polished Spell,209,1,8,1,3,1
+19024,3,32005,1,110,True Polished Spell,209,1,8,1,4,1
+19025,3,31968,1,80,True Dragon's Supreme,209,1,8,1,0,1
+19026,3,31968,1,90,True Dragon's Supreme,209,1,8,1,1,1
+19027,3,31968,1,100,True Dragon's Supreme,209,1,8,1,2,1
+19028,3,31968,1,110,True Dragon's Supreme,209,1,8,1,3,1
+19029,3,31968,1,120,True Dragon's Supreme,209,1,8,1,4,1
+19030,3,34270,1,85,True Dragon's Supreme,209,1,8,1,0,1
+19031,3,34270,1,95,True Dragon's Supreme,209,1,8,1,1,1
+19032,3,34270,1,105,True Dragon's Supreme,209,1,8,1,2,1
+19033,3,34270,1,115,True Dragon's Supreme,209,1,8,1,3,1
+19034,3,34270,1,125,True Dragon's Supreme,209,1,8,1,4,1
+19035,3,35805,1,90,True Dragon's Supreme,209,1,8,1,0,1
+19036,3,35805,1,98,True Dragon's Supreme,209,1,8,1,1,1
+19037,3,35805,1,108,True Dragon's Supreme,209,1,8,1,2,1
+19038,3,35805,1,118,True Dragon's Supreme,209,1,8,1,3,1
+19039,3,35805,1,128,True Dragon's Supreme,209,1,8,1,4,1
+19040,3,32005,1,70,True Polished Staff,211,1,4,1,0,1
+19041,3,32005,1,80,True Polished Staff,211,1,4,1,1,1
+19042,3,32005,1,90,True Polished Staff,211,1,4,1,2,1
+19043,3,32005,1,100,True Polished Staff,211,1,4,1,3,1
+19044,3,32005,1,110,True Polished Staff,211,1,4,1,4,1
+19045,3,31968,1,80,True Chilly Cane,211,1,4,1,0,1
+19046,3,31968,1,90,True Chilly Cane,211,1,4,1,1,1
+19047,3,31968,1,100,True Chilly Cane,211,1,4,1,2,1
+19048,3,31968,1,110,True Chilly Cane,211,1,4,1,3,1
+19049,3,31968,1,120,True Chilly Cane,211,1,4,1,4,1
+19050,3,34270,1,85,True Chilly Cane,211,1,4,1,0,1
+19051,3,34270,1,95,True Chilly Cane,211,1,4,1,1,1
+19052,3,34270,1,105,True Chilly Cane,211,1,4,1,2,1
+19053,3,34270,1,115,True Chilly Cane,211,1,4,1,3,1
+19054,3,34270,1,125,True Chilly Cane,211,1,4,1,4,1
+19055,3,35805,1,90,True Chilly Cane,211,1,4,1,0,1
+19056,3,35805,1,98,True Chilly Cane,211,1,4,1,1,1
+19057,3,35805,1,108,True Chilly Cane,211,1,4,1,2,1
+19058,3,35805,1,118,True Chilly Cane,211,1,4,1,3,1
+19059,3,35805,1,128,True Chilly Cane,211,1,4,1,4,1
+19060,3,32005,1,70,True Polished Wand,212,1,6,1,0,1
+19061,3,32005,1,80,True Polished Wand,212,1,6,1,1,1
+19062,3,32005,1,90,True Polished Wand,212,1,6,1,2,1
+19063,3,32005,1,100,True Polished Wand,212,1,6,1,3,1
+19064,3,32005,1,110,True Polished Wand,212,1,6,1,4,1
+19065,3,31968,1,80,True Road to Hades,212,1,6,1,0,1
+19066,3,31968,1,90,True Road to Hades,212,1,6,1,1,1
+19067,3,31968,1,100,True Road to Hades,212,1,6,1,2,1
+19068,3,31968,1,110,True Road to Hades,212,1,6,1,3,1
+19069,3,31968,1,120,True Road to Hades,212,1,6,1,4,1
+19070,3,34270,1,85,True Road to Hades,212,1,6,1,0,1
+19071,3,34270,1,95,True Road to Hades,212,1,6,1,1,1
+19072,3,34270,1,105,True Road to Hades,212,1,6,1,2,1
+19073,3,34270,1,115,True Road to Hades,212,1,6,1,3,1
+19074,3,34270,1,125,True Road to Hades,212,1,6,1,4,1
+19075,3,35805,1,90,True Road to Hades,212,1,6,1,0,1
+19076,3,35805,1,98,True Road to Hades,212,1,6,1,1,1
+19077,3,35805,1,108,True Road to Hades,212,1,6,1,2,1
+19078,3,35805,1,118,True Road to Hades,212,1,6,1,3,1
+19079,3,35805,1,128,True Road to Hades,212,1,6,1,4,1
+19080,3,32005,1,70,True Polished Lance,213,1,10,1,0,1
+19081,3,32005,1,80,True Polished Lance,213,1,10,1,1,1
+19082,3,32005,1,90,True Polished Lance,213,1,10,1,2,1
+19083,3,32005,1,100,True Polished Lance,213,1,10,1,3,1
+19084,3,32005,1,110,True Polished Lance,213,1,10,1,4,1
+19085,3,31968,1,80,True Everlance,213,1,10,1,0,1
+19086,3,31968,1,90,True Everlance,213,1,10,1,1,1
+19087,3,31968,1,100,True Everlance,213,1,10,1,2,1
+19088,3,31968,1,110,True Everlance,213,1,10,1,3,1
+19089,3,31968,1,120,True Everlance,213,1,10,1,4,1
+19090,3,34270,1,85,True Everlance,213,1,10,1,0,1
+19091,3,34270,1,95,True Everlance,213,1,10,1,1,1
+19092,3,34270,1,105,True Everlance,213,1,10,1,2,1
+19093,3,34270,1,115,True Everlance,213,1,10,1,3,1
+19094,3,34270,1,125,True Everlance,213,1,10,1,4,1
+19149,3,25604,1,75,Crimson Sword,201,80,1,1,0,1
+19150,3,25604,1,75,Crimson Sword,201,80,1,1,1,1
+19151,3,25604,1,75,Crimson Sword,201,80,1,1,2,1
+19152,3,25604,1,75,Crimson Sword,201,80,1,1,3,1
+19153,3,25604,1,75,Crimson Sword,201,80,1,1,4,1
+19154,3,32005,1,75,Crimson Blade,203,80,7,1,0,1
+19155,3,32005,1,75,Crimson Blade,203,80,7,1,1,1
+19156,3,32005,1,75,Crimson Blade,203,80,7,1,2,1
+19157,3,32005,1,75,Crimson Blade,203,80,7,1,3,1
+19158,3,32005,1,75,Crimson Blade,203,80,7,1,4,1
+19159,3,25604,1,75,Crimson Wall,204,80,5,1,0,1
+19160,3,25604,1,75,Crimson Wall,204,80,5,1,1,1
+19161,3,25604,1,75,Crimson Wall,204,80,5,1,2,1
+19162,3,25604,1,75,Crimson Wall,204,80,5,1,3,1
+19163,3,25604,1,75,Crimson Wall,204,80,5,1,4,1
+19164,3,32005,1,75,Crimson Daggers,206,80,2,1,0,1
+19165,3,32005,1,75,Crimson Daggers,206,80,2,1,1,1
+19166,3,32005,1,75,Crimson Daggers,206,80,2,1,2,1
+19167,3,32005,1,75,Crimson Daggers,206,80,2,1,3,1
+19168,3,32005,1,75,Crimson Daggers,206,80,2,1,4,1
+19169,3,32005,1,75,Crimson Bow,207,80,3,1,0,1
+19170,3,32005,1,75,Crimson Bow,207,80,3,1,1,1
+19171,3,32005,1,75,Crimson Bow,207,80,3,1,2,1
+19172,3,32005,1,75,Crimson Bow,207,80,3,1,3,1
+19173,3,32005,1,75,Crimson Bow,207,80,3,1,4,1
+19174,3,32005,1,75,Crimson Gauntlet,208,80,9,1,0,1
+19175,3,32005,1,75,Crimson Gauntlet,208,80,9,1,1,1
+19176,3,32005,1,75,Crimson Gauntlet,208,80,9,1,2,1
+19177,3,32005,1,75,Crimson Gauntlet,208,80,9,1,3,1
+19178,3,32005,1,75,Crimson Gauntlet,208,80,9,1,4,1
+19179,3,32005,1,75,Crimson Spell,209,80,8,1,0,1
+19180,3,32005,1,75,Crimson Spell,209,80,8,1,1,1
+19181,3,32005,1,75,Crimson Spell,209,80,8,1,2,1
+19182,3,32005,1,75,Crimson Spell,209,80,8,1,3,1
+19183,3,32005,1,75,Crimson Spell,209,80,8,1,4,1
+19184,3,32005,1,75,Crimson Staff,211,80,4,1,0,1
+19185,3,32005,1,75,Crimson Staff,211,80,4,1,1,1
+19186,3,32005,1,75,Crimson Staff,211,80,4,1,2,1
+19187,3,32005,1,75,Crimson Staff,211,80,4,1,3,1
+19188,3,32005,1,75,Crimson Staff,211,80,4,1,4,1
+19189,3,32005,1,75,Crimson Wand,212,80,6,1,0,1
+19190,3,32005,1,75,Crimson Wand,212,80,6,1,1,1
+19191,3,32005,1,75,Crimson Wand,212,80,6,1,2,1
+19192,3,32005,1,75,Crimson Wand,212,80,6,1,3,1
+19193,3,32005,1,75,Crimson Wand,212,80,6,1,4,1
+19194,3,32005,1,75,Crimson Spear,213,80,10,1,0,1
+19195,3,32005,1,75,Crimson Spear,213,80,10,1,1,1
+19196,3,32005,1,75,Crimson Spear,213,80,10,1,2,1
+19197,3,32005,1,75,Crimson Spear,213,80,10,1,3,1
+19198,3,32005,1,75,Crimson Spear,213,80,10,1,4,1
 19389,3,10,1,15,Craigblade,203,1,7,1,4,1
-19390,3,50000,1,0,Blue Storm Mithril Sword,201,1,1,4,4,1
-19391,3,50000,1,0,Blue Storm Mithril Bow,207,1,3,4,4,1
-19392,3,50000,1,0,Blue Storm Mithril Wall,204,1,5,4,4,1
-19393,3,50000,1,0,Blue Storm Mithril Staff,211,1,4,4,4,1
-19394,3,50000,1,0,Blue Storm Mithril Daggers,206,1,2,4,4,1
-19395,3,50000,1,0,Blue Storm Mithril Wand,212,1,6,4,4,1
-19396,3,50000,1,0,Blue Storm Mithril Shooter,209,1,8,4,4,1
-19397,3,50000,1,0,Blue Storm Mithril Blade,203,1,7,4,4,1
-19398,3,50000,1,0,Blue Storm Mithril Arm,208,1,9,4,4,1
-19399,3,50000,1,0,Blue Storm Mithril Lance,213,1,10,4,4,1
-19400,3,50000,1,3,Edge of Vanguard,201,1,1,4,4,1
-19401,3,50000,1,3,Arrow of Vanguard,207,1,3,4,4,1
-19402,3,50000,1,3,Wall of Vanguard,204,1,5,4,4,1
-19403,3,50000,1,3,Staff of Vanguard,211,1,4,4,4,1
-19404,3,50000,1,3,Daggers of Vanguard,206,1,2,4,4,1
-19405,3,50000,1,3,Wand of Vanguard,212,1,6,4,4,1
-19406,3,50000,1,3,Spell of Vanguard,209,1,8,4,4,1
-19407,3,50000,1,3,Blade of Vanguard,203,1,7,4,4,1
-19408,3,50000,1,3,Hand of Vanguard,208,1,9,4,4,1
-19409,3,50000,1,3,Lance of Vanguard,213,1,10,4,4,1
-19410,3,50000,1,6,Supreme Ruler's Arabesque Sword,201,80,1,4,4,1
-19411,3,50000,1,6,Supreme Ruler's Arabesque Bow,207,80,3,4,4,1
-19412,3,50000,1,6,Supreme Ruler's Arabesque Guard,204,80,5,4,4,1
-19413,3,50000,1,6,Supreme Ruler's Arabesque Staff,211,80,4,4,4,1
-19414,3,50000,1,6,Supreme Ruler's Arabesque Knife,206,80,2,4,4,1
-19415,3,50000,1,6,Supreme Ruler's Arabesque Wand,212,80,6,4,4,1
-19416,3,50000,1,6,Supreme Ruler's Arabesque Shooter,209,80,8,4,4,1
-19417,3,50000,1,6,Supreme Ruler's Arabesque Savior,203,80,7,4,4,1
-19418,3,50000,1,6,Supreme Ruler's Arabesque Arms,208,80,9,4,4,1
-19419,3,50000,1,6,Supreme Ruler's Arabesque Spear,213,80,10,4,4,1
-19420,3,50000,1,8,Ablaze Falchion,201,80,1,4,4,1
-19421,3,50000,1,8,Ablaze Composite,207,80,3,4,4,1
-19422,3,50000,1,8,Ablaze Scutum,204,80,5,4,4,1
-19423,3,50000,1,8,Ablaze Staff,211,80,4,4,4,1
-19424,3,50000,1,8,Ablaze Daggers,206,80,2,4,4,1
-19425,3,50000,1,8,Ablaze Druid Wand,212,80,6,4,4,1
-19426,3,50000,1,8,Ablaze Twin Spell,209,80,8,4,4,1
-19427,3,50000,1,8,Ablaze Claymore,203,80,7,4,4,1
-19428,3,50000,1,8,Ablaze Gauntlet,208,80,9,4,4,1
-19429,3,50000,1,8,Ablaze Partisan,213,80,10,4,4,1
-19430,3,50000,1,0,Rapier of Serpent Wings,201,85,1,4,4,1
-19431,3,50000,1,0,Longbow of Serpent Wings,207,85,3,4,4,1
-19432,3,50000,1,0,Heavy Fort of Serpent Wings,204,85,5,4,4,1
-19433,3,50000,1,0,Silver Cane of Serpent Wings,211,85,4,4,4,1
-19434,3,50000,1,0,Twin Daggers of Serpent Wings,206,85,2,4,4,1
-19435,3,50000,1,0,Druid Wand of Serpent Wings,212,85,6,4,4,1
-19436,3,50000,1,0,Curse Shooter of Serpent Wings,209,85,8,4,4,1
-19437,3,50000,1,0,Zweihänder of Serpent Wings,203,85,7,4,4,1
-19438,3,50000,1,0,Gauntlet of Serpent Wings,208,85,9,4,4,1
-19439,3,50000,1,0,Swordstaff of Serpent Wings,213,85,10,4,4,1
-19440,3,50000,1,2,Sword of Strife,201,85,1,4,4,1
-19441,3,50000,1,2,Bow of Strife,207,85,3,4,4,1
-19442,3,50000,1,2,Wall of Strife,204,85,5,4,4,1
-19443,3,50000,1,2,Staff of Strife,211,85,4,4,4,1
-19444,3,50000,1,2,Crow of Strife,206,85,2,4,4,1
-19445,3,50000,1,2,Wand of Strife,212,85,6,4,4,1
-19446,3,50000,1,2,Spell of Strife,209,85,8,4,4,1
-19447,3,50000,1,2,Blade of Strife,203,85,7,4,4,1
-19448,3,50000,1,2,Arm of Strife,208,85,9,4,4,1
-19449,3,50000,1,2,Lance of Strife,213,85,10,4,4,1
+19390,3,50000,1,80,Blue Storm Mithril Sword,201,1,1,4,4,1
+19391,3,50000,1,80,Blue Storm Mithril Bow,207,1,3,4,4,1
+19392,3,50000,1,80,Blue Storm Mithril Wall,204,1,5,4,4,1
+19393,3,50000,1,80,Blue Storm Mithril Staff,211,1,4,4,4,1
+19394,3,50000,1,80,Blue Storm Mithril Daggers,206,1,2,4,4,1
+19395,3,50000,1,80,Blue Storm Mithril Wand,212,1,6,4,4,1
+19396,3,50000,1,80,Blue Storm Mithril Shooter,209,1,8,4,4,1
+19397,3,50000,1,80,Blue Storm Mithril Blade,203,1,7,4,4,1
+19398,3,50000,1,80,Blue Storm Mithril Arm,208,1,9,4,4,1
+19399,3,50000,1,80,Blue Storm Mithril Lance,213,1,10,4,4,1
+19400,3,50000,1,83,Edge of Vanguard,201,1,1,4,4,1
+19401,3,50000,1,83,Arrow of Vanguard,207,1,3,4,4,1
+19402,3,50000,1,83,Wall of Vanguard,204,1,5,4,4,1
+19403,3,50000,1,83,Staff of Vanguard,211,1,4,4,4,1
+19404,3,50000,1,83,Daggers of Vanguard,206,1,2,4,4,1
+19405,3,50000,1,83,Wand of Vanguard,212,1,6,4,4,1
+19406,3,50000,1,83,Spell of Vanguard,209,1,8,4,4,1
+19407,3,50000,1,83,Blade of Vanguard,203,1,7,4,4,1
+19408,3,50000,1,83,Hand of Vanguard,208,1,9,4,4,1
+19409,3,50000,1,83,Lance of Vanguard,213,1,10,4,4,1
+19410,3,50000,1,86,Supreme Ruler's Arabesque Sword,201,80,1,4,4,1
+19411,3,50000,1,86,Supreme Ruler's Arabesque Bow,207,80,3,4,4,1
+19412,3,50000,1,86,Supreme Ruler's Arabesque Guard,204,80,5,4,4,1
+19413,3,50000,1,86,Supreme Ruler's Arabesque Staff,211,80,4,4,4,1
+19414,3,50000,1,86,Supreme Ruler's Arabesque Knife,206,80,2,4,4,1
+19415,3,50000,1,86,Supreme Ruler's Arabesque Wand,212,80,6,4,4,1
+19416,3,50000,1,86,Supreme Ruler's Arabesque Shooter,209,80,8,4,4,1
+19417,3,50000,1,86,Supreme Ruler's Arabesque Savior,203,80,7,4,4,1
+19418,3,50000,1,86,Supreme Ruler's Arabesque Arms,208,80,9,4,4,1
+19419,3,50000,1,86,Supreme Ruler's Arabesque Spear,213,80,10,4,4,1
+19420,3,50000,1,88,Ablaze Falchion,201,80,1,4,4,1
+19421,3,50000,1,88,Ablaze Composite,207,80,3,4,4,1
+19422,3,50000,1,88,Ablaze Scutum,204,80,5,4,4,1
+19423,3,50000,1,88,Ablaze Staff,211,80,4,4,4,1
+19424,3,50000,1,88,Ablaze Daggers,206,80,2,4,4,1
+19425,3,50000,1,88,Ablaze Druid Wand,212,80,6,4,4,1
+19426,3,50000,1,88,Ablaze Twin Spell,209,80,8,4,4,1
+19427,3,50000,1,88,Ablaze Claymore,203,80,7,4,4,1
+19428,3,50000,1,88,Ablaze Gauntlet,208,80,9,4,4,1
+19429,3,50000,1,88,Ablaze Partisan,213,80,10,4,4,1
+19430,3,50000,1,96,Rapier of Serpent Wings,201,85,1,4,4,1
+19431,3,50000,1,96,Longbow of Serpent Wings,207,85,3,4,4,1
+19432,3,50000,1,96,Heavy Fort of Serpent Wings,204,85,5,4,4,1
+19433,3,50000,1,96,Silver Cane of Serpent Wings,211,85,4,4,4,1
+19434,3,50000,1,96,Twin Daggers of Serpent Wings,206,85,2,4,4,1
+19435,3,50000,1,96,Druid Wand of Serpent Wings,212,85,6,4,4,1
+19436,3,50000,1,96,Curse Shooter of Serpent Wings,209,85,8,4,4,1
+19437,3,50000,1,96,Zweihänder of Serpent Wings,203,85,7,4,4,1
+19438,3,50000,1,96,Gauntlet of Serpent Wings,208,85,9,4,4,1
+19439,3,50000,1,96,Swordstaff of Serpent Wings,213,85,10,4,4,1
+19440,3,50000,1,98,Sword of Strife,201,85,1,4,4,1
+19441,3,50000,1,98,Bow of Strife,207,85,3,4,4,1
+19442,3,50000,1,98,Wall of Strife,204,85,5,4,4,1
+19443,3,50000,1,98,Staff of Strife,211,85,4,4,4,1
+19444,3,50000,1,98,Crow of Strife,206,85,2,4,4,1
+19445,3,50000,1,98,Wand of Strife,212,85,6,4,4,1
+19446,3,50000,1,98,Spell of Strife,209,85,8,4,4,1
+19447,3,50000,1,98,Blade of Strife,203,85,7,4,4,1
+19448,3,50000,1,98,Arm of Strife,208,85,9,4,4,1
+19449,3,50000,1,98,Lance of Strife,213,85,10,4,4,1
 19485,3,5000,1,7,Olfring Sword (Forest),201,1,1,4,0,1
 19486,3,5000,1,9,Olfring Sword (Forest),201,1,1,4,1,1
 19487,3,5000,1,12,Olfring Sword (Forest),201,1,1,4,2,1
-19488,3,5000,1,12,Olfring Sword (Forest),201,1,1,4,3,1
-19489,3,5000,1,2,Olfring Sword (Forest),201,1,1,4,4,1
-19464,3,5000,1,8,Olfring Sword (Sea),201,1,1,4,4,1
-19465,3,5000,1,0,Olfring Sword (Radiance),201,1,1,4,4,1
-19466,3,5000,1,2,Olfring Sword (Star),201,1,1,4,4,1
-19467,3,5000,1,8,Olfring Sword (Terra Preta),201,1,1,4,4,1
-19472,3,5000,1,8,Olfring Guard (Sunlight),204,1,5,4,4,1
-19473,3,5000,1,8,Olfring Guard (Sea),204,1,5,4,4,1
-19474,3,5000,1,2,Olfring Guard (Terra Preta),204,1,5,4,4,1
-19521,3,5000,1,8,Olfring Guard (Iron),204,1,5,4,4,1
-19479,3,5000,1,8,Olfring Bow (Sunlight),207,1,3,4,4,1
-19478,3,5000,1,8,Olfring Bow (Sea),207,1,3,4,4,1
-19480,3,5000,1,0,Olfring Bow (Star),207,1,3,4,4,1
-19481,3,5000,1,8,Olfring Cane (Sunlight),211,1,4,4,4,1
-19482,3,5000,1,7,Olfring Cane (Sea),211,1,4,4,4,1
-19483,3,5000,1,0,Olfring Cane (Radiance),211,1,4,4,4,1
-19484,3,5000,1,8,Olfring Cane (Star),211,1,4,4,4,1
+19488,3,5000,1,60,Olfring Sword (Forest),201,1,1,4,3,1
+19489,3,5000,1,82,Olfring Sword (Forest),201,1,1,4,4,1
+19464,3,5000,1,40,Olfring Sword (Sea),201,1,1,4,4,1
+19465,3,5000,1,80,Olfring Sword (Radiance),201,1,1,4,4,1
+19466,3,5000,1,82,Olfring Sword (Star),201,1,1,4,4,1
+19467,3,5000,1,40,Olfring Sword (Terra Preta),201,1,1,4,4,1
+19472,3,5000,1,40,Olfring Guard (Sunlight),204,1,5,4,4,1
+19473,3,5000,1,40,Olfring Guard (Sea),204,1,5,4,4,1
+19474,3,5000,1,82,Olfring Guard (Terra Preta),204,1,5,4,4,1
+19521,3,5000,1,40,Olfring Guard (Iron),204,1,5,4,4,1
+19479,3,5000,1,40,Olfring Bow (Sunlight),207,1,3,4,4,1
+19478,3,5000,1,40,Olfring Bow (Sea),207,1,3,4,4,1
+19480,3,5000,1,80,Olfring Bow (Star),207,1,3,4,4,1
+19481,3,5000,1,40,Olfring Cane (Sunlight),211,1,4,4,4,1
+19482,3,5000,1,55,Olfring Cane (Sea),211,1,4,4,4,1
+19483,3,5000,1,80,Olfring Cane (Radiance),211,1,4,4,4,1
+19484,3,5000,1,40,Olfring Cane (Star),211,1,4,4,4,1
 19495,3,5000,1,7,Olfring Seiðr (Forest),208,1,9,4,0,1
 19496,3,5000,1,9,Olfring Seiðr (Forest),208,1,9,4,1,1
 19497,3,5000,1,12,Olfring Seiðr (Forest),208,1,9,4,2,1
-19498,3,5000,1,5,Olfring Seiðr (Forest),208,1,9,4,3,1
-19499,3,5000,1,8,Olfring Seiðr (Forest),208,1,9,4,4,1
-19512,3,50000,1,0,Ghosts 'n Goblins Arthur's Lance,213,1,10,4,4,1
+19498,3,5000,1,85,Olfring Seiðr (Forest),208,1,9,4,3,1
+19499,3,5000,1,88,Olfring Seiðr (Forest),208,1,9,4,4,1
+19512,3,50000,1,80,Ghosts 'n Goblins Arthur's Lance,213,1,10,4,4,1
 19523,3,10000,1,7,Olfring Guard (Forest),204,1,5,4,0,1
 19524,3,10000,1,12,Olfring Guard (Forest),204,1,5,4,1,1
-19525,3,10000,1,8,Olfring Guard (Forest),204,1,5,4,2,1
-19526,3,10000,1,10,Olfring Guard (Forest),204,1,5,4,3,1
-19527,3,10000,1,7,Olfring Guard (Forest),204,1,5,4,4,1
-19530,3,5000,1,7,Olfring Guard (Radiance),204,1,5,4,4,1
-19531,3,5000,1,0,Olfring Guard (Star),204,1,5,4,4,1
+19525,3,10000,1,40,Olfring Guard (Forest),204,1,5,4,2,1
+19526,3,10000,1,90,Olfring Guard (Forest),204,1,5,4,3,1
+19527,3,10000,1,103,Olfring Guard (Forest),204,1,5,4,4,1
+19530,3,5000,1,55,Olfring Guard (Radiance),204,1,5,4,4,1
+19531,3,5000,1,80,Olfring Guard (Star),204,1,5,4,4,1
 19539,3,10000,1,7,Olfring Bow (Forest),207,1,3,4,0,1
 19540,3,10000,1,12,Olfring Bow (Forest),207,1,3,4,1,1
-19541,3,10000,1,8,Olfring Bow (Forest),207,1,3,4,2,1
-19542,3,10000,1,0,Olfring Bow (Forest),207,1,3,4,3,1
-19543,3,10000,1,1,Olfring Bow (Forest),207,1,3,4,4,1
-19544,3,5000,1,7,Olfring Bow (Radiance),207,1,3,4,4,1
-19545,3,5000,1,7,Olfring Bow (Terra Preta),207,1,3,4,4,1
+19541,3,10000,1,40,Olfring Bow (Forest),207,1,3,4,2,1
+19542,3,10000,1,96,Olfring Bow (Forest),207,1,3,4,3,1
+19543,3,10000,1,113,Olfring Bow (Forest),207,1,3,4,4,1
+19544,3,5000,1,55,Olfring Bow (Radiance),207,1,3,4,4,1
+19545,3,5000,1,55,Olfring Bow (Terra Preta),207,1,3,4,4,1
 19546,3,5000,1,7,Olfring Cane (Forest),211,1,4,4,0,1
 19547,3,5000,1,12,Olfring Cane (Forest),211,1,4,4,1,1
-19548,3,5000,1,8,Olfring Cane (Forest),211,1,4,4,2,1
-19549,3,5000,1,6,Olfring Cane (Forest),211,1,4,4,3,1
-19550,3,5000,1,12,Olfring Cane (Forest),211,1,4,4,4,1
-19551,3,5000,1,7,Olfring Cane (Terra Preta),211,1,4,4,4,1
+19548,3,5000,1,40,Olfring Cane (Forest),211,1,4,4,2,1
+19549,3,5000,1,70,Olfring Cane (Forest),211,1,4,4,3,1
+19550,3,5000,1,92,Olfring Cane (Forest),211,1,4,4,4,1
+19551,3,5000,1,55,Olfring Cane (Terra Preta),211,1,4,4,4,1
 19552,3,5000,1,7,Olfring Shooter (Forest),209,1,8,4,0,1
 19553,3,5000,1,12,Olfring Shooter (Forest),209,1,8,4,1,1
-19554,3,5000,1,8,Olfring Shooter (Forest),209,1,8,4,2,1
-19555,3,5000,1,6,Olfring Shooter (Forest),209,1,8,4,3,1
-19556,3,5000,1,12,Olfring Shooter (Forest),209,1,8,4,4,1
+19554,3,5000,1,40,Olfring Shooter (Forest),209,1,8,4,2,1
+19555,3,5000,1,70,Olfring Shooter (Forest),209,1,8,4,3,1
+19556,3,5000,1,92,Olfring Shooter (Forest),209,1,8,4,4,1
 19557,3,5000,1,7,Olfring Daggers (Forest),206,1,2,4,0,1
 19558,3,5000,1,12,Olfring Daggers (Forest),206,1,2,4,1,1
-19559,3,5000,1,8,Olfring Daggers (Forest),206,1,2,4,2,1
-19560,3,5000,1,6,Olfring Daggers (Forest),206,1,2,4,3,1
-19561,3,5000,1,1,Olfring Daggers (Forest),206,1,2,4,4,1
-19528,3,5000,1,7,Olfring Sword (Sunlight),201,1,1,4,4,1
-19568,3,10000,1,9,Holy Night's Holly Stiletto,201,1,1,0,0,1
+19559,3,5000,1,40,Olfring Daggers (Forest),206,1,2,4,2,1
+19560,3,5000,1,70,Olfring Daggers (Forest),206,1,2,4,3,1
+19561,3,5000,1,97,Olfring Daggers (Forest),206,1,2,4,4,1
+19528,3,5000,1,55,Olfring Sword (Sunlight),201,1,1,4,4,1
+19568,3,10000,1,25,Holy Night's Holly Stiletto,201,1,1,0,0,1
 19569,3,10000,1,14,White Sweetheart's Candy Sword,201,1,1,4,0,1
-19572,3,10000,1,9,Holy Night's Candle Blade,203,1,7,0,0,1
+19572,3,10000,1,25,Holy Night's Candle Blade,203,1,7,0,0,1
 19573,3,10000,1,14,White Sweetheart's Twist Blade,203,1,7,4,0,1
-19574,3,10000,1,9,Holy Night's Sled Guard,204,1,5,0,0,1
+19574,3,10000,1,25,Holy Night's Sled Guard,204,1,5,0,0,1
 19575,3,10000,1,14,White Sweetheart's Cookie Wall,204,1,5,4,0,1
-19578,3,10000,1,9,Holy Night's Leg Daggers,206,1,2,0,0,1
+19578,3,10000,1,25,Holy Night's Leg Daggers,206,1,2,0,0,1
 19579,3,10000,1,14,White Sweetheart's Candy Daggers,206,1,2,4,0,1
-19580,3,10000,1,9,Holy Night's Tannenbaum Bow,207,1,3,0,0,1
+19580,3,10000,1,25,Holy Night's Tannenbaum Bow,207,1,3,0,0,1
 19581,3,10000,1,14,White Sweetheart's Candy Bow,207,1,3,4,0,1
-19582,3,10000,1,9,Holy Night's Claus Gauntlet,208,1,9,0,0,1
+19582,3,10000,1,25,Holy Night's Claus Gauntlet,208,1,9,0,0,1
 19583,3,10000,1,14,White Sweetheart's Macaron Arm,208,1,9,4,0,1
-19584,3,10000,1,9,Holy Night's Fir Spell,209,1,8,0,0,1
+19584,3,10000,1,25,Holy Night's Fir Spell,209,1,8,0,0,1
 19585,3,10000,1,14,White Sweetheart's Stripe Shooter,209,1,8,4,0,1
-19586,3,10000,1,9,Holy Night's Candy Cane,211,1,4,0,0,1
+19586,3,10000,1,25,Holy Night's Candy Cane,211,1,4,0,0,1
 19587,3,10000,1,14,White Sweetheart's Lollipop Cane,211,1,4,4,0,1
-19588,3,10000,1,9,Holy Night's Boot Wand,212,1,6,0,0,1
+19588,3,10000,1,25,Holy Night's Boot Wand,212,1,6,0,0,1
 19589,3,10000,1,14,White Sweetheart's Candy Wand,212,1,6,4,0,1
-19590,3,10000,1,9,Holy Night's Tree Lance,213,1,10,0,0,1
+19590,3,10000,1,25,Holy Night's Tree Lance,213,1,10,0,0,1
 19591,3,10000,1,14,White Sweetheart's Drop Spear,213,1,10,4,0,1
-19592,3,10000,1,14,Green Light War Axe,203,1,7,4,4,1
-19593,3,10000,1,14,The Seven-Tailed Serpent and the Golden Staff,212,1,6,4,4,1
-19658,3,50000,1,4,Rostam's Blaze,201,90,1,1,0,1
-19659,3,50000,1,4,Rostam's Blaze,201,90,1,1,1,1
-19660,3,50000,1,4,Rostam's Blaze,201,90,1,1,2,1
-19661,3,50000,1,4,Rostam's Blaze,201,90,1,1,3,1
-19662,3,50000,1,4,Rostam's Blaze,201,90,1,1,4,1
-19663,3,50000,1,10,Adamas Military Expedition Sword,201,1,1,4,4,1
-19664,3,50000,1,13,Edge of Agitator,201,1,1,4,4,1
-19743,3,31826,1,4,Red Dawn's Steel Edge,201,90,1,1,0,1
-19744,3,31826,1,4,Red Dawn's Steel Edge,201,90,1,1,1,1
-19745,3,31826,1,4,Red Dawn's Steel Edge,201,90,1,1,2,1
-19746,3,31826,1,4,Red Dawn's Steel Edge,201,90,1,1,3,1
-19747,3,31826,1,4,Red Dawn's Steel Edge,201,90,1,1,4,1
-19748,3,33390,1,9,Sword of Vermilion,201,93,1,1,0,1
-19749,3,33390,1,9,Sword of Vermilion,201,93,1,1,1,1
-19750,3,33390,1,9,Sword of Vermilion,201,93,1,1,2,1
-19751,3,33390,1,9,Sword of Vermilion,201,93,1,1,3,1
-19752,3,33390,1,9,Sword of Vermilion,201,93,1,1,4,1
-19753,3,34344,1,12,Altinon Sword,201,95,1,1,0,1
-19754,3,34344,1,12,Altinon Sword,201,95,1,1,1,1
-19755,3,34344,1,12,Altinon Sword,201,95,1,1,2,1
-19756,3,34344,1,12,Altinon Sword,201,95,1,1,3,1
-19757,3,34344,1,12,Altinon Sword,201,95,1,1,4,1
-19758,3,34980,1,14,Flamberge of Grail,201,95,1,1,0,1
-19759,3,34980,1,14,Flamberge of Grail,201,95,1,1,1,1
-19760,3,34980,1,14,Flamberge of Grail,201,95,1,1,2,1
-19761,3,34980,1,14,Flamberge of Grail,201,95,1,1,3,1
-19762,3,34980,1,14,Flamberge of Grail,201,95,1,1,4,1
-19763,3,50000,1,6,Intellect's Weise Sword,201,1,1,4,4,1
-19764,3,50000,1,9,Edge of Kenntnis,201,1,1,4,4,1
-19765,3,50000,1,10,Rapier of Glowing Embers,201,90,1,4,4,1
-19766,3,50000,1,12,Sword of Altesch,201,90,1,4,4,1
-20101,3,31826,1,14,Edge of Altura,201,95,1,1,0,1
-20102,3,31826,1,14,Edge of Altura,201,95,1,1,1,1
-20103,3,31826,1,14,Edge of Altura,201,95,1,1,2,1
-20104,3,31826,1,14,Edge of Altura,201,95,1,1,3,1
-20105,3,31826,1,14,Edge of Altura,201,95,1,1,4,1
-20106,3,33390,1,3,Rousing Schlucht Sword,201,98,1,1,0,1
-20107,3,33390,1,3,Rousing Schlucht Sword,201,98,1,1,1,1
-20108,3,33390,1,3,Rousing Schlucht Sword,201,98,1,1,2,1
-20109,3,33390,1,3,Rousing Schlucht Sword,201,98,1,1,3,1
-20110,3,33390,1,3,Rousing Schlucht Sword,201,98,1,1,4,1
-20111,3,34344,1,6,Passion Sword,201,100,1,1,0,1
-20112,3,34344,1,6,Passion Sword,201,100,1,1,1,1
-20113,3,34344,1,6,Passion Sword,201,100,1,1,2,1
-20114,3,34344,1,6,Passion Sword,201,100,1,1,3,1
-20115,3,34344,1,6,Passion Sword,201,100,1,1,4,1
-20116,3,34980,1,8,Éruption,201,100,1,1,0,1
-20117,3,34980,1,8,Éruption,201,100,1,1,1,1
-20118,3,34980,1,8,Éruption,201,100,1,1,2,1
-20119,3,34980,1,8,Éruption,201,100,1,1,3,1
-20120,3,34980,1,8,Éruption,201,100,1,1,4,1
-20121,3,50000,1,0,Honnête Sword of Purity,201,1,1,4,4,1
-20122,3,50000,1,3,Edge of Fedeltà,201,1,1,4,4,1
-20123,3,50000,1,4,Holy War Sphidante Sword,201,95,1,4,4,1
-20124,3,50000,1,6,Sword of Vainqueur,201,95,1,4,4,1
-19672,3,50000,1,4,Keyumars Glinz,203,90,7,1,0,1
-19673,3,50000,1,4,Keyumars Glinz,203,90,7,1,1,1
-19674,3,50000,1,4,Keyumars Glinz,203,90,7,1,2,1
-19675,3,50000,1,4,Keyumars Glinz,203,90,7,1,3,1
-19676,3,50000,1,4,Keyumars Glinz,203,90,7,1,4,1
-19677,3,50000,1,10,Adamas Military Expedition Blade,203,1,7,4,4,1
-19678,3,50000,1,13,Blade of Agitator,203,1,7,4,4,1
-19789,3,39700,1,4,Red Dawn's Steel Saber,203,90,7,1,0,1
-19790,3,39700,1,4,Red Dawn's Steel Saber,203,90,7,1,1,1
-19791,3,39700,1,4,Red Dawn's Steel Saber,203,90,7,1,2,1
-19792,3,39700,1,4,Red Dawn's Steel Saber,203,90,7,1,3,1
-19793,3,39700,1,4,Red Dawn's Steel Saber,203,90,7,1,4,1
-19794,3,41685,1,9,Blade of Vermilion,203,93,7,1,0,1
-19795,3,41685,1,9,Blade of Vermilion,203,93,7,1,1,1
-19796,3,41685,1,9,Blade of Vermilion,203,93,7,1,2,1
-19797,3,41685,1,9,Blade of Vermilion,203,93,7,1,3,1
-19798,3,41685,1,9,Blade of Vermilion,203,93,7,1,4,1
-19799,3,42876,1,12,Firash Blade,203,95,7,1,0,1
-19800,3,42876,1,12,Firash Blade,203,95,7,1,1,1
-19801,3,42876,1,12,Firash Blade,203,95,7,1,2,1
-19802,3,42876,1,12,Firash Blade,203,95,7,1,3,1
-19803,3,42876,1,12,Firash Blade,203,95,7,1,4,1
-19804,3,43670,1,14,Espadon of Orage,203,95,7,1,0,1
-19805,3,43670,1,14,Espadon of Orage,203,95,7,1,1,1
-19806,3,43670,1,14,Espadon of Orage,203,95,7,1,2,1
-19807,3,43670,1,14,Espadon of Orage,203,95,7,1,3,1
-19808,3,43670,1,14,Espadon of Orage,203,95,7,1,4,1
-19809,3,50000,1,6,Intellect's Weise Breaker,203,1,7,4,4,1
-19810,3,50000,1,9,Saber of Kenntnis,203,1,7,4,4,1
-19811,3,50000,1,10,Pistoia of Glowing Embers,203,90,7,4,4,1
-19812,3,50000,1,12,Blade of Altesch,203,90,7,4,4,1
-20147,3,43670,1,14,Blade of Altura,203,95,7,1,0,1
-20148,3,43670,1,14,Blade of Altura,203,95,7,1,1,1
-20149,3,43670,1,14,Blade of Altura,203,95,7,1,2,1
-20150,3,43670,1,14,Blade of Altura,203,95,7,1,3,1
-20151,3,43670,1,14,Blade of Altura,203,95,7,1,4,1
-20152,3,45655,1,3,Rousing Schlucht Blade,203,98,7,1,0,1
-20153,3,45655,1,3,Rousing Schlucht Blade,203,98,7,1,1,1
-20154,3,45655,1,3,Rousing Schlucht Blade,203,98,7,1,2,1
-20155,3,45655,1,3,Rousing Schlucht Blade,203,98,7,1,3,1
-20156,3,45655,1,3,Rousing Schlucht Blade,203,98,7,1,4,1
-20157,3,46846,1,6,Puissance Blade,203,100,7,1,0,1
-20158,3,46846,1,6,Puissance Blade,203,100,7,1,1,1
-20159,3,46846,1,6,Puissance Blade,203,100,7,1,2,1
-20160,3,46846,1,6,Puissance Blade,203,100,7,1,3,1
-20161,3,46846,1,6,Puissance Blade,203,100,7,1,4,1
-20162,3,47640,1,8,Évaporation,203,100,7,1,0,1
-20163,3,47640,1,8,Évaporation,203,100,7,1,1,1
-20164,3,47640,1,8,Évaporation,203,100,7,1,2,1
-20165,3,47640,1,8,Évaporation,203,100,7,1,3,1
-20166,3,47640,1,8,Évaporation,203,100,7,1,4,1
-20167,3,50000,1,0,Honnête Blade of Purity,203,1,7,4,4,1
-20168,3,50000,1,3,Saber of Fedeltà,203,1,7,4,4,1
-20169,3,50000,1,4,Holy War Sphidante Blade,203,95,7,4,4,1
-20170,3,50000,1,6,Blade of Vainqueur,203,95,7,4,4,1
-19679,3,50000,1,4,Iskandar Seals,204,90,5,1,0,1
-19680,3,50000,1,4,Iskandar Seals,204,90,5,1,1,1
-19681,3,50000,1,4,Iskandar Seals,204,90,5,1,2,1
-19682,3,50000,1,4,Iskandar Seals,204,90,5,1,3,1
-19683,3,50000,1,4,Iskandar Seals,204,90,5,1,4,1
-19684,3,50000,1,10,Adamas Military Expedition Wall,204,1,5,4,4,1
-19685,3,50000,1,13,Wall of Agitator,204,1,5,4,4,1
-19813,3,31900,1,4,Red Dawn's Steel Guard,204,90,5,1,0,1
-19814,3,31900,1,4,Red Dawn's Steel Guard,204,90,5,1,1,1
-19815,3,31900,1,4,Red Dawn's Steel Guard,204,90,5,1,2,1
-19816,3,31900,1,4,Red Dawn's Steel Guard,204,90,5,1,3,1
-19817,3,31900,1,4,Red Dawn's Steel Guard,204,90,5,1,4,1
-19818,3,33495,1,9,Wall of Vermilion,204,93,5,1,0,1
-19819,3,33495,1,9,Wall of Vermilion,204,93,5,1,1,1
-19820,3,33495,1,9,Wall of Vermilion,204,93,5,1,2,1
-19821,3,33495,1,9,Wall of Vermilion,204,93,5,1,3,1
-19822,3,33495,1,9,Wall of Vermilion,204,93,5,1,4,1
-19823,3,34452,1,12,Dúva's Wall,204,95,5,1,0,1
-19824,3,34452,1,12,Dúva's Wall,204,95,5,1,1,1
-19825,3,34452,1,12,Dúva's Wall,204,95,5,1,2,1
-19826,3,34452,1,12,Dúva's Wall,204,95,5,1,3,1
-19827,3,34452,1,12,Dúva's Wall,204,95,5,1,4,1
-19828,3,35090,1,14,Fort of Fonse,204,95,5,1,0,1
-19829,3,35090,1,14,Fort of Fonse,204,95,5,1,1,1
-19830,3,35090,1,14,Fort of Fonse,204,95,5,1,2,1
-19831,3,35090,1,14,Fort of Fonse,204,95,5,1,3,1
-19832,3,35090,1,14,Fort of Fonse,204,95,5,1,4,1
-19833,3,50000,1,6,Intellect's Weise Scutum,204,1,5,4,4,1
-19834,3,50000,1,9,Wall of Kenntnis,204,1,5,4,4,1
-19835,3,50000,1,10,Scutum of Glowing Embers,204,90,5,4,4,1
-19836,3,50000,1,12,Fort of Altesch,204,90,5,4,4,1
-20171,3,35090,1,14,Wall of Altura,204,95,5,1,0,1
-20172,3,35090,1,14,Wall of Altura,204,95,5,1,1,1
-20173,3,35090,1,14,Wall of Altura,204,95,5,1,2,1
-20174,3,35090,1,14,Wall of Altura,204,95,5,1,3,1
-20175,3,35090,1,14,Wall of Altura,204,95,5,1,4,1
-20176,3,36685,1,3,Rousing Schlucht Guard,204,98,5,1,0,1
-20177,3,36685,1,3,Rousing Schlucht Guard,204,98,5,1,1,1
-20178,3,36685,1,3,Rousing Schlucht Guard,204,98,5,1,2,1
-20179,3,36685,1,3,Rousing Schlucht Guard,204,98,5,1,3,1
-20180,3,36685,1,3,Rousing Schlucht Guard,204,98,5,1,4,1
-20181,3,37642,1,6,Plaisance Wall,204,100,5,1,0,1
-20182,3,37642,1,6,Plaisance Wall,204,100,5,1,1,1
-20183,3,37642,1,6,Plaisance Wall,204,100,5,1,2,1
-20184,3,37642,1,6,Plaisance Wall,204,100,5,1,3,1
-20185,3,37642,1,6,Plaisance Wall,204,100,5,1,4,1
-20186,3,38280,1,8,Volcan,204,100,5,1,0,1
-20187,3,38280,1,8,Volcan,204,100,5,1,1,1
-20188,3,38280,1,8,Volcan,204,100,5,1,2,1
-20189,3,38280,1,8,Volcan,204,100,5,1,3,1
-20190,3,38280,1,8,Volcan,204,100,5,1,4,1
-20191,3,50000,1,0,Honnête Guard of Purity,204,1,5,4,4,1
-20192,3,50000,1,3,Wall of Fedeltà,204,1,5,4,4,1
-20193,3,50000,1,4,Holy War Sphidante Guard,204,95,5,4,4,1
-20194,3,50000,1,6,Wall of Vainqueur,204,95,5,4,4,1
-19693,3,50000,1,4,Arshak's Throes,206,90,2,1,0,1
-19694,3,50000,1,4,Arshak's Throes,206,90,2,1,1,1
-19695,3,50000,1,4,Arshak's Throes,206,90,2,1,2,1
-19696,3,50000,1,4,Arshak's Throes,206,90,2,1,3,1
-19697,3,50000,1,4,Arshak's Throes,206,90,2,1,4,1
-19698,3,50000,1,10,Adamas Military Expedition Daggers,206,1,2,4,4,1
-19699,3,50000,1,13,Daggers of Agitator,206,1,2,4,4,1
-19859,3,39700,1,4,Red Dawn's Steel Daggers,206,90,2,1,0,1
-19860,3,39700,1,4,Red Dawn's Steel Daggers,206,90,2,1,1,1
-19861,3,39700,1,4,Red Dawn's Steel Daggers,206,90,2,1,2,1
-19862,3,39700,1,4,Red Dawn's Steel Daggers,206,90,2,1,3,1
-19863,3,39700,1,4,Red Dawn's Steel Daggers,206,90,2,1,4,1
-19864,3,41685,1,9,Edge of Vermilion,206,93,2,1,0,1
-19865,3,41685,1,9,Edge of Vermilion,206,93,2,1,1,1
-19866,3,41685,1,9,Edge of Vermilion,206,93,2,1,2,1
-19867,3,41685,1,9,Edge of Vermilion,206,93,2,1,3,1
-19868,3,41685,1,9,Edge of Vermilion,206,93,2,1,4,1
-19869,3,42876,1,12,Afet Baselards,206,95,2,1,0,1
-19870,3,42876,1,12,Afet Baselards,206,95,2,1,1,1
-19871,3,42876,1,12,Afet Baselards,206,95,2,1,2,1
-19872,3,42876,1,12,Afet Baselards,206,95,2,1,3,1
-19873,3,42876,1,12,Afet Baselards,206,95,2,1,4,1
-19874,3,43670,1,14,Daggers of Ombre,206,95,2,1,0,1
-19875,3,43670,1,14,Daggers of Ombre,206,95,2,1,1,1
-19876,3,43670,1,14,Daggers of Ombre,206,95,2,1,2,1
-19877,3,43670,1,14,Daggers of Ombre,206,95,2,1,3,1
-19878,3,43670,1,14,Daggers of Ombre,206,95,2,1,4,1
-19879,3,50000,1,6,Intellect's Weise Daggers,206,1,2,4,4,1
-19880,3,50000,1,9,Crow of Kenntnis,206,1,2,4,4,1
-19881,3,50000,1,10,Cinquedea of Glowing Embers,206,90,2,4,4,1
-19882,3,50000,1,12,Daggers of Altesch,206,90,2,4,4,1
-20217,3,43670,1,14,Daggers of Altura,206,95,2,1,0,1
-20218,3,43670,1,14,Daggers of Altura,206,95,2,1,1,1
-20219,3,43670,1,14,Daggers of Altura,206,95,2,1,2,1
-20220,3,43670,1,14,Daggers of Altura,206,95,2,1,3,1
-20221,3,43670,1,14,Daggers of Altura,206,95,2,1,4,1
-20222,3,45655,1,3,Rousing Schlucht Daggers,206,98,2,1,0,1
-20223,3,45655,1,3,Rousing Schlucht Daggers,206,98,2,1,1,1
-20224,3,45655,1,3,Rousing Schlucht Daggers,206,98,2,1,2,1
-20225,3,45655,1,3,Rousing Schlucht Daggers,206,98,2,1,3,1
-20226,3,45655,1,3,Rousing Schlucht Daggers,206,98,2,1,4,1
-20227,3,46846,1,6,Cruel Daggers,206,100,2,1,0,1
-20228,3,46846,1,6,Cruel Daggers,206,100,2,1,1,1
-20229,3,46846,1,6,Cruel Daggers,206,100,2,1,2,1
-20230,3,46846,1,6,Cruel Daggers,206,100,2,1,3,1
-20231,3,46846,1,6,Cruel Daggers,206,100,2,1,4,1
-20232,3,47640,1,8,Jaria,206,100,2,1,0,1
-20233,3,47640,1,8,Jaria,206,100,2,1,1,1
-20234,3,47640,1,8,Jaria,206,100,2,1,2,1
-20235,3,47640,1,8,Jaria,206,100,2,1,3,1
-20236,3,47640,1,8,Jaria,206,100,2,1,4,1
-20237,3,50000,1,0,Honnête Daggers of Purity,206,1,2,4,4,1
-20238,3,50000,1,3,Daggers of Fedeltà,206,1,2,4,4,1
-20239,3,50000,1,4,Holy War Sphidante Daggers,206,95,2,4,4,1
-20240,3,50000,1,6,Crow of Vainqueur,206,95,2,4,4,1
-19700,3,50000,1,4,Jamshid Dart,207,90,3,1,0,1
-19701,3,50000,1,4,Jamshid Dart,207,90,3,1,1,1
-19702,3,50000,1,4,Jamshid Dart,207,90,3,1,2,1
-19703,3,50000,1,4,Jamshid Dart,207,90,3,1,3,1
-19704,3,50000,1,4,Jamshid Dart,207,90,3,1,4,1
-19705,3,50000,1,10,Adamas Military Expedition Bow,207,1,3,4,4,1
-19706,3,50000,1,13,Arrow of Agitator,207,1,3,4,4,1
-19883,3,39700,1,4,Red Dawn's Steel Bow,207,90,3,1,0,1
-19884,3,39700,1,4,Red Dawn's Steel Bow,207,90,3,1,1,1
-19885,3,39700,1,4,Red Dawn's Steel Bow,207,90,3,1,2,1
-19886,3,39700,1,4,Red Dawn's Steel Bow,207,90,3,1,3,1
-19887,3,39700,1,4,Red Dawn's Steel Bow,207,90,3,1,4,1
-19888,3,41685,1,9,Bow of Vermilion,207,93,3,1,0,1
-19889,3,41685,1,9,Bow of Vermilion,207,93,3,1,1,1
-19890,3,41685,1,9,Bow of Vermilion,207,93,3,1,2,1
-19891,3,41685,1,9,Bow of Vermilion,207,93,3,1,3,1
-19892,3,41685,1,9,Bow of Vermilion,207,93,3,1,4,1
-19893,3,42876,1,12,Funeri Bow,207,95,3,1,0,1
-19894,3,42876,1,12,Funeri Bow,207,95,3,1,1,1
-19895,3,42876,1,12,Funeri Bow,207,95,3,1,2,1
-19896,3,42876,1,12,Funeri Bow,207,95,3,1,3,1
-19897,3,42876,1,12,Funeri Bow,207,95,3,1,4,1
-19898,3,43670,1,14,Bow of Tourbillon,207,95,3,1,0,1
-19899,3,43670,1,14,Bow of Tourbillon,207,95,3,1,1,1
-19900,3,43670,1,14,Bow of Tourbillon,207,95,3,1,2,1
-19901,3,43670,1,14,Bow of Tourbillon,207,95,3,1,3,1
-19902,3,43670,1,14,Bow of Tourbillon,207,95,3,1,4,1
-19903,3,50000,1,6,Intellect's Weise Arrow,207,1,3,4,4,1
-19904,3,50000,1,9,Bow of Kenntnis,207,1,3,4,4,1
-19905,3,50000,1,10,Longbow of Glowing Embers,207,90,3,4,4,1
-19906,3,50000,1,12,Arrow of Altesch,207,90,3,4,4,1
-20241,3,43670,1,14,Arrow of Altura,207,95,3,1,0,1
-20242,3,43670,1,14,Arrow of Altura,207,95,3,1,1,1
-20243,3,43670,1,14,Arrow of Altura,207,95,3,1,2,1
-20244,3,43670,1,14,Arrow of Altura,207,95,3,1,3,1
-20245,3,43670,1,14,Arrow of Altura,207,95,3,1,4,1
-20246,3,45655,1,3,Rousing Schlucht Bow,207,98,3,1,0,1
-20247,3,45655,1,3,Rousing Schlucht Bow,207,98,3,1,1,1
-20248,3,45655,1,3,Rousing Schlucht Bow,207,98,3,1,2,1
-20249,3,45655,1,3,Rousing Schlucht Bow,207,98,3,1,3,1
-20250,3,45655,1,3,Rousing Schlucht Bow,207,98,3,1,4,1
-20251,3,46846,1,6,Anstaing Bow,207,100,3,1,0,1
-20252,3,46846,1,6,Anstaing Bow,207,100,3,1,1,1
-20253,3,46846,1,6,Anstaing Bow,207,100,3,1,2,1
-20254,3,46846,1,6,Anstaing Bow,207,100,3,1,3,1
-20255,3,46846,1,6,Anstaing Bow,207,100,3,1,4,1
-20256,3,47640,1,8,Enfer,207,100,3,1,0,1
-20257,3,47640,1,8,Enfer,207,100,3,1,1,1
-20258,3,47640,1,8,Enfer,207,100,3,1,2,1
-20259,3,47640,1,8,Enfer,207,100,3,1,3,1
-20260,3,47640,1,8,Enfer,207,100,3,1,4,1
-20261,3,50000,1,0,Honnête Bow of Purity,207,1,3,4,4,1
-20262,3,50000,1,3,Bow of Fedeltà,207,1,3,4,4,1
-20263,3,50000,1,4,Holy War Sphidante Bow,207,95,3,4,4,1
-20264,3,50000,1,6,Arrow of Vainqueur,207,95,3,4,4,1
-19707,3,50000,1,4,Haiz Fereydun,208,90,9,1,0,1
-19708,3,50000,1,4,Haiz Fereydun,208,90,9,1,1,1
-19709,3,50000,1,4,Haiz Fereydun,208,90,9,1,2,1
-19710,3,50000,1,4,Haiz Fereydun,208,90,9,1,3,1
-19711,3,50000,1,4,Haiz Fereydun,208,90,9,1,4,1
-19712,3,50000,1,10,Adamas Military Expedition Arm,208,1,9,4,4,1
-19713,3,50000,1,13,Hands of Agitator,208,1,9,4,4,1
-19907,3,39700,1,4,Red Dawn's Steel Arm,208,90,9,1,0,1
-19908,3,39700,1,4,Red Dawn's Steel Arm,208,90,9,1,1,1
-19909,3,39700,1,4,Red Dawn's Steel Arm,208,90,9,1,2,1
-19910,3,39700,1,4,Red Dawn's Steel Arm,208,90,9,1,3,1
-19911,3,39700,1,4,Red Dawn's Steel Arm,208,90,9,1,4,1
-19912,3,41685,1,9,Hand of Vermilion,208,93,9,1,0,1
-19913,3,41685,1,9,Hand of Vermilion,208,93,9,1,1,1
-19914,3,41685,1,9,Hand of Vermilion,208,93,9,1,2,1
-19915,3,41685,1,9,Hand of Vermilion,208,93,9,1,3,1
-19916,3,41685,1,9,Hand of Vermilion,208,93,9,1,4,1
-19917,3,42876,1,12,Lux's Gauntlet,208,95,9,1,0,1
-19918,3,42876,1,12,Lux's Gauntlet,208,95,9,1,1,1
-19919,3,42876,1,12,Lux's Gauntlet,208,95,9,1,2,1
-19920,3,42876,1,12,Lux's Gauntlet,208,95,9,1,3,1
-19921,3,42876,1,12,Lux's Gauntlet,208,95,9,1,4,1
-19922,3,43670,1,14,Arm of Grace,208,95,9,1,0,1
-19923,3,43670,1,14,Arm of Grace,208,95,9,1,1,1
-19924,3,43670,1,14,Arm of Grace,208,95,9,1,2,1
-19925,3,43670,1,14,Arm of Grace,208,95,9,1,3,1
-19926,3,43670,1,14,Arm of Grace,208,95,9,1,4,1
-19927,3,50000,1,6,Intellect's Weise Glove,208,1,9,4,4,1
-19928,3,50000,1,9,Hand of Kenntnis,208,1,9,4,4,1
-19929,3,50000,1,10,Gauntlet of Glowing Embers,208,90,9,4,4,1
-19930,3,50000,1,12,Arm of Altesch,208,90,9,4,4,1
-20265,3,43670,1,14,Hand of Altura,208,95,9,1,0,1
-20266,3,43670,1,14,Hand of Altura,208,95,9,1,1,1
-20267,3,43670,1,14,Hand of Altura,208,95,9,1,2,1
-20268,3,43670,1,14,Hand of Altura,208,95,9,1,3,1
-20269,3,43670,1,14,Hand of Altura,208,95,9,1,4,1
-20270,3,45655,1,3,Rousing Schlucht Arm,208,98,9,1,0,1
-20271,3,45655,1,3,Rousing Schlucht Arm,208,98,9,1,1,1
-20272,3,45655,1,3,Rousing Schlucht Arm,208,98,9,1,2,1
-20273,3,45655,1,3,Rousing Schlucht Arm,208,98,9,1,3,1
-20274,3,45655,1,3,Rousing Schlucht Arm,208,98,9,1,4,1
-20275,3,46846,1,6,Avare Gauntlet,208,100,9,1,0,1
-20276,3,46846,1,6,Avare Gauntlet,208,100,9,1,1,1
-20277,3,46846,1,6,Avare Gauntlet,208,100,9,1,2,1
-20278,3,46846,1,6,Avare Gauntlet,208,100,9,1,3,1
-20279,3,46846,1,6,Avare Gauntlet,208,100,9,1,4,1
-20280,3,47640,1,8,Explosion,208,100,9,1,0,1
-20281,3,47640,1,8,Explosion,208,100,9,1,1,1
-20282,3,47640,1,8,Explosion,208,100,9,1,2,1
-20283,3,47640,1,8,Explosion,208,100,9,1,3,1
-20284,3,47640,1,8,Explosion,208,100,9,1,4,1
-20285,3,50000,1,0,Honnête Glove of Purity,208,1,9,4,4,1
-20286,3,50000,1,3,Arm of Fedeltà,208,1,9,4,4,1
-20287,3,50000,1,4,Holy War Sphidante Arms,208,95,9,4,4,1
-20288,3,50000,1,6,Hand of Vainqueur,208,95,9,4,4,1
-19714,3,50000,1,4,Blessed Ardashir,209,90,8,1,0,1
-19715,3,50000,1,4,Blessed Ardashir,209,90,8,1,1,1
-19716,3,50000,1,4,Blessed Ardashir,209,90,8,1,2,1
-19717,3,50000,1,4,Blessed Ardashir,209,90,8,1,3,1
-19718,3,50000,1,4,Blessed Ardashir,209,90,8,1,4,1
-19719,3,50000,1,10,Adamas Military Expedition Shooter,209,1,8,4,4,1
-19720,3,50000,1,13,Spell of Agitator,209,1,8,4,4,1
-19931,3,39700,1,4,Red Dawn's Steel Shooter,209,90,8,1,0,1
-19932,3,39700,1,4,Red Dawn's Steel Shooter,209,90,8,1,1,1
-19933,3,39700,1,4,Red Dawn's Steel Shooter,209,90,8,1,2,1
-19934,3,39700,1,4,Red Dawn's Steel Shooter,209,90,8,1,3,1
-19935,3,39700,1,4,Red Dawn's Steel Shooter,209,90,8,1,4,1
-19936,3,41685,1,9,Spell of Vermilion,209,93,8,1,0,1
-19937,3,41685,1,9,Spell of Vermilion,209,93,8,1,1,1
-19938,3,41685,1,9,Spell of Vermilion,209,93,8,1,2,1
-19939,3,41685,1,9,Spell of Vermilion,209,93,8,1,3,1
-19940,3,41685,1,9,Spell of Vermilion,209,93,8,1,4,1
-19941,3,42876,1,12,Jinas Shooter,209,95,8,1,0,1
-19942,3,42876,1,12,Jinas Shooter,209,95,8,1,1,1
-19943,3,42876,1,12,Jinas Shooter,209,95,8,1,2,1
-19944,3,42876,1,12,Jinas Shooter,209,95,8,1,3,1
-19945,3,42876,1,12,Jinas Shooter,209,95,8,1,4,1
-19946,3,43670,1,14,Spell of Typhoon,209,95,8,1,0,1
-19947,3,43670,1,14,Spell of Typhoon,209,95,8,1,1,1
-19948,3,43670,1,14,Spell of Typhoon,209,95,8,1,2,1
-19949,3,43670,1,14,Spell of Typhoon,209,95,8,1,3,1
-19950,3,43670,1,14,Spell of Typhoon,209,95,8,1,4,1
-19951,3,50000,1,6,Intellect's Weise Shooter,209,1,8,4,4,1
-19952,3,50000,1,9,Spell of Kenntnis,209,1,8,4,4,1
-19953,3,50000,1,10,Twin Shooter of Glowing Embers,209,90,8,4,4,1
-19954,3,50000,1,12,Spell of Altesch,209,90,8,4,4,1
-20289,3,43670,1,14,Spell of Altura,209,95,8,1,0,1
-20290,3,43670,1,14,Spell of Altura,209,95,8,1,1,1
-20291,3,43670,1,14,Spell of Altura,209,95,8,1,2,1
-20292,3,43670,1,14,Spell of Altura,209,95,8,1,3,1
-20293,3,43670,1,14,Spell of Altura,209,95,8,1,4,1
-20294,3,45655,1,3,Rousing Schlucht Shooter,209,98,8,1,0,1
-20295,3,45655,1,3,Rousing Schlucht Shooter,209,98,8,1,1,1
-20296,3,45655,1,3,Rousing Schlucht Shooter,209,98,8,1,2,1
-20297,3,45655,1,3,Rousing Schlucht Shooter,209,98,8,1,3,1
-20298,3,45655,1,3,Rousing Schlucht Shooter,209,98,8,1,4,1
-20299,3,46846,1,6,Réverie Shooter,209,100,8,1,0,1
-20300,3,46846,1,6,Réverie Shooter,209,100,8,1,1,1
-20301,3,46846,1,6,Réverie Shooter,209,100,8,1,2,1
-20302,3,46846,1,6,Réverie Shooter,209,100,8,1,3,1
-20303,3,46846,1,6,Réverie Shooter,209,100,8,1,4,1
-20304,3,47640,1,8,Purgatoire,209,100,8,1,0,1
-20305,3,47640,1,8,Purgatoire,209,100,8,1,1,1
-20306,3,47640,1,8,Purgatoire,209,100,8,1,2,1
-20307,3,47640,1,8,Purgatoire,209,100,8,1,3,1
-20308,3,47640,1,8,Purgatoire,209,100,8,1,4,1
-20309,3,50000,1,0,Honnête Shooter of Purity,209,1,8,4,4,1
-20310,3,50000,1,3,Spell of Fedeltà,209,1,8,4,4,1
-20311,3,50000,1,4,Holy War Sphidante Shooter,209,95,8,4,4,1
-20312,3,50000,1,6,Spell of Vainqueur,209,95,8,4,4,1
-19721,3,50000,1,4,Saar's Vessel,211,90,4,1,0,1
-19722,3,50000,1,4,Saar's Vessel,211,90,4,1,1,1
-19723,3,50000,1,4,Saar's Vessel,211,90,4,1,2,1
-19724,3,50000,1,4,Saar's Vessel,211,90,4,1,3,1
-19725,3,50000,1,4,Saar's Vessel,211,90,4,1,4,1
-19726,3,50000,1,10,Adamas Military Expedition Staff,211,1,4,4,4,1
-19727,3,50000,1,13,Staff of Agitator,211,1,4,4,4,1
-19955,3,39700,1,4,Red Dawn's Steel Cane,211,90,4,1,0,1
-19956,3,39700,1,4,Red Dawn's Steel Cane,211,90,4,1,1,1
-19957,3,39700,1,4,Red Dawn's Steel Cane,211,90,4,1,2,1
-19958,3,39700,1,4,Red Dawn's Steel Cane,211,90,4,1,3,1
-19959,3,39700,1,4,Red Dawn's Steel Cane,211,90,4,1,4,1
-19960,3,41685,1,9,Staff of Vermilion,211,93,4,1,0,1
-19961,3,41685,1,9,Staff of Vermilion,211,93,4,1,1,1
-19962,3,41685,1,9,Staff of Vermilion,211,93,4,1,2,1
-19963,3,41685,1,9,Staff of Vermilion,211,93,4,1,3,1
-19964,3,41685,1,9,Staff of Vermilion,211,93,4,1,4,1
-19965,3,42876,1,12,Youches' Staff,211,95,4,1,0,1
-19966,3,42876,1,12,Youches' Staff,211,95,4,1,1,1
-19967,3,42876,1,12,Youches' Staff,211,95,4,1,2,1
-19968,3,42876,1,12,Youches' Staff,211,95,4,1,3,1
-19969,3,42876,1,12,Youches' Staff,211,95,4,1,4,1
-19970,3,43670,1,14,Cane of Lumiere,211,95,4,1,0,1
-19971,3,43670,1,14,Cane of Lumiere,211,95,4,1,1,1
-19972,3,43670,1,14,Cane of Lumiere,211,95,4,1,2,1
-19973,3,43670,1,14,Cane of Lumiere,211,95,4,1,3,1
-19974,3,43670,1,14,Cane of Lumiere,211,95,4,1,4,1
-19975,3,50000,1,6,Intellect's Weise Cane,211,1,4,4,4,1
-19976,3,50000,1,9,Staff of Kenntnis,211,1,4,4,4,1
-19977,3,50000,1,10,Spine Cane of Glowing Embers,211,90,4,4,4,1
-19978,3,50000,1,12,Staff of Altesch,211,90,4,4,4,1
-20313,3,43670,1,14,Staff of Altura,211,95,4,1,0,1
-20314,3,43670,1,14,Staff of Altura,211,95,4,1,1,1
-20315,3,43670,1,14,Staff of Altura,211,95,4,1,2,1
-20316,3,43670,1,14,Staff of Altura,211,95,4,1,3,1
-20317,3,43670,1,14,Staff of Altura,211,95,4,1,4,1
-20318,3,45655,1,3,Rousing Schlucht Cane,211,98,4,1,0,1
-20319,3,45655,1,3,Rousing Schlucht Cane,211,98,4,1,1,1
-20320,3,45655,1,3,Rousing Schlucht Cane,211,98,4,1,2,1
-20321,3,45655,1,3,Rousing Schlucht Cane,211,98,4,1,3,1
-20322,3,45655,1,3,Rousing Schlucht Cane,211,98,4,1,4,1
-20323,3,46846,1,6,Genereux Staff,211,100,4,1,0,1
-20324,3,46846,1,6,Genereux Staff,211,100,4,1,1,1
-20325,3,46846,1,6,Genereux Staff,211,100,4,1,2,1
-20326,3,46846,1,6,Genereux Staff,211,100,4,1,3,1
-20327,3,46846,1,6,Genereux Staff,211,100,4,1,4,1
-20328,3,47640,1,8,Chaleur,211,100,4,1,0,1
-20329,3,47640,1,8,Chaleur,211,100,4,1,1,1
-20330,3,47640,1,8,Chaleur,211,100,4,1,2,1
-20331,3,47640,1,8,Chaleur,211,100,4,1,3,1
-20332,3,47640,1,8,Chaleur,211,100,4,1,4,1
-20337,3,50000,1,0,Honnête Cane of Purity,211,1,4,4,4,1
-20342,3,50000,1,3,Staff of Fedeltà,211,1,4,4,4,1
-20343,3,50000,1,4,Holy War Sphidante Cane,211,95,4,4,4,1
-20344,3,50000,1,6,Staff of Vainqueur,211,95,4,4,4,1
-19728,3,50000,1,4,Magicka Shapur,212,90,6,1,0,1
-19729,3,50000,1,4,Magicka Shapur,212,90,6,1,1,1
-19730,3,50000,1,4,Magicka Shapur,212,90,6,1,2,1
-19731,3,50000,1,4,Magicka Shapur,212,90,6,1,3,1
-19732,3,50000,1,4,Magicka Shapur,212,90,6,1,4,1
-19733,3,50000,1,10,Adamas Military Expedition Wand,212,1,6,4,4,1
-19734,3,50000,1,13,Wand of Agitator,212,1,6,4,4,1
-19979,3,39700,1,4,Red Dawn's Steel Wand,212,90,6,1,0,1
-19980,3,39700,1,4,Red Dawn's Steel Wand,212,90,6,1,1,1
-19981,3,39700,1,4,Red Dawn's Steel Wand,212,90,6,1,2,1
-19982,3,39700,1,4,Red Dawn's Steel Wand,212,90,6,1,3,1
-19983,3,39700,1,4,Red Dawn's Steel Wand,212,90,6,1,4,1
-19984,3,41685,1,9,Wand of Vermilion,212,93,6,1,0,1
-19985,3,41685,1,9,Wand of Vermilion,212,93,6,1,1,1
-19986,3,41685,1,9,Wand of Vermilion,212,93,6,1,2,1
-19987,3,41685,1,9,Wand of Vermilion,212,93,6,1,3,1
-19988,3,41685,1,9,Wand of Vermilion,212,93,6,1,4,1
-19989,3,42876,1,12,Garip's Wand,212,95,6,1,0,1
-19990,3,42876,1,12,Garip's Wand,212,95,6,1,1,1
-19991,3,42876,1,12,Garip's Wand,212,95,6,1,2,1
-19992,3,42876,1,12,Garip's Wand,212,95,6,1,3,1
-19993,3,42876,1,12,Garip's Wand,212,95,6,1,4,1
-19994,3,43670,1,14,Wand of La Mer,212,95,6,1,0,1
-19995,3,43670,1,14,Wand of La Mer,212,95,6,1,1,1
-19996,3,43670,1,14,Wand of La Mer,212,95,6,1,2,1
-19997,3,43670,1,14,Wand of La Mer,212,95,6,1,3,1
-19998,3,43670,1,14,Wand of La Mer,212,95,6,1,4,1
-19999,3,50000,1,6,Intellect's Weise Wand,212,1,6,4,4,1
-20000,3,50000,1,9,Wand of Kenntnis,212,1,6,4,4,1
-20001,3,50000,1,10,Magias Wand of Glowing Embers,212,90,6,4,4,1
-20002,3,50000,1,12,Wand of Altesch,212,90,6,4,4,1
-20345,3,43670,1,14,Wand of Altura,212,95,6,1,0,1
-20346,3,43670,1,14,Wand of Altura,212,95,6,1,1,1
-20347,3,43670,1,14,Wand of Altura,212,95,6,1,2,1
-20348,3,43670,1,14,Wand of Altura,212,95,6,1,3,1
-20349,3,43670,1,14,Wand of Altura,212,95,6,1,4,1
-20350,3,45655,1,3,Rousing Schlucht Wand,212,98,6,1,0,1
-20351,3,45655,1,3,Rousing Schlucht Wand,212,98,6,1,1,1
-20352,3,45655,1,3,Rousing Schlucht Wand,212,98,6,1,2,1
-20353,3,45655,1,3,Rousing Schlucht Wand,212,98,6,1,3,1
-20354,3,45655,1,3,Rousing Schlucht Wand,212,98,6,1,4,1
-20355,3,46846,1,6,Sagesse Wand,212,100,6,1,0,1
-20356,3,46846,1,6,Sagesse Wand,212,100,6,1,1,1
-20357,3,46846,1,6,Sagesse Wand,212,100,6,1,2,1
-20358,3,46846,1,6,Sagesse Wand,212,100,6,1,3,1
-20359,3,46846,1,6,Sagesse Wand,212,100,6,1,4,1
-20360,3,47640,1,8,Désastre,212,100,6,1,0,1
-20361,3,47640,1,8,Désastre,212,100,6,1,1,1
-20362,3,47640,1,8,Désastre,212,100,6,1,2,1
-20363,3,47640,1,8,Désastre,212,100,6,1,3,1
-20364,3,47640,1,8,Désastre,212,100,6,1,4,1
-20369,3,50000,1,0,Honnête Wand of Purity,212,1,6,4,4,1
-20370,3,50000,1,3,Wand of Fedeltà,212,1,6,4,4,1
-20371,3,50000,1,4,Holy War Sphidante Wand,212,95,6,4,4,1
-20372,3,50000,1,6,Wand of Vainqueur,212,95,6,4,4,1
-19735,3,50000,1,4,Hoshang's Scythe,213,90,10,1,0,1
-19736,3,50000,1,4,Hoshang's Scythe,213,90,10,1,1,1
-19737,3,50000,1,4,Hoshang's Scythe,213,90,10,1,2,1
-19738,3,50000,1,4,Hoshang's Scythe,213,90,10,1,3,1
-19739,3,50000,1,4,Hoshang's Scythe,213,90,10,1,4,1
-19740,3,50000,1,10,Adamas Military Expedition Lance,213,1,10,4,4,1
-19741,3,50000,1,13,Lance of Agitator,213,1,10,4,4,1
-20003,3,39700,1,4,Red Dawn's Steel Lance,213,90,10,1,0,1
-20004,3,39700,1,4,Red Dawn's Steel Lance,213,90,10,1,1,1
-20005,3,39700,1,4,Red Dawn's Steel Lance,213,90,10,1,2,1
-20006,3,39700,1,4,Red Dawn's Steel Lance,213,90,10,1,3,1
-20007,3,39700,1,4,Red Dawn's Steel Lance,213,90,10,1,4,1
-20008,3,41685,1,9,Lance of Vermilion,213,93,10,1,0,1
-20009,3,41685,1,9,Lance of Vermilion,213,93,10,1,1,1
-20010,3,41685,1,9,Lance of Vermilion,213,93,10,1,2,1
-20011,3,41685,1,9,Lance of Vermilion,213,93,10,1,3,1
-20012,3,41685,1,9,Lance of Vermilion,213,93,10,1,4,1
-20013,3,42876,1,12,Dilime Spear,213,95,10,1,0,1
-20014,3,42876,1,12,Dilime Spear,213,95,10,1,1,1
-20015,3,42876,1,12,Dilime Spear,213,95,10,1,2,1
-20016,3,42876,1,12,Dilime Spear,213,95,10,1,3,1
-20017,3,42876,1,12,Dilime Spear,213,95,10,1,4,1
-20018,3,43670,1,14,Breath of Eclair,213,95,10,1,0,1
-20019,3,43670,1,14,Breath of Eclair,213,95,10,1,1,1
-20020,3,43670,1,14,Breath of Eclair,213,95,10,1,2,1
-20021,3,43670,1,14,Breath of Eclair,213,95,10,1,3,1
-20022,3,43670,1,14,Breath of Eclair,213,95,10,1,4,1
-20023,3,50000,1,6,Intellect's Weise Spear,213,1,10,4,4,1
-20024,3,50000,1,9,Lance of Kenntnis,213,1,10,4,4,1
-20025,3,50000,1,10,Screw Lance of Glowing Embers,213,90,10,4,4,1
-20026,3,50000,1,12,Spear of Altesch,213,90,10,4,4,1
-20373,3,43670,1,14,Lance of Altura,213,95,10,1,0,1
-20374,3,43670,1,14,Lance of Altura,213,95,10,1,1,1
-20375,3,43670,1,14,Lance of Altura,213,95,10,1,2,1
-20376,3,43670,1,14,Lance of Altura,213,95,10,1,3,1
-20377,3,43670,1,14,Lance of Altura,213,95,10,1,4,1
-20378,3,45655,1,3,Rousing Schlucht Spear,213,98,10,1,0,1
-20379,3,45655,1,3,Rousing Schlucht Spear,213,98,10,1,1,1
-20380,3,45655,1,3,Rousing Schlucht Spear,213,98,10,1,2,1
-20381,3,45655,1,3,Rousing Schlucht Spear,213,98,10,1,3,1
-20382,3,45655,1,3,Rousing Schlucht Spear,213,98,10,1,4,1
-20383,3,46846,1,6,Effort Spear,213,100,10,1,0,1
-20384,3,46846,1,6,Effort Spear,213,100,10,1,1,1
-20385,3,46846,1,6,Effort Spear,213,100,10,1,2,1
-20386,3,46846,1,6,Effort Spear,213,100,10,1,3,1
-20387,3,46846,1,6,Effort Spear,213,100,10,1,4,1
-20388,3,47640,1,8,Avalanche,213,100,10,1,0,1
-20389,3,47640,1,8,Avalanche,213,100,10,1,1,1
-20390,3,47640,1,8,Avalanche,213,100,10,1,2,1
-20391,3,47640,1,8,Avalanche,213,100,10,1,3,1
-20392,3,47640,1,8,Avalanche,213,100,10,1,4,1
-20393,3,50000,1,0,Honnête Spear of Purity,213,1,10,4,4,1
-20394,3,50000,1,3,Lance of Fedeltà,213,1,10,4,4,1
-20395,3,50000,1,4,Holy War Sphidante Spear,213,95,10,4,4,1
-20396,3,50000,1,6,Spear of Vainqueur,213,95,10,4,4,1
+19592,3,10000,1,94,Green Light War Axe,203,1,7,4,4,1
+19593,3,10000,1,94,The Seven-Tailed Serpent and the Golden Staff,212,1,6,4,4,1
+19658,3,50000,1,100,Rostam's Blaze,201,90,1,1,0,1
+19659,3,50000,1,100,Rostam's Blaze,201,90,1,1,1,1
+19660,3,50000,1,100,Rostam's Blaze,201,90,1,1,2,1
+19661,3,50000,1,100,Rostam's Blaze,201,90,1,1,3,1
+19662,3,50000,1,100,Rostam's Blaze,201,90,1,1,4,1
+19663,3,50000,1,90,Adamas Military Expedition Sword,201,1,1,4,4,1
+19664,3,50000,1,93,Edge of Agitator,201,1,1,4,4,1
+19743,3,31826,1,100,Red Dawn's Steel Edge,201,90,1,1,0,1
+19744,3,31826,1,100,Red Dawn's Steel Edge,201,90,1,1,1,1
+19745,3,31826,1,100,Red Dawn's Steel Edge,201,90,1,1,2,1
+19746,3,31826,1,100,Red Dawn's Steel Edge,201,90,1,1,3,1
+19747,3,31826,1,100,Red Dawn's Steel Edge,201,90,1,1,4,1
+19748,3,33390,1,105,Sword of Vermilion,201,93,1,1,0,1
+19749,3,33390,1,105,Sword of Vermilion,201,93,1,1,1,1
+19750,3,33390,1,105,Sword of Vermilion,201,93,1,1,2,1
+19751,3,33390,1,105,Sword of Vermilion,201,93,1,1,3,1
+19752,3,33390,1,105,Sword of Vermilion,201,93,1,1,4,1
+19753,3,34344,1,108,Altinon Sword,201,95,1,1,0,1
+19754,3,34344,1,108,Altinon Sword,201,95,1,1,1,1
+19755,3,34344,1,108,Altinon Sword,201,95,1,1,2,1
+19756,3,34344,1,108,Altinon Sword,201,95,1,1,3,1
+19757,3,34344,1,108,Altinon Sword,201,95,1,1,4,1
+19758,3,34980,1,110,Flamberge of Grail,201,95,1,1,0,1
+19759,3,34980,1,110,Flamberge of Grail,201,95,1,1,1,1
+19760,3,34980,1,110,Flamberge of Grail,201,95,1,1,2,1
+19761,3,34980,1,110,Flamberge of Grail,201,95,1,1,3,1
+19762,3,34980,1,110,Flamberge of Grail,201,95,1,1,4,1
+19763,3,50000,1,102,Intellect's Weise Sword,201,1,1,4,4,1
+19764,3,50000,1,105,Edge of Kenntnis,201,1,1,4,4,1
+19765,3,50000,1,106,Rapier of Glowing Embers,201,90,1,4,4,1
+19766,3,50000,1,108,Sword of Altesch,201,90,1,4,4,1
+20101,3,31826,1,110,Edge of Altura,201,95,1,1,0,1
+20102,3,31826,1,110,Edge of Altura,201,95,1,1,1,1
+20103,3,31826,1,110,Edge of Altura,201,95,1,1,2,1
+20104,3,31826,1,110,Edge of Altura,201,95,1,1,3,1
+20105,3,31826,1,110,Edge of Altura,201,95,1,1,4,1
+20106,3,33390,1,115,Rousing Schlucht Sword,201,98,1,1,0,1
+20107,3,33390,1,115,Rousing Schlucht Sword,201,98,1,1,1,1
+20108,3,33390,1,115,Rousing Schlucht Sword,201,98,1,1,2,1
+20109,3,33390,1,115,Rousing Schlucht Sword,201,98,1,1,3,1
+20110,3,33390,1,115,Rousing Schlucht Sword,201,98,1,1,4,1
+20111,3,34344,1,118,Passion Sword,201,100,1,1,0,1
+20112,3,34344,1,118,Passion Sword,201,100,1,1,1,1
+20113,3,34344,1,118,Passion Sword,201,100,1,1,2,1
+20114,3,34344,1,118,Passion Sword,201,100,1,1,3,1
+20115,3,34344,1,118,Passion Sword,201,100,1,1,4,1
+20116,3,34980,1,120,Éruption,201,100,1,1,0,1
+20117,3,34980,1,120,Éruption,201,100,1,1,1,1
+20118,3,34980,1,120,Éruption,201,100,1,1,2,1
+20119,3,34980,1,120,Éruption,201,100,1,1,3,1
+20120,3,34980,1,120,Éruption,201,100,1,1,4,1
+20121,3,50000,1,112,Honnête Sword of Purity,201,1,1,4,4,1
+20122,3,50000,1,115,Edge of Fedeltà,201,1,1,4,4,1
+20123,3,50000,1,116,Holy War Sphidante Sword,201,95,1,4,4,1
+20124,3,50000,1,118,Sword of Vainqueur,201,95,1,4,4,1
+19672,3,50000,1,100,Keyumars Glinz,203,90,7,1,0,1
+19673,3,50000,1,100,Keyumars Glinz,203,90,7,1,1,1
+19674,3,50000,1,100,Keyumars Glinz,203,90,7,1,2,1
+19675,3,50000,1,100,Keyumars Glinz,203,90,7,1,3,1
+19676,3,50000,1,100,Keyumars Glinz,203,90,7,1,4,1
+19677,3,50000,1,90,Adamas Military Expedition Blade,203,1,7,4,4,1
+19678,3,50000,1,93,Blade of Agitator,203,1,7,4,4,1
+19789,3,39700,1,100,Red Dawn's Steel Saber,203,90,7,1,0,1
+19790,3,39700,1,100,Red Dawn's Steel Saber,203,90,7,1,1,1
+19791,3,39700,1,100,Red Dawn's Steel Saber,203,90,7,1,2,1
+19792,3,39700,1,100,Red Dawn's Steel Saber,203,90,7,1,3,1
+19793,3,39700,1,100,Red Dawn's Steel Saber,203,90,7,1,4,1
+19794,3,41685,1,105,Blade of Vermilion,203,93,7,1,0,1
+19795,3,41685,1,105,Blade of Vermilion,203,93,7,1,1,1
+19796,3,41685,1,105,Blade of Vermilion,203,93,7,1,2,1
+19797,3,41685,1,105,Blade of Vermilion,203,93,7,1,3,1
+19798,3,41685,1,105,Blade of Vermilion,203,93,7,1,4,1
+19799,3,42876,1,108,Firash Blade,203,95,7,1,0,1
+19800,3,42876,1,108,Firash Blade,203,95,7,1,1,1
+19801,3,42876,1,108,Firash Blade,203,95,7,1,2,1
+19802,3,42876,1,108,Firash Blade,203,95,7,1,3,1
+19803,3,42876,1,108,Firash Blade,203,95,7,1,4,1
+19804,3,43670,1,110,Espadon of Orage,203,95,7,1,0,1
+19805,3,43670,1,110,Espadon of Orage,203,95,7,1,1,1
+19806,3,43670,1,110,Espadon of Orage,203,95,7,1,2,1
+19807,3,43670,1,110,Espadon of Orage,203,95,7,1,3,1
+19808,3,43670,1,110,Espadon of Orage,203,95,7,1,4,1
+19809,3,50000,1,102,Intellect's Weise Breaker,203,1,7,4,4,1
+19810,3,50000,1,105,Saber of Kenntnis,203,1,7,4,4,1
+19811,3,50000,1,106,Pistoia of Glowing Embers,203,90,7,4,4,1
+19812,3,50000,1,108,Blade of Altesch,203,90,7,4,4,1
+20147,3,43670,1,110,Blade of Altura,203,95,7,1,0,1
+20148,3,43670,1,110,Blade of Altura,203,95,7,1,1,1
+20149,3,43670,1,110,Blade of Altura,203,95,7,1,2,1
+20150,3,43670,1,110,Blade of Altura,203,95,7,1,3,1
+20151,3,43670,1,110,Blade of Altura,203,95,7,1,4,1
+20152,3,45655,1,115,Rousing Schlucht Blade,203,98,7,1,0,1
+20153,3,45655,1,115,Rousing Schlucht Blade,203,98,7,1,1,1
+20154,3,45655,1,115,Rousing Schlucht Blade,203,98,7,1,2,1
+20155,3,45655,1,115,Rousing Schlucht Blade,203,98,7,1,3,1
+20156,3,45655,1,115,Rousing Schlucht Blade,203,98,7,1,4,1
+20157,3,46846,1,118,Puissance Blade,203,100,7,1,0,1
+20158,3,46846,1,118,Puissance Blade,203,100,7,1,1,1
+20159,3,46846,1,118,Puissance Blade,203,100,7,1,2,1
+20160,3,46846,1,118,Puissance Blade,203,100,7,1,3,1
+20161,3,46846,1,118,Puissance Blade,203,100,7,1,4,1
+20162,3,47640,1,120,Évaporation,203,100,7,1,0,1
+20163,3,47640,1,120,Évaporation,203,100,7,1,1,1
+20164,3,47640,1,120,Évaporation,203,100,7,1,2,1
+20165,3,47640,1,120,Évaporation,203,100,7,1,3,1
+20166,3,47640,1,120,Évaporation,203,100,7,1,4,1
+20167,3,50000,1,112,Honnête Blade of Purity,203,1,7,4,4,1
+20168,3,50000,1,115,Saber of Fedeltà,203,1,7,4,4,1
+20169,3,50000,1,116,Holy War Sphidante Blade,203,95,7,4,4,1
+20170,3,50000,1,118,Blade of Vainqueur,203,95,7,4,4,1
+19679,3,50000,1,100,Iskandar Seals,204,90,5,1,0,1
+19680,3,50000,1,100,Iskandar Seals,204,90,5,1,1,1
+19681,3,50000,1,100,Iskandar Seals,204,90,5,1,2,1
+19682,3,50000,1,100,Iskandar Seals,204,90,5,1,3,1
+19683,3,50000,1,100,Iskandar Seals,204,90,5,1,4,1
+19684,3,50000,1,90,Adamas Military Expedition Wall,204,1,5,4,4,1
+19685,3,50000,1,93,Wall of Agitator,204,1,5,4,4,1
+19813,3,31900,1,100,Red Dawn's Steel Guard,204,90,5,1,0,1
+19814,3,31900,1,100,Red Dawn's Steel Guard,204,90,5,1,1,1
+19815,3,31900,1,100,Red Dawn's Steel Guard,204,90,5,1,2,1
+19816,3,31900,1,100,Red Dawn's Steel Guard,204,90,5,1,3,1
+19817,3,31900,1,100,Red Dawn's Steel Guard,204,90,5,1,4,1
+19818,3,33495,1,105,Wall of Vermilion,204,93,5,1,0,1
+19819,3,33495,1,105,Wall of Vermilion,204,93,5,1,1,1
+19820,3,33495,1,105,Wall of Vermilion,204,93,5,1,2,1
+19821,3,33495,1,105,Wall of Vermilion,204,93,5,1,3,1
+19822,3,33495,1,105,Wall of Vermilion,204,93,5,1,4,1
+19823,3,34452,1,108,Dúva's Wall,204,95,5,1,0,1
+19824,3,34452,1,108,Dúva's Wall,204,95,5,1,1,1
+19825,3,34452,1,108,Dúva's Wall,204,95,5,1,2,1
+19826,3,34452,1,108,Dúva's Wall,204,95,5,1,3,1
+19827,3,34452,1,108,Dúva's Wall,204,95,5,1,4,1
+19828,3,35090,1,110,Fort of Fonse,204,95,5,1,0,1
+19829,3,35090,1,110,Fort of Fonse,204,95,5,1,1,1
+19830,3,35090,1,110,Fort of Fonse,204,95,5,1,2,1
+19831,3,35090,1,110,Fort of Fonse,204,95,5,1,3,1
+19832,3,35090,1,110,Fort of Fonse,204,95,5,1,4,1
+19833,3,50000,1,102,Intellect's Weise Scutum,204,1,5,4,4,1
+19834,3,50000,1,105,Wall of Kenntnis,204,1,5,4,4,1
+19835,3,50000,1,106,Scutum of Glowing Embers,204,90,5,4,4,1
+19836,3,50000,1,108,Fort of Altesch,204,90,5,4,4,1
+20171,3,35090,1,110,Wall of Altura,204,95,5,1,0,1
+20172,3,35090,1,110,Wall of Altura,204,95,5,1,1,1
+20173,3,35090,1,110,Wall of Altura,204,95,5,1,2,1
+20174,3,35090,1,110,Wall of Altura,204,95,5,1,3,1
+20175,3,35090,1,110,Wall of Altura,204,95,5,1,4,1
+20176,3,36685,1,115,Rousing Schlucht Guard,204,98,5,1,0,1
+20177,3,36685,1,115,Rousing Schlucht Guard,204,98,5,1,1,1
+20178,3,36685,1,115,Rousing Schlucht Guard,204,98,5,1,2,1
+20179,3,36685,1,115,Rousing Schlucht Guard,204,98,5,1,3,1
+20180,3,36685,1,115,Rousing Schlucht Guard,204,98,5,1,4,1
+20181,3,37642,1,118,Plaisance Wall,204,100,5,1,0,1
+20182,3,37642,1,118,Plaisance Wall,204,100,5,1,1,1
+20183,3,37642,1,118,Plaisance Wall,204,100,5,1,2,1
+20184,3,37642,1,118,Plaisance Wall,204,100,5,1,3,1
+20185,3,37642,1,118,Plaisance Wall,204,100,5,1,4,1
+20186,3,38280,1,120,Volcan,204,100,5,1,0,1
+20187,3,38280,1,120,Volcan,204,100,5,1,1,1
+20188,3,38280,1,120,Volcan,204,100,5,1,2,1
+20189,3,38280,1,120,Volcan,204,100,5,1,3,1
+20190,3,38280,1,120,Volcan,204,100,5,1,4,1
+20191,3,50000,1,112,Honnête Guard of Purity,204,1,5,4,4,1
+20192,3,50000,1,115,Wall of Fedeltà,204,1,5,4,4,1
+20193,3,50000,1,116,Holy War Sphidante Guard,204,95,5,4,4,1
+20194,3,50000,1,118,Wall of Vainqueur,204,95,5,4,4,1
+19693,3,50000,1,100,Arshak's Throes,206,90,2,1,0,1
+19694,3,50000,1,100,Arshak's Throes,206,90,2,1,1,1
+19695,3,50000,1,100,Arshak's Throes,206,90,2,1,2,1
+19696,3,50000,1,100,Arshak's Throes,206,90,2,1,3,1
+19697,3,50000,1,100,Arshak's Throes,206,90,2,1,4,1
+19698,3,50000,1,90,Adamas Military Expedition Daggers,206,1,2,4,4,1
+19699,3,50000,1,93,Daggers of Agitator,206,1,2,4,4,1
+19859,3,39700,1,100,Red Dawn's Steel Daggers,206,90,2,1,0,1
+19860,3,39700,1,100,Red Dawn's Steel Daggers,206,90,2,1,1,1
+19861,3,39700,1,100,Red Dawn's Steel Daggers,206,90,2,1,2,1
+19862,3,39700,1,100,Red Dawn's Steel Daggers,206,90,2,1,3,1
+19863,3,39700,1,100,Red Dawn's Steel Daggers,206,90,2,1,4,1
+19864,3,41685,1,105,Edge of Vermilion,206,93,2,1,0,1
+19865,3,41685,1,105,Edge of Vermilion,206,93,2,1,1,1
+19866,3,41685,1,105,Edge of Vermilion,206,93,2,1,2,1
+19867,3,41685,1,105,Edge of Vermilion,206,93,2,1,3,1
+19868,3,41685,1,105,Edge of Vermilion,206,93,2,1,4,1
+19869,3,42876,1,108,Afet Baselards,206,95,2,1,0,1
+19870,3,42876,1,108,Afet Baselards,206,95,2,1,1,1
+19871,3,42876,1,108,Afet Baselards,206,95,2,1,2,1
+19872,3,42876,1,108,Afet Baselards,206,95,2,1,3,1
+19873,3,42876,1,108,Afet Baselards,206,95,2,1,4,1
+19874,3,43670,1,110,Daggers of Ombre,206,95,2,1,0,1
+19875,3,43670,1,110,Daggers of Ombre,206,95,2,1,1,1
+19876,3,43670,1,110,Daggers of Ombre,206,95,2,1,2,1
+19877,3,43670,1,110,Daggers of Ombre,206,95,2,1,3,1
+19878,3,43670,1,110,Daggers of Ombre,206,95,2,1,4,1
+19879,3,50000,1,102,Intellect's Weise Daggers,206,1,2,4,4,1
+19880,3,50000,1,105,Crow of Kenntnis,206,1,2,4,4,1
+19881,3,50000,1,106,Cinquedea of Glowing Embers,206,90,2,4,4,1
+19882,3,50000,1,108,Daggers of Altesch,206,90,2,4,4,1
+20217,3,43670,1,110,Daggers of Altura,206,95,2,1,0,1
+20218,3,43670,1,110,Daggers of Altura,206,95,2,1,1,1
+20219,3,43670,1,110,Daggers of Altura,206,95,2,1,2,1
+20220,3,43670,1,110,Daggers of Altura,206,95,2,1,3,1
+20221,3,43670,1,110,Daggers of Altura,206,95,2,1,4,1
+20222,3,45655,1,115,Rousing Schlucht Daggers,206,98,2,1,0,1
+20223,3,45655,1,115,Rousing Schlucht Daggers,206,98,2,1,1,1
+20224,3,45655,1,115,Rousing Schlucht Daggers,206,98,2,1,2,1
+20225,3,45655,1,115,Rousing Schlucht Daggers,206,98,2,1,3,1
+20226,3,45655,1,115,Rousing Schlucht Daggers,206,98,2,1,4,1
+20227,3,46846,1,118,Cruel Daggers,206,100,2,1,0,1
+20228,3,46846,1,118,Cruel Daggers,206,100,2,1,1,1
+20229,3,46846,1,118,Cruel Daggers,206,100,2,1,2,1
+20230,3,46846,1,118,Cruel Daggers,206,100,2,1,3,1
+20231,3,46846,1,118,Cruel Daggers,206,100,2,1,4,1
+20232,3,47640,1,120,Jaria,206,100,2,1,0,1
+20233,3,47640,1,120,Jaria,206,100,2,1,1,1
+20234,3,47640,1,120,Jaria,206,100,2,1,2,1
+20235,3,47640,1,120,Jaria,206,100,2,1,3,1
+20236,3,47640,1,120,Jaria,206,100,2,1,4,1
+20237,3,50000,1,112,Honnête Daggers of Purity,206,1,2,4,4,1
+20238,3,50000,1,115,Daggers of Fedeltà,206,1,2,4,4,1
+20239,3,50000,1,116,Holy War Sphidante Daggers,206,95,2,4,4,1
+20240,3,50000,1,118,Crow of Vainqueur,206,95,2,4,4,1
+19700,3,50000,1,100,Jamshid Dart,207,90,3,1,0,1
+19701,3,50000,1,100,Jamshid Dart,207,90,3,1,1,1
+19702,3,50000,1,100,Jamshid Dart,207,90,3,1,2,1
+19703,3,50000,1,100,Jamshid Dart,207,90,3,1,3,1
+19704,3,50000,1,100,Jamshid Dart,207,90,3,1,4,1
+19705,3,50000,1,90,Adamas Military Expedition Bow,207,1,3,4,4,1
+19706,3,50000,1,93,Arrow of Agitator,207,1,3,4,4,1
+19883,3,39700,1,100,Red Dawn's Steel Bow,207,90,3,1,0,1
+19884,3,39700,1,100,Red Dawn's Steel Bow,207,90,3,1,1,1
+19885,3,39700,1,100,Red Dawn's Steel Bow,207,90,3,1,2,1
+19886,3,39700,1,100,Red Dawn's Steel Bow,207,90,3,1,3,1
+19887,3,39700,1,100,Red Dawn's Steel Bow,207,90,3,1,4,1
+19888,3,41685,1,105,Bow of Vermilion,207,93,3,1,0,1
+19889,3,41685,1,105,Bow of Vermilion,207,93,3,1,1,1
+19890,3,41685,1,105,Bow of Vermilion,207,93,3,1,2,1
+19891,3,41685,1,105,Bow of Vermilion,207,93,3,1,3,1
+19892,3,41685,1,105,Bow of Vermilion,207,93,3,1,4,1
+19893,3,42876,1,108,Funeri Bow,207,95,3,1,0,1
+19894,3,42876,1,108,Funeri Bow,207,95,3,1,1,1
+19895,3,42876,1,108,Funeri Bow,207,95,3,1,2,1
+19896,3,42876,1,108,Funeri Bow,207,95,3,1,3,1
+19897,3,42876,1,108,Funeri Bow,207,95,3,1,4,1
+19898,3,43670,1,110,Bow of Tourbillon,207,95,3,1,0,1
+19899,3,43670,1,110,Bow of Tourbillon,207,95,3,1,1,1
+19900,3,43670,1,110,Bow of Tourbillon,207,95,3,1,2,1
+19901,3,43670,1,110,Bow of Tourbillon,207,95,3,1,3,1
+19902,3,43670,1,110,Bow of Tourbillon,207,95,3,1,4,1
+19903,3,50000,1,102,Intellect's Weise Arrow,207,1,3,4,4,1
+19904,3,50000,1,105,Bow of Kenntnis,207,1,3,4,4,1
+19905,3,50000,1,106,Longbow of Glowing Embers,207,90,3,4,4,1
+19906,3,50000,1,108,Arrow of Altesch,207,90,3,4,4,1
+20241,3,43670,1,110,Arrow of Altura,207,95,3,1,0,1
+20242,3,43670,1,110,Arrow of Altura,207,95,3,1,1,1
+20243,3,43670,1,110,Arrow of Altura,207,95,3,1,2,1
+20244,3,43670,1,110,Arrow of Altura,207,95,3,1,3,1
+20245,3,43670,1,110,Arrow of Altura,207,95,3,1,4,1
+20246,3,45655,1,115,Rousing Schlucht Bow,207,98,3,1,0,1
+20247,3,45655,1,115,Rousing Schlucht Bow,207,98,3,1,1,1
+20248,3,45655,1,115,Rousing Schlucht Bow,207,98,3,1,2,1
+20249,3,45655,1,115,Rousing Schlucht Bow,207,98,3,1,3,1
+20250,3,45655,1,115,Rousing Schlucht Bow,207,98,3,1,4,1
+20251,3,46846,1,118,Anstaing Bow,207,100,3,1,0,1
+20252,3,46846,1,118,Anstaing Bow,207,100,3,1,1,1
+20253,3,46846,1,118,Anstaing Bow,207,100,3,1,2,1
+20254,3,46846,1,118,Anstaing Bow,207,100,3,1,3,1
+20255,3,46846,1,118,Anstaing Bow,207,100,3,1,4,1
+20256,3,47640,1,120,Enfer,207,100,3,1,0,1
+20257,3,47640,1,120,Enfer,207,100,3,1,1,1
+20258,3,47640,1,120,Enfer,207,100,3,1,2,1
+20259,3,47640,1,120,Enfer,207,100,3,1,3,1
+20260,3,47640,1,120,Enfer,207,100,3,1,4,1
+20261,3,50000,1,112,Honnête Bow of Purity,207,1,3,4,4,1
+20262,3,50000,1,115,Bow of Fedeltà,207,1,3,4,4,1
+20263,3,50000,1,116,Holy War Sphidante Bow,207,95,3,4,4,1
+20264,3,50000,1,118,Arrow of Vainqueur,207,95,3,4,4,1
+19707,3,50000,1,100,Haiz Fereydun,208,90,9,1,0,1
+19708,3,50000,1,100,Haiz Fereydun,208,90,9,1,1,1
+19709,3,50000,1,100,Haiz Fereydun,208,90,9,1,2,1
+19710,3,50000,1,100,Haiz Fereydun,208,90,9,1,3,1
+19711,3,50000,1,100,Haiz Fereydun,208,90,9,1,4,1
+19712,3,50000,1,90,Adamas Military Expedition Arm,208,1,9,4,4,1
+19713,3,50000,1,93,Hands of Agitator,208,1,9,4,4,1
+19907,3,39700,1,100,Red Dawn's Steel Arm,208,90,9,1,0,1
+19908,3,39700,1,100,Red Dawn's Steel Arm,208,90,9,1,1,1
+19909,3,39700,1,100,Red Dawn's Steel Arm,208,90,9,1,2,1
+19910,3,39700,1,100,Red Dawn's Steel Arm,208,90,9,1,3,1
+19911,3,39700,1,100,Red Dawn's Steel Arm,208,90,9,1,4,1
+19912,3,41685,1,105,Hand of Vermilion,208,93,9,1,0,1
+19913,3,41685,1,105,Hand of Vermilion,208,93,9,1,1,1
+19914,3,41685,1,105,Hand of Vermilion,208,93,9,1,2,1
+19915,3,41685,1,105,Hand of Vermilion,208,93,9,1,3,1
+19916,3,41685,1,105,Hand of Vermilion,208,93,9,1,4,1
+19917,3,42876,1,108,Lux's Gauntlet,208,95,9,1,0,1
+19918,3,42876,1,108,Lux's Gauntlet,208,95,9,1,1,1
+19919,3,42876,1,108,Lux's Gauntlet,208,95,9,1,2,1
+19920,3,42876,1,108,Lux's Gauntlet,208,95,9,1,3,1
+19921,3,42876,1,108,Lux's Gauntlet,208,95,9,1,4,1
+19922,3,43670,1,110,Arm of Grace,208,95,9,1,0,1
+19923,3,43670,1,110,Arm of Grace,208,95,9,1,1,1
+19924,3,43670,1,110,Arm of Grace,208,95,9,1,2,1
+19925,3,43670,1,110,Arm of Grace,208,95,9,1,3,1
+19926,3,43670,1,110,Arm of Grace,208,95,9,1,4,1
+19927,3,50000,1,102,Intellect's Weise Glove,208,1,9,4,4,1
+19928,3,50000,1,105,Hand of Kenntnis,208,1,9,4,4,1
+19929,3,50000,1,106,Gauntlet of Glowing Embers,208,90,9,4,4,1
+19930,3,50000,1,108,Arm of Altesch,208,90,9,4,4,1
+20265,3,43670,1,110,Hand of Altura,208,95,9,1,0,1
+20266,3,43670,1,110,Hand of Altura,208,95,9,1,1,1
+20267,3,43670,1,110,Hand of Altura,208,95,9,1,2,1
+20268,3,43670,1,110,Hand of Altura,208,95,9,1,3,1
+20269,3,43670,1,110,Hand of Altura,208,95,9,1,4,1
+20270,3,45655,1,115,Rousing Schlucht Arm,208,98,9,1,0,1
+20271,3,45655,1,115,Rousing Schlucht Arm,208,98,9,1,1,1
+20272,3,45655,1,115,Rousing Schlucht Arm,208,98,9,1,2,1
+20273,3,45655,1,115,Rousing Schlucht Arm,208,98,9,1,3,1
+20274,3,45655,1,115,Rousing Schlucht Arm,208,98,9,1,4,1
+20275,3,46846,1,118,Avare Gauntlet,208,100,9,1,0,1
+20276,3,46846,1,118,Avare Gauntlet,208,100,9,1,1,1
+20277,3,46846,1,118,Avare Gauntlet,208,100,9,1,2,1
+20278,3,46846,1,118,Avare Gauntlet,208,100,9,1,3,1
+20279,3,46846,1,118,Avare Gauntlet,208,100,9,1,4,1
+20280,3,47640,1,120,Explosion,208,100,9,1,0,1
+20281,3,47640,1,120,Explosion,208,100,9,1,1,1
+20282,3,47640,1,120,Explosion,208,100,9,1,2,1
+20283,3,47640,1,120,Explosion,208,100,9,1,3,1
+20284,3,47640,1,120,Explosion,208,100,9,1,4,1
+20285,3,50000,1,112,Honnête Glove of Purity,208,1,9,4,4,1
+20286,3,50000,1,115,Arm of Fedeltà,208,1,9,4,4,1
+20287,3,50000,1,116,Holy War Sphidante Arms,208,95,9,4,4,1
+20288,3,50000,1,118,Hand of Vainqueur,208,95,9,4,4,1
+19714,3,50000,1,100,Blessed Ardashir,209,90,8,1,0,1
+19715,3,50000,1,100,Blessed Ardashir,209,90,8,1,1,1
+19716,3,50000,1,100,Blessed Ardashir,209,90,8,1,2,1
+19717,3,50000,1,100,Blessed Ardashir,209,90,8,1,3,1
+19718,3,50000,1,100,Blessed Ardashir,209,90,8,1,4,1
+19719,3,50000,1,90,Adamas Military Expedition Shooter,209,1,8,4,4,1
+19720,3,50000,1,93,Spell of Agitator,209,1,8,4,4,1
+19931,3,39700,1,100,Red Dawn's Steel Shooter,209,90,8,1,0,1
+19932,3,39700,1,100,Red Dawn's Steel Shooter,209,90,8,1,1,1
+19933,3,39700,1,100,Red Dawn's Steel Shooter,209,90,8,1,2,1
+19934,3,39700,1,100,Red Dawn's Steel Shooter,209,90,8,1,3,1
+19935,3,39700,1,100,Red Dawn's Steel Shooter,209,90,8,1,4,1
+19936,3,41685,1,105,Spell of Vermilion,209,93,8,1,0,1
+19937,3,41685,1,105,Spell of Vermilion,209,93,8,1,1,1
+19938,3,41685,1,105,Spell of Vermilion,209,93,8,1,2,1
+19939,3,41685,1,105,Spell of Vermilion,209,93,8,1,3,1
+19940,3,41685,1,105,Spell of Vermilion,209,93,8,1,4,1
+19941,3,42876,1,108,Jinas Shooter,209,95,8,1,0,1
+19942,3,42876,1,108,Jinas Shooter,209,95,8,1,1,1
+19943,3,42876,1,108,Jinas Shooter,209,95,8,1,2,1
+19944,3,42876,1,108,Jinas Shooter,209,95,8,1,3,1
+19945,3,42876,1,108,Jinas Shooter,209,95,8,1,4,1
+19946,3,43670,1,110,Spell of Typhoon,209,95,8,1,0,1
+19947,3,43670,1,110,Spell of Typhoon,209,95,8,1,1,1
+19948,3,43670,1,110,Spell of Typhoon,209,95,8,1,2,1
+19949,3,43670,1,110,Spell of Typhoon,209,95,8,1,3,1
+19950,3,43670,1,110,Spell of Typhoon,209,95,8,1,4,1
+19951,3,50000,1,102,Intellect's Weise Shooter,209,1,8,4,4,1
+19952,3,50000,1,105,Spell of Kenntnis,209,1,8,4,4,1
+19953,3,50000,1,106,Twin Shooter of Glowing Embers,209,90,8,4,4,1
+19954,3,50000,1,108,Spell of Altesch,209,90,8,4,4,1
+20289,3,43670,1,110,Spell of Altura,209,95,8,1,0,1
+20290,3,43670,1,110,Spell of Altura,209,95,8,1,1,1
+20291,3,43670,1,110,Spell of Altura,209,95,8,1,2,1
+20292,3,43670,1,110,Spell of Altura,209,95,8,1,3,1
+20293,3,43670,1,110,Spell of Altura,209,95,8,1,4,1
+20294,3,45655,1,115,Rousing Schlucht Shooter,209,98,8,1,0,1
+20295,3,45655,1,115,Rousing Schlucht Shooter,209,98,8,1,1,1
+20296,3,45655,1,115,Rousing Schlucht Shooter,209,98,8,1,2,1
+20297,3,45655,1,115,Rousing Schlucht Shooter,209,98,8,1,3,1
+20298,3,45655,1,115,Rousing Schlucht Shooter,209,98,8,1,4,1
+20299,3,46846,1,118,Réverie Shooter,209,100,8,1,0,1
+20300,3,46846,1,118,Réverie Shooter,209,100,8,1,1,1
+20301,3,46846,1,118,Réverie Shooter,209,100,8,1,2,1
+20302,3,46846,1,118,Réverie Shooter,209,100,8,1,3,1
+20303,3,46846,1,118,Réverie Shooter,209,100,8,1,4,1
+20304,3,47640,1,120,Purgatoire,209,100,8,1,0,1
+20305,3,47640,1,120,Purgatoire,209,100,8,1,1,1
+20306,3,47640,1,120,Purgatoire,209,100,8,1,2,1
+20307,3,47640,1,120,Purgatoire,209,100,8,1,3,1
+20308,3,47640,1,120,Purgatoire,209,100,8,1,4,1
+20309,3,50000,1,112,Honnête Shooter of Purity,209,1,8,4,4,1
+20310,3,50000,1,115,Spell of Fedeltà,209,1,8,4,4,1
+20311,3,50000,1,116,Holy War Sphidante Shooter,209,95,8,4,4,1
+20312,3,50000,1,118,Spell of Vainqueur,209,95,8,4,4,1
+19721,3,50000,1,100,Saar's Vessel,211,90,4,1,0,1
+19722,3,50000,1,100,Saar's Vessel,211,90,4,1,1,1
+19723,3,50000,1,100,Saar's Vessel,211,90,4,1,2,1
+19724,3,50000,1,100,Saar's Vessel,211,90,4,1,3,1
+19725,3,50000,1,100,Saar's Vessel,211,90,4,1,4,1
+19726,3,50000,1,90,Adamas Military Expedition Staff,211,1,4,4,4,1
+19727,3,50000,1,93,Staff of Agitator,211,1,4,4,4,1
+19955,3,39700,1,100,Red Dawn's Steel Cane,211,90,4,1,0,1
+19956,3,39700,1,100,Red Dawn's Steel Cane,211,90,4,1,1,1
+19957,3,39700,1,100,Red Dawn's Steel Cane,211,90,4,1,2,1
+19958,3,39700,1,100,Red Dawn's Steel Cane,211,90,4,1,3,1
+19959,3,39700,1,100,Red Dawn's Steel Cane,211,90,4,1,4,1
+19960,3,41685,1,105,Staff of Vermilion,211,93,4,1,0,1
+19961,3,41685,1,105,Staff of Vermilion,211,93,4,1,1,1
+19962,3,41685,1,105,Staff of Vermilion,211,93,4,1,2,1
+19963,3,41685,1,105,Staff of Vermilion,211,93,4,1,3,1
+19964,3,41685,1,105,Staff of Vermilion,211,93,4,1,4,1
+19965,3,42876,1,108,Youches' Staff,211,95,4,1,0,1
+19966,3,42876,1,108,Youches' Staff,211,95,4,1,1,1
+19967,3,42876,1,108,Youches' Staff,211,95,4,1,2,1
+19968,3,42876,1,108,Youches' Staff,211,95,4,1,3,1
+19969,3,42876,1,108,Youches' Staff,211,95,4,1,4,1
+19970,3,43670,1,110,Cane of Lumiere,211,95,4,1,0,1
+19971,3,43670,1,110,Cane of Lumiere,211,95,4,1,1,1
+19972,3,43670,1,110,Cane of Lumiere,211,95,4,1,2,1
+19973,3,43670,1,110,Cane of Lumiere,211,95,4,1,3,1
+19974,3,43670,1,110,Cane of Lumiere,211,95,4,1,4,1
+19975,3,50000,1,102,Intellect's Weise Cane,211,1,4,4,4,1
+19976,3,50000,1,105,Staff of Kenntnis,211,1,4,4,4,1
+19977,3,50000,1,106,Spine Cane of Glowing Embers,211,90,4,4,4,1
+19978,3,50000,1,108,Staff of Altesch,211,90,4,4,4,1
+20313,3,43670,1,110,Staff of Altura,211,95,4,1,0,1
+20314,3,43670,1,110,Staff of Altura,211,95,4,1,1,1
+20315,3,43670,1,110,Staff of Altura,211,95,4,1,2,1
+20316,3,43670,1,110,Staff of Altura,211,95,4,1,3,1
+20317,3,43670,1,110,Staff of Altura,211,95,4,1,4,1
+20318,3,45655,1,115,Rousing Schlucht Cane,211,98,4,1,0,1
+20319,3,45655,1,115,Rousing Schlucht Cane,211,98,4,1,1,1
+20320,3,45655,1,115,Rousing Schlucht Cane,211,98,4,1,2,1
+20321,3,45655,1,115,Rousing Schlucht Cane,211,98,4,1,3,1
+20322,3,45655,1,115,Rousing Schlucht Cane,211,98,4,1,4,1
+20323,3,46846,1,118,Genereux Staff,211,100,4,1,0,1
+20324,3,46846,1,118,Genereux Staff,211,100,4,1,1,1
+20325,3,46846,1,118,Genereux Staff,211,100,4,1,2,1
+20326,3,46846,1,118,Genereux Staff,211,100,4,1,3,1
+20327,3,46846,1,118,Genereux Staff,211,100,4,1,4,1
+20328,3,47640,1,120,Chaleur,211,100,4,1,0,1
+20329,3,47640,1,120,Chaleur,211,100,4,1,1,1
+20330,3,47640,1,120,Chaleur,211,100,4,1,2,1
+20331,3,47640,1,120,Chaleur,211,100,4,1,3,1
+20332,3,47640,1,120,Chaleur,211,100,4,1,4,1
+20337,3,50000,1,112,Honnête Cane of Purity,211,1,4,4,4,1
+20342,3,50000,1,115,Staff of Fedeltà,211,1,4,4,4,1
+20343,3,50000,1,116,Holy War Sphidante Cane,211,95,4,4,4,1
+20344,3,50000,1,118,Staff of Vainqueur,211,95,4,4,4,1
+19728,3,50000,1,100,Magicka Shapur,212,90,6,1,0,1
+19729,3,50000,1,100,Magicka Shapur,212,90,6,1,1,1
+19730,3,50000,1,100,Magicka Shapur,212,90,6,1,2,1
+19731,3,50000,1,100,Magicka Shapur,212,90,6,1,3,1
+19732,3,50000,1,100,Magicka Shapur,212,90,6,1,4,1
+19733,3,50000,1,90,Adamas Military Expedition Wand,212,1,6,4,4,1
+19734,3,50000,1,93,Wand of Agitator,212,1,6,4,4,1
+19979,3,39700,1,100,Red Dawn's Steel Wand,212,90,6,1,0,1
+19980,3,39700,1,100,Red Dawn's Steel Wand,212,90,6,1,1,1
+19981,3,39700,1,100,Red Dawn's Steel Wand,212,90,6,1,2,1
+19982,3,39700,1,100,Red Dawn's Steel Wand,212,90,6,1,3,1
+19983,3,39700,1,100,Red Dawn's Steel Wand,212,90,6,1,4,1
+19984,3,41685,1,105,Wand of Vermilion,212,93,6,1,0,1
+19985,3,41685,1,105,Wand of Vermilion,212,93,6,1,1,1
+19986,3,41685,1,105,Wand of Vermilion,212,93,6,1,2,1
+19987,3,41685,1,105,Wand of Vermilion,212,93,6,1,3,1
+19988,3,41685,1,105,Wand of Vermilion,212,93,6,1,4,1
+19989,3,42876,1,108,Garip's Wand,212,95,6,1,0,1
+19990,3,42876,1,108,Garip's Wand,212,95,6,1,1,1
+19991,3,42876,1,108,Garip's Wand,212,95,6,1,2,1
+19992,3,42876,1,108,Garip's Wand,212,95,6,1,3,1
+19993,3,42876,1,108,Garip's Wand,212,95,6,1,4,1
+19994,3,43670,1,110,Wand of La Mer,212,95,6,1,0,1
+19995,3,43670,1,110,Wand of La Mer,212,95,6,1,1,1
+19996,3,43670,1,110,Wand of La Mer,212,95,6,1,2,1
+19997,3,43670,1,110,Wand of La Mer,212,95,6,1,3,1
+19998,3,43670,1,110,Wand of La Mer,212,95,6,1,4,1
+19999,3,50000,1,102,Intellect's Weise Wand,212,1,6,4,4,1
+20000,3,50000,1,105,Wand of Kenntnis,212,1,6,4,4,1
+20001,3,50000,1,106,Magias Wand of Glowing Embers,212,90,6,4,4,1
+20002,3,50000,1,108,Wand of Altesch,212,90,6,4,4,1
+20345,3,43670,1,110,Wand of Altura,212,95,6,1,0,1
+20346,3,43670,1,110,Wand of Altura,212,95,6,1,1,1
+20347,3,43670,1,110,Wand of Altura,212,95,6,1,2,1
+20348,3,43670,1,110,Wand of Altura,212,95,6,1,3,1
+20349,3,43670,1,110,Wand of Altura,212,95,6,1,4,1
+20350,3,45655,1,115,Rousing Schlucht Wand,212,98,6,1,0,1
+20351,3,45655,1,115,Rousing Schlucht Wand,212,98,6,1,1,1
+20352,3,45655,1,115,Rousing Schlucht Wand,212,98,6,1,2,1
+20353,3,45655,1,115,Rousing Schlucht Wand,212,98,6,1,3,1
+20354,3,45655,1,115,Rousing Schlucht Wand,212,98,6,1,4,1
+20355,3,46846,1,118,Sagesse Wand,212,100,6,1,0,1
+20356,3,46846,1,118,Sagesse Wand,212,100,6,1,1,1
+20357,3,46846,1,118,Sagesse Wand,212,100,6,1,2,1
+20358,3,46846,1,118,Sagesse Wand,212,100,6,1,3,1
+20359,3,46846,1,118,Sagesse Wand,212,100,6,1,4,1
+20360,3,47640,1,120,Désastre,212,100,6,1,0,1
+20361,3,47640,1,120,Désastre,212,100,6,1,1,1
+20362,3,47640,1,120,Désastre,212,100,6,1,2,1
+20363,3,47640,1,120,Désastre,212,100,6,1,3,1
+20364,3,47640,1,120,Désastre,212,100,6,1,4,1
+20369,3,50000,1,112,Honnête Wand of Purity,212,1,6,4,4,1
+20370,3,50000,1,115,Wand of Fedeltà,212,1,6,4,4,1
+20371,3,50000,1,116,Holy War Sphidante Wand,212,95,6,4,4,1
+20372,3,50000,1,118,Wand of Vainqueur,212,95,6,4,4,1
+19735,3,50000,1,100,Hoshang's Scythe,213,90,10,1,0,1
+19736,3,50000,1,100,Hoshang's Scythe,213,90,10,1,1,1
+19737,3,50000,1,100,Hoshang's Scythe,213,90,10,1,2,1
+19738,3,50000,1,100,Hoshang's Scythe,213,90,10,1,3,1
+19739,3,50000,1,100,Hoshang's Scythe,213,90,10,1,4,1
+19740,3,50000,1,90,Adamas Military Expedition Lance,213,1,10,4,4,1
+19741,3,50000,1,93,Lance of Agitator,213,1,10,4,4,1
+20003,3,39700,1,100,Red Dawn's Steel Lance,213,90,10,1,0,1
+20004,3,39700,1,100,Red Dawn's Steel Lance,213,90,10,1,1,1
+20005,3,39700,1,100,Red Dawn's Steel Lance,213,90,10,1,2,1
+20006,3,39700,1,100,Red Dawn's Steel Lance,213,90,10,1,3,1
+20007,3,39700,1,100,Red Dawn's Steel Lance,213,90,10,1,4,1
+20008,3,41685,1,105,Lance of Vermilion,213,93,10,1,0,1
+20009,3,41685,1,105,Lance of Vermilion,213,93,10,1,1,1
+20010,3,41685,1,105,Lance of Vermilion,213,93,10,1,2,1
+20011,3,41685,1,105,Lance of Vermilion,213,93,10,1,3,1
+20012,3,41685,1,105,Lance of Vermilion,213,93,10,1,4,1
+20013,3,42876,1,108,Dilime Spear,213,95,10,1,0,1
+20014,3,42876,1,108,Dilime Spear,213,95,10,1,1,1
+20015,3,42876,1,108,Dilime Spear,213,95,10,1,2,1
+20016,3,42876,1,108,Dilime Spear,213,95,10,1,3,1
+20017,3,42876,1,108,Dilime Spear,213,95,10,1,4,1
+20018,3,43670,1,110,Breath of Eclair,213,95,10,1,0,1
+20019,3,43670,1,110,Breath of Eclair,213,95,10,1,1,1
+20020,3,43670,1,110,Breath of Eclair,213,95,10,1,2,1
+20021,3,43670,1,110,Breath of Eclair,213,95,10,1,3,1
+20022,3,43670,1,110,Breath of Eclair,213,95,10,1,4,1
+20023,3,50000,1,102,Intellect's Weise Spear,213,1,10,4,4,1
+20024,3,50000,1,105,Lance of Kenntnis,213,1,10,4,4,1
+20025,3,50000,1,106,Screw Lance of Glowing Embers,213,90,10,4,4,1
+20026,3,50000,1,108,Spear of Altesch,213,90,10,4,4,1
+20373,3,43670,1,110,Lance of Altura,213,95,10,1,0,1
+20374,3,43670,1,110,Lance of Altura,213,95,10,1,1,1
+20375,3,43670,1,110,Lance of Altura,213,95,10,1,2,1
+20376,3,43670,1,110,Lance of Altura,213,95,10,1,3,1
+20377,3,43670,1,110,Lance of Altura,213,95,10,1,4,1
+20378,3,45655,1,115,Rousing Schlucht Spear,213,98,10,1,0,1
+20379,3,45655,1,115,Rousing Schlucht Spear,213,98,10,1,1,1
+20380,3,45655,1,115,Rousing Schlucht Spear,213,98,10,1,2,1
+20381,3,45655,1,115,Rousing Schlucht Spear,213,98,10,1,3,1
+20382,3,45655,1,115,Rousing Schlucht Spear,213,98,10,1,4,1
+20383,3,46846,1,118,Effort Spear,213,100,10,1,0,1
+20384,3,46846,1,118,Effort Spear,213,100,10,1,1,1
+20385,3,46846,1,118,Effort Spear,213,100,10,1,2,1
+20386,3,46846,1,118,Effort Spear,213,100,10,1,3,1
+20387,3,46846,1,118,Effort Spear,213,100,10,1,4,1
+20388,3,47640,1,120,Avalanche,213,100,10,1,0,1
+20389,3,47640,1,120,Avalanche,213,100,10,1,1,1
+20390,3,47640,1,120,Avalanche,213,100,10,1,2,1
+20391,3,47640,1,120,Avalanche,213,100,10,1,3,1
+20392,3,47640,1,120,Avalanche,213,100,10,1,4,1
+20393,3,50000,1,112,Honnête Spear of Purity,213,1,10,4,4,1
+20394,3,50000,1,115,Lance of Fedeltà,213,1,10,4,4,1
+20395,3,50000,1,116,Holy War Sphidante Spear,213,95,10,4,4,1
+20396,3,50000,1,118,Spear of Vainqueur,213,95,10,4,4,1
 20027,3,0,1,1,Scimitar,215,1,11,1,0,1
 20028,3,0,1,2,Scimitar,215,1,11,1,1,1
 20029,3,0,1,3,Scimitar,215,1,11,1,2,1
@@ -9924,93 +9924,93 @@
 20037,3,3970,1,10,Kris,215,50,11,1,0,1
 20038,3,3970,1,11,Kris,215,50,11,1,1,1
 20039,3,3970,1,12,Kris,215,50,11,1,2,1
-20040,3,3970,1,4,Kris,215,50,11,1,3,1
-20041,3,3970,1,14,Kris,215,50,11,1,4,1
-20042,3,13895,1,3,Magias Sword,215,70,11,1,0,1
-20043,3,13895,1,8,Magias Sword,215,70,11,1,1,1
-20044,3,13895,1,8,Magias Sword,215,70,11,1,2,1
-20045,3,13895,1,8,Magias Sword,215,70,11,1,3,1
-20046,3,13895,1,13,Magias Sword,215,70,11,1,4,1
-20047,3,19850,1,2,Fallen Truth,215,75,11,1,0,1
-20048,3,19850,1,2,Fallen Truth,215,75,11,1,1,1
-20049,3,19850,1,7,Fallen Truth,215,75,11,1,2,1
-20050,3,19850,1,7,Fallen Truth,215,75,11,1,3,1
-20051,3,19850,1,12,Fallen Truth,215,75,11,1,4,1
-20052,3,25805,1,1,Auxilia,215,80,11,1,0,1
-20053,3,25805,1,1,Auxilia,215,80,11,1,1,1
-20054,3,25805,1,6,Auxilia,215,80,11,1,2,1
-20055,3,25805,1,0,Auxilia,215,80,11,1,3,1
-20056,3,25805,1,5,Auxilia,215,80,11,1,4,1
-20057,3,35730,1,10,Bastard Sword of Resentment,215,85,11,1,0,1
-20058,3,35730,1,10,Bastard Sword of Resentment,215,85,11,1,1,1
-20059,3,35730,1,10,Bastard Sword of Resentment,215,85,11,1,2,1
-20060,3,35730,1,15,Bastard Sword of Resentment,215,85,11,1,3,1
-20061,3,35730,1,15,Bastard Sword of Resentment,215,85,11,1,4,1
-20062,3,38906,1,2,Bozorg Kaldo,215,90,11,1,0,1
-20063,3,38906,1,2,Bozorg Kaldo,215,90,11,1,1,1
-20064,3,38906,1,2,Bozorg Kaldo,215,90,11,1,2,1
-20065,3,38906,1,2,Bozorg Kaldo,215,90,11,1,3,1
-20066,3,38906,1,2,Bozorg Kaldo,215,90,11,1,4,1
+20040,3,3970,1,20,Kris,215,50,11,1,3,1
+20041,3,3970,1,30,Kris,215,50,11,1,4,1
+20042,3,13895,1,35,Magias Sword,215,70,11,1,0,1
+20043,3,13895,1,40,Magias Sword,215,70,11,1,1,1
+20044,3,13895,1,40,Magias Sword,215,70,11,1,2,1
+20045,3,13895,1,40,Magias Sword,215,70,11,1,3,1
+20046,3,13895,1,45,Magias Sword,215,70,11,1,4,1
+20047,3,19850,1,50,Fallen Truth,215,75,11,1,0,1
+20048,3,19850,1,50,Fallen Truth,215,75,11,1,1,1
+20049,3,19850,1,55,Fallen Truth,215,75,11,1,2,1
+20050,3,19850,1,55,Fallen Truth,215,75,11,1,3,1
+20051,3,19850,1,60,Fallen Truth,215,75,11,1,4,1
+20052,3,25805,1,65,Auxilia,215,80,11,1,0,1
+20053,3,25805,1,65,Auxilia,215,80,11,1,1,1
+20054,3,25805,1,70,Auxilia,215,80,11,1,2,1
+20055,3,25805,1,80,Auxilia,215,80,11,1,3,1
+20056,3,25805,1,85,Auxilia,215,80,11,1,4,1
+20057,3,35730,1,90,Bastard Sword of Resentment,215,85,11,1,0,1
+20058,3,35730,1,90,Bastard Sword of Resentment,215,85,11,1,1,1
+20059,3,35730,1,90,Bastard Sword of Resentment,215,85,11,1,2,1
+20060,3,35730,1,95,Bastard Sword of Resentment,215,85,11,1,3,1
+20061,3,35730,1,95,Bastard Sword of Resentment,215,85,11,1,4,1
+20062,3,38906,1,98,Bozorg Kaldo,215,90,11,1,0,1
+20063,3,38906,1,98,Bozorg Kaldo,215,90,11,1,1,1
+20064,3,38906,1,98,Bozorg Kaldo,215,90,11,1,2,1
+20065,3,38906,1,98,Bozorg Kaldo,215,90,11,1,3,1
+20066,3,38906,1,98,Bozorg Kaldo,215,90,11,1,4,1
 20067,3,100,1,1,Rusted Magick Sword,215,1,11,1,0,1
 21404,3,100,1,1,Rusted Magick Sword,215,1,11,1,1,1
 21405,3,100,1,1,Rusted Magick Sword,215,1,11,1,2,1
 21406,3,100,1,1,Rusted Magick Sword,215,1,11,1,3,1
 21407,3,100,1,1,Rusted Magick Sword,215,1,11,1,4,1
-20072,3,1000,1,4,Polished Saber,215,1,11,1,0,1
-21408,3,1000,1,9,Polished Saber,215,1,11,1,1,1
-21409,3,1000,1,9,Polished Saber,215,1,11,1,2,1
-21410,3,1000,1,14,Polished Saber,215,1,11,1,3,1
-21411,3,1000,1,3,Polished Saber,215,1,11,1,4,1
-20073,3,39700,1,4,Red Dawn's Steel Sword,215,90,11,1,0,1
-20074,3,39700,1,4,Red Dawn's Steel Sword,215,90,11,1,1,1
-20075,3,39700,1,4,Red Dawn's Steel Sword,215,90,11,1,2,1
-20076,3,39700,1,4,Red Dawn's Steel Sword,215,90,11,1,3,1
-20077,3,39700,1,4,Red Dawn's Steel Sword,215,90,11,1,4,1
-20078,3,41685,1,9,Saber of Vermilion,215,93,11,1,0,1
-20079,3,41685,1,9,Saber of Vermilion,215,93,11,1,1,1
-20080,3,41685,1,9,Saber of Vermilion,215,93,11,1,2,1
-20081,3,41685,1,9,Saber of Vermilion,215,93,11,1,3,1
-20082,3,41685,1,9,Saber of Vermilion,215,93,11,1,4,1
-20083,3,42876,1,12,Patlat Edge,215,95,11,1,0,1
-20084,3,42876,1,12,Patlat Edge,215,95,11,1,1,1
-20085,3,42876,1,12,Patlat Edge,215,95,11,1,2,1
-20086,3,42876,1,12,Patlat Edge,215,95,11,1,3,1
-20087,3,42876,1,12,Patlat Edge,215,95,11,1,4,1
-20088,3,43670,1,14,Urughan Kris,215,95,11,1,0,1
-20089,3,43670,1,14,Urughan Kris,215,95,11,1,1,1
-20090,3,43670,1,14,Urughan Kris,215,95,11,1,2,1
-20091,3,43670,1,14,Urughan Kris,215,95,11,1,3,1
-20092,3,43670,1,14,Urughan Kris,215,95,11,1,4,1
-20097,3,50000,1,6,Intellect's Weise Scimitar,215,1,11,4,4,1
-20098,3,50000,1,9,Saif of Kenntnis,215,1,11,4,4,1
-20099,3,50000,1,10,Shamshir of Glowing Embers,215,90,11,4,4,1
-20100,3,50000,1,12,Scimitar of Altesch,215,90,11,4,4,1
-20397,3,43670,1,14,Saif of Altura,215,95,11,1,0,1
-20398,3,43670,1,14,Saif of Altura,215,95,11,1,1,1
-20399,3,43670,1,14,Saif of Altura,215,95,11,1,2,1
-20400,3,43670,1,14,Saif of Altura,215,95,11,1,3,1
-20401,3,43670,1,14,Saif of Altura,215,95,11,1,4,1
-20402,3,45655,1,3,Rousing Schlucht Scimitar,215,98,11,1,0,1
-20403,3,45655,1,3,Rousing Schlucht Scimitar,215,98,11,1,1,1
-20404,3,45655,1,3,Rousing Schlucht Scimitar,215,98,11,1,2,1
-20405,3,45655,1,3,Rousing Schlucht Scimitar,215,98,11,1,3,1
-20406,3,45655,1,3,Rousing Schlucht Scimitar,215,98,11,1,4,1
-20407,3,46846,1,6,Ideal Scimitar,215,100,11,1,0,1
-20408,3,46846,1,6,Ideal Scimitar,215,100,11,1,1,1
-20409,3,46846,1,6,Ideal Scimitar,215,100,11,1,2,1
-20410,3,46846,1,6,Ideal Scimitar,215,100,11,1,3,1
-20411,3,46846,1,6,Ideal Scimitar,215,100,11,1,4,1
-20412,3,47640,1,8,Sublimation,215,100,11,1,0,1
-20413,3,47640,1,8,Sublimation,215,100,11,1,1,1
-20414,3,47640,1,8,Sublimation,215,100,11,1,2,1
-20415,3,47640,1,8,Sublimation,215,100,11,1,3,1
-20416,3,47640,1,8,Sublimation,215,100,11,1,4,1
-20421,3,50000,1,0,Honnête Scimitar of Purity,215,1,11,4,4,1
-20422,3,50000,1,3,Scimitar of Fedeltà,215,1,11,4,4,1
-20423,3,50000,1,4,Holy War Sphidante Scimitar,215,95,11,4,4,1
-20424,3,50000,1,6,Saber of Vainqueur,215,95,11,4,4,1
-21186,3,10000,1,14,3F,203,1,7,4,4,1
-21187,3,10000,1,14,Ainz Ooal Gown,212,1,6,4,4,1
+20072,3,1000,1,20,Polished Saber,215,1,11,1,0,1
+21408,3,1000,1,25,Polished Saber,215,1,11,1,1,1
+21409,3,1000,1,25,Polished Saber,215,1,11,1,2,1
+21410,3,1000,1,30,Polished Saber,215,1,11,1,3,1
+21411,3,1000,1,35,Polished Saber,215,1,11,1,4,1
+20073,3,39700,1,100,Red Dawn's Steel Sword,215,90,11,1,0,1
+20074,3,39700,1,100,Red Dawn's Steel Sword,215,90,11,1,1,1
+20075,3,39700,1,100,Red Dawn's Steel Sword,215,90,11,1,2,1
+20076,3,39700,1,100,Red Dawn's Steel Sword,215,90,11,1,3,1
+20077,3,39700,1,100,Red Dawn's Steel Sword,215,90,11,1,4,1
+20078,3,41685,1,105,Saber of Vermilion,215,93,11,1,0,1
+20079,3,41685,1,105,Saber of Vermilion,215,93,11,1,1,1
+20080,3,41685,1,105,Saber of Vermilion,215,93,11,1,2,1
+20081,3,41685,1,105,Saber of Vermilion,215,93,11,1,3,1
+20082,3,41685,1,105,Saber of Vermilion,215,93,11,1,4,1
+20083,3,42876,1,108,Patlat Edge,215,95,11,1,0,1
+20084,3,42876,1,108,Patlat Edge,215,95,11,1,1,1
+20085,3,42876,1,108,Patlat Edge,215,95,11,1,2,1
+20086,3,42876,1,108,Patlat Edge,215,95,11,1,3,1
+20087,3,42876,1,108,Patlat Edge,215,95,11,1,4,1
+20088,3,43670,1,110,Urughan Kris,215,95,11,1,0,1
+20089,3,43670,1,110,Urughan Kris,215,95,11,1,1,1
+20090,3,43670,1,110,Urughan Kris,215,95,11,1,2,1
+20091,3,43670,1,110,Urughan Kris,215,95,11,1,3,1
+20092,3,43670,1,110,Urughan Kris,215,95,11,1,4,1
+20097,3,50000,1,102,Intellect's Weise Scimitar,215,1,11,4,4,1
+20098,3,50000,1,105,Saif of Kenntnis,215,1,11,4,4,1
+20099,3,50000,1,106,Shamshir of Glowing Embers,215,90,11,4,4,1
+20100,3,50000,1,108,Scimitar of Altesch,215,90,11,4,4,1
+20397,3,43670,1,110,Saif of Altura,215,95,11,1,0,1
+20398,3,43670,1,110,Saif of Altura,215,95,11,1,1,1
+20399,3,43670,1,110,Saif of Altura,215,95,11,1,2,1
+20400,3,43670,1,110,Saif of Altura,215,95,11,1,3,1
+20401,3,43670,1,110,Saif of Altura,215,95,11,1,4,1
+20402,3,45655,1,115,Rousing Schlucht Scimitar,215,98,11,1,0,1
+20403,3,45655,1,115,Rousing Schlucht Scimitar,215,98,11,1,1,1
+20404,3,45655,1,115,Rousing Schlucht Scimitar,215,98,11,1,2,1
+20405,3,45655,1,115,Rousing Schlucht Scimitar,215,98,11,1,3,1
+20406,3,45655,1,115,Rousing Schlucht Scimitar,215,98,11,1,4,1
+20407,3,46846,1,118,Ideal Scimitar,215,100,11,1,0,1
+20408,3,46846,1,118,Ideal Scimitar,215,100,11,1,1,1
+20409,3,46846,1,118,Ideal Scimitar,215,100,11,1,2,1
+20410,3,46846,1,118,Ideal Scimitar,215,100,11,1,3,1
+20411,3,46846,1,118,Ideal Scimitar,215,100,11,1,4,1
+20412,3,47640,1,120,Sublimation,215,100,11,1,0,1
+20413,3,47640,1,120,Sublimation,215,100,11,1,1,1
+20414,3,47640,1,120,Sublimation,215,100,11,1,2,1
+20415,3,47640,1,120,Sublimation,215,100,11,1,3,1
+20416,3,47640,1,120,Sublimation,215,100,11,1,4,1
+20421,3,50000,1,112,Honnête Scimitar of Purity,215,1,11,4,4,1
+20422,3,50000,1,115,Scimitar of Fedeltà,215,1,11,4,4,1
+20423,3,50000,1,116,Holy War Sphidante Scimitar,215,95,11,4,4,1
+20424,3,50000,1,118,Saber of Vainqueur,215,95,11,4,4,1
+21186,3,10000,1,94,3F,203,1,7,4,4,1
+21187,3,10000,1,94,Ainz Ooal Gown,212,1,6,4,4,1
 21412,3,200,1,1,Conspicuous Rusted Magick Sword,215,1,11,1,0,1
 21413,3,200,1,1,Conspicuous Rusted Magick Sword,215,1,11,1,1,1
 21414,3,200,1,1,Conspicuous Rusted Magick Sword,215,1,11,1,2,1
@@ -10026,410 +10026,410 @@
 21424,3,200,1,3,Conspicuous Rusted Magick Sword,215,1,11,1,2,1
 21425,3,200,1,3,Conspicuous Rusted Magick Sword,215,1,11,1,3,1
 21426,3,200,1,3,Conspicuous Rusted Magick Sword,215,1,11,1,4,1
-21427,3,20000,1,2,Crimson Firangi,215,1,11,1,0,1
-21428,3,20000,1,7,Crimson Firangi,215,1,11,1,1,1
-21429,3,20000,1,7,Crimson Firangi,215,1,11,1,2,1
-21430,3,20000,1,12,Crimson Firangi,215,1,11,1,3,1
-21431,3,20000,1,1,Crimson Firangi,215,1,11,1,4,1
-21432,3,20000,1,7,Crimson Firangi,215,1,11,1,0,1
-21433,3,20000,1,12,Crimson Firangi,215,1,11,1,1,1
-21434,3,20000,1,12,Crimson Firangi,215,1,11,1,2,1
-21435,3,20000,1,1,Crimson Firangi,215,1,11,1,3,1
-21436,3,20000,1,6,Crimson Firangi,215,1,11,1,4,1
-21437,3,20000,1,12,Crimson Firangi,215,1,11,1,0,1
-21438,3,20000,1,1,Crimson Firangi,215,1,11,1,1,1
-21439,3,20000,1,1,Crimson Firangi,215,1,11,1,2,1
-21440,3,20000,1,6,Crimson Firangi,215,1,11,1,3,1
-21441,3,20000,1,11,Crimson Firangi,215,1,11,1,4,1
-21442,3,25604,1,6,True Polished Saber,215,1,11,1,0,1
-21443,3,25604,1,0,True Polished Saber,215,1,11,1,1,1
-21444,3,25604,1,10,True Polished Saber,215,1,11,1,2,1
-21445,3,25604,1,4,True Polished Saber,215,1,11,1,3,1
-21446,3,25604,1,14,True Polished Saber,215,1,11,1,4,1
-21447,3,25574,1,0,True Crimson Firangi,215,1,11,1,0,1
-21448,3,25574,1,10,True Crimson Firangi,215,1,11,1,1,1
-21449,3,25574,1,4,True Crimson Firangi,215,1,11,1,2,1
-21450,3,25574,1,14,True Crimson Firangi,215,1,11,1,3,1
-21451,3,25574,1,8,True Crimson Firangi,215,1,11,1,4,1
-21452,3,27416,1,5,True Crimson Firangi,215,1,11,1,0,1
-21453,3,27416,1,15,True Crimson Firangi,215,1,11,1,1,1
-21454,3,27416,1,9,True Crimson Firangi,215,1,11,1,2,1
-21455,3,27416,1,3,True Crimson Firangi,215,1,11,1,3,1
-21456,3,27416,1,13,True Crimson Firangi,215,1,11,1,4,1
-21457,3,28644,1,10,True Crimson Firangi,215,1,11,1,0,1
-21458,3,28644,1,2,True Crimson Firangi,215,1,11,1,1,1
-21459,3,28644,1,12,True Crimson Firangi,215,1,11,1,2,1
-21460,3,28644,1,6,True Crimson Firangi,215,1,11,1,3,1
-21461,3,28644,1,0,True Crimson Firangi,215,1,11,1,4,1
-21670,3,10000,1,9,Guts' Greatsword,203,1,7,0,0,1
-21671,3,10000,1,9,Skull Knight's Sword,201,1,1,0,0,1
-21724,3,10000,1,6,Olfring Breaker (Star),203,1,7,4,4,1
-21725,3,10000,1,0,Olfring Breaker (Terra Preta),203,1,7,4,4,1
-21726,3,10000,1,7,Olfring Breaker (Sea),203,1,7,4,4,1
-21727,3,10000,1,6,Olfring Breaker (Radiance),203,1,7,4,4,1
-21728,3,10000,1,6,Olfring Daggers (Sunlight),206,1,2,4,4,1
-21729,3,10000,1,6,Olfring Daggers (Sea),206,1,2,4,4,1
-21730,3,10000,1,6,Olfring Daggers (Radiance),206,1,2,4,4,1
-21731,3,10000,1,6,Olfring Daggers (Star),206,1,2,4,4,1
-21732,3,10000,1,6,Olfring Seiðr (Sea),208,1,9,4,4,1
-21733,3,10000,1,6,Olfring Seiðr (Star),208,1,9,4,4,1
-21734,3,10000,1,6,Olfring Seiðr (Terra Preta),208,1,9,4,4,1
+21427,3,20000,1,50,Crimson Firangi,215,1,11,1,0,1
+21428,3,20000,1,55,Crimson Firangi,215,1,11,1,1,1
+21429,3,20000,1,55,Crimson Firangi,215,1,11,1,2,1
+21430,3,20000,1,60,Crimson Firangi,215,1,11,1,3,1
+21431,3,20000,1,65,Crimson Firangi,215,1,11,1,4,1
+21432,3,20000,1,55,Crimson Firangi,215,1,11,1,0,1
+21433,3,20000,1,60,Crimson Firangi,215,1,11,1,1,1
+21434,3,20000,1,60,Crimson Firangi,215,1,11,1,2,1
+21435,3,20000,1,65,Crimson Firangi,215,1,11,1,3,1
+21436,3,20000,1,70,Crimson Firangi,215,1,11,1,4,1
+21437,3,20000,1,60,Crimson Firangi,215,1,11,1,0,1
+21438,3,20000,1,65,Crimson Firangi,215,1,11,1,1,1
+21439,3,20000,1,65,Crimson Firangi,215,1,11,1,2,1
+21440,3,20000,1,70,Crimson Firangi,215,1,11,1,3,1
+21441,3,20000,1,75,Crimson Firangi,215,1,11,1,4,1
+21442,3,25604,1,70,True Polished Saber,215,1,11,1,0,1
+21443,3,25604,1,80,True Polished Saber,215,1,11,1,1,1
+21444,3,25604,1,90,True Polished Saber,215,1,11,1,2,1
+21445,3,25604,1,100,True Polished Saber,215,1,11,1,3,1
+21446,3,25604,1,110,True Polished Saber,215,1,11,1,4,1
+21447,3,25574,1,80,True Crimson Firangi,215,1,11,1,0,1
+21448,3,25574,1,90,True Crimson Firangi,215,1,11,1,1,1
+21449,3,25574,1,100,True Crimson Firangi,215,1,11,1,2,1
+21450,3,25574,1,110,True Crimson Firangi,215,1,11,1,3,1
+21451,3,25574,1,120,True Crimson Firangi,215,1,11,1,4,1
+21452,3,27416,1,85,True Crimson Firangi,215,1,11,1,0,1
+21453,3,27416,1,95,True Crimson Firangi,215,1,11,1,1,1
+21454,3,27416,1,105,True Crimson Firangi,215,1,11,1,2,1
+21455,3,27416,1,115,True Crimson Firangi,215,1,11,1,3,1
+21456,3,27416,1,125,True Crimson Firangi,215,1,11,1,4,1
+21457,3,28644,1,90,True Crimson Firangi,215,1,11,1,0,1
+21458,3,28644,1,98,True Crimson Firangi,215,1,11,1,1,1
+21459,3,28644,1,108,True Crimson Firangi,215,1,11,1,2,1
+21460,3,28644,1,118,True Crimson Firangi,215,1,11,1,3,1
+21461,3,28644,1,128,True Crimson Firangi,215,1,11,1,4,1
+21670,3,10000,1,105,Guts' Greatsword,203,1,7,0,0,1
+21671,3,10000,1,105,Skull Knight's Sword,201,1,1,0,0,1
+21724,3,10000,1,86,Olfring Breaker (Star),203,1,7,4,4,1
+21725,3,10000,1,96,Olfring Breaker (Terra Preta),203,1,7,4,4,1
+21726,3,10000,1,103,Olfring Breaker (Sea),203,1,7,4,4,1
+21727,3,10000,1,86,Olfring Breaker (Radiance),203,1,7,4,4,1
+21728,3,10000,1,86,Olfring Daggers (Sunlight),206,1,2,4,4,1
+21729,3,10000,1,86,Olfring Daggers (Sea),206,1,2,4,4,1
+21730,3,10000,1,86,Olfring Daggers (Radiance),206,1,2,4,4,1
+21731,3,10000,1,86,Olfring Daggers (Star),206,1,2,4,4,1
+21732,3,10000,1,86,Olfring Seiðr (Sea),208,1,9,4,4,1
+21733,3,10000,1,86,Olfring Seiðr (Star),208,1,9,4,4,1
+21734,3,10000,1,86,Olfring Seiðr (Terra Preta),208,1,9,4,4,1
 21735,3,10000,1,7,Olfring Wand (Forest),212,1,6,4,0,1
 21736,3,10000,1,12,Olfring Wand (Forest),212,1,6,4,1,1
-21737,3,10000,1,8,Olfring Wand (Forest),212,1,6,4,2,1
-21738,3,10000,1,10,Olfring Wand (Forest),212,1,6,4,3,1
-21739,3,10000,1,11,Olfring Wand (Forest),212,1,6,4,4,1
-21740,3,10000,1,7,Olfring Wand (Star),212,1,6,4,4,1
+21737,3,10000,1,40,Olfring Wand (Forest),212,1,6,4,2,1
+21738,3,10000,1,90,Olfring Wand (Forest),212,1,6,4,3,1
+21739,3,10000,1,107,Olfring Wand (Forest),212,1,6,4,4,1
+21740,3,10000,1,103,Olfring Wand (Star),212,1,6,4,4,1
 21741,3,10000,1,7,Supreme Olfring Daggers (Green),206,1,2,4,0,1
 21742,3,10000,1,12,Supreme Olfring Daggers (Green),206,1,2,4,1,1
-21743,3,10000,1,8,Supreme Olfring Daggers (Green),206,1,2,4,2,1
-21744,3,10000,1,10,Supreme Olfring Daggers (Green),206,1,2,4,3,1
-21745,3,10000,1,11,Supreme Olfring Daggers (Green),206,1,2,4,4,1
-21746,3,10000,1,9,Supreme Olfring Sword (Star),201,1,1,4,4,1
-21748,3,10000,1,0,Olfring Sword (Scarlet),201,1,1,4,4,1
-21750,3,10000,1,0,Olfring Sword (Iron),201,1,1,4,4,1
-21752,3,10000,1,0,Olfring Guard (Indigo),204,1,5,4,4,1
-21754,3,10000,1,0,Olfring Guard (Pure),204,1,5,4,4,1
-21756,3,10000,1,1,Olfring Bow (Pure),207,1,3,4,4,1
-21757,3,10000,1,0,Olfring Bow (Amur Cork),207,1,3,4,4,1
-21758,3,10000,1,1,Olfring Cane (Pure),211,1,4,4,4,1
-21759,3,10000,1,0,Olfring Cane (Iron),211,1,4,4,4,1
+21743,3,10000,1,40,Supreme Olfring Daggers (Green),206,1,2,4,2,1
+21744,3,10000,1,90,Supreme Olfring Daggers (Green),206,1,2,4,3,1
+21745,3,10000,1,107,Supreme Olfring Daggers (Green),206,1,2,4,4,1
+21746,3,10000,1,105,Supreme Olfring Sword (Star),201,1,1,4,4,1
+21748,3,10000,1,96,Olfring Sword (Scarlet),201,1,1,4,4,1
+21750,3,10000,1,96,Olfring Sword (Iron),201,1,1,4,4,1
+21752,3,10000,1,96,Olfring Guard (Indigo),204,1,5,4,4,1
+21754,3,10000,1,96,Olfring Guard (Pure),204,1,5,4,4,1
+21756,3,10000,1,113,Olfring Bow (Pure),207,1,3,4,4,1
+21757,3,10000,1,96,Olfring Bow (Amur Cork),207,1,3,4,4,1
+21758,3,10000,1,113,Olfring Cane (Pure),211,1,4,4,4,1
+21759,3,10000,1,96,Olfring Cane (Iron),211,1,4,4,4,1
 21760,3,10000,1,7,Olfring Breaker (Forest),203,1,7,4,0,1
 21761,3,10000,1,12,Olfring Breaker (Forest),203,1,7,4,1,1
-21762,3,10000,1,8,Olfring Breaker (Forest),203,1,7,4,2,1
-21763,3,10000,1,0,Olfring Breaker (Forest),203,1,7,4,3,1
-21764,3,10000,1,5,Olfring Breaker (Forest),203,1,7,4,4,1
-21765,3,10000,1,0,Olfring Daggers (Terra Preta),206,1,2,4,4,1
-21766,3,10000,1,0,Olfring Shooter (Sunlight),209,1,8,4,4,1
-21767,3,10000,1,0,Olfring Shooter (Terra Preta),209,1,8,4,4,1
-21768,3,10000,1,0,Olfring Wand (Terra Preta),212,1,6,4,4,1
-21769,3,10000,1,6,Supreme Olfring Sword (Forest),201,1,1,4,0,1
-21770,3,10000,1,8,Supreme Olfring Sword (Forest),201,1,1,4,1,1
-21771,3,10000,1,10,Supreme Olfring Sword (Forest),201,1,1,4,2,1
-21772,3,10000,1,0,Supreme Olfring Sword (Forest),201,1,1,4,3,1
-21773,3,10000,1,5,Supreme Olfring Sword (Forest),201,1,1,4,4,1
-21781,3,10000,1,14,Adel's Greatsword+,201,1,1,1,4,1
-21782,3,10000,1,14,Ice Sword+,203,1,7,1,4,1
-21783,3,10000,1,14,Olga's Staff,212,1,6,1,4,1
-21784,3,10000,1,14,Obsidian Sword,215,1,11,1,4,1
-23539,3,10000,1,3,Slaying King's Sword,215,1,11,4,4,1
-23540,3,10000,1,3,Thorny Spear of Fresh Blood,213,1,10,4,4,1
-23541,3,10000,1,3,God-Slaying Sword Emperor,215,1,11,4,4,1
-23542,3,10000,1,3,Spuit Lance,213,1,10,4,4,1
-23543,3,10000,1,3,3F+,203,1,7,4,4,1
-23544,3,10000,1,3,Ainz Ooal Gown+,212,1,6,4,4,1
-23712,3,48000,1,2,Spirit's Sword,201,100,1,1,0,1
-23713,3,48000,1,2,Spirit's Sword,201,100,1,1,1,1
-23714,3,48000,1,2,Spirit's Sword,201,100,1,1,2,1
-23715,3,48000,1,2,Spirit's Sword,201,100,1,1,3,1
-23716,3,48000,1,2,Spirit's Sword,201,100,1,1,4,1
-23717,3,48000,1,2,Fire King's Sword,201,100,1,1,0,1
-23718,3,48000,1,2,Fire King's Sword,201,100,1,1,1,1
-23719,3,48000,1,2,Fire King's Sword,201,100,1,1,2,1
-23720,3,48000,1,2,Fire King's Sword,201,100,1,1,3,1
-23721,3,48000,1,2,Fire King's Sword,201,100,1,1,4,1
-23722,3,48000,1,2,White Wings' Sword,201,100,1,1,0,1
-23723,3,48000,1,2,White Wings' Sword,201,100,1,1,1,1
-23724,3,48000,1,2,White Wings' Sword,201,100,1,1,2,1
-23725,3,48000,1,2,White Wings' Sword,201,100,1,1,3,1
-23726,3,48000,1,2,White Wings' Sword,201,100,1,1,4,1
-23727,3,48000,1,2,Golden Sword,201,100,1,1,0,1
-23728,3,48000,1,2,Golden Sword,201,100,1,1,1,1
-23729,3,48000,1,2,Golden Sword,201,100,1,1,2,1
-23730,3,48000,1,2,Golden Sword,201,100,1,1,3,1
-23731,3,48000,1,2,Golden Sword,201,100,1,1,4,1
-23732,3,48000,1,7,Blackshatter Sword,201,100,1,1,0,1
-23733,3,48000,1,7,Blackshatter Sword,201,100,1,1,1,1
-23734,3,48000,1,7,Blackshatter Sword,201,100,1,1,2,1
-23735,3,48000,1,7,Blackshatter Sword,201,100,1,1,3,1
-23736,3,48000,1,7,Blackshatter Sword,201,100,1,1,4,1
-23737,3,50000,1,2,Lost Continent's Rover Sword,201,1,1,4,4,1
-23738,3,50000,1,2,"Ancient Muse's Sword, Left Behind",201,1,1,4,4,1
-23739,3,50000,1,7,Frozen Crystal Elga Sword,201,1,1,4,4,1
-23740,3,10000,1,8,Olfring Sword (Willow Green),201,1,1,4,4,1
-23770,3,48000,1,2,Spirit's Greatsword,203,100,7,1,0,1
-23771,3,48000,1,2,Spirit's Greatsword,203,100,7,1,1,1
-23772,3,48000,1,2,Spirit's Greatsword,203,100,7,1,2,1
-23773,3,48000,1,2,Spirit's Greatsword,203,100,7,1,3,1
-23774,3,48000,1,2,Spirit's Greatsword,203,100,7,1,4,1
-23775,3,48000,1,2,Fire King's Greatsword,203,100,7,1,0,1
-23776,3,48000,1,2,Fire King's Greatsword,203,100,7,1,1,1
-23777,3,48000,1,2,Fire King's Greatsword,203,100,7,1,2,1
-23778,3,48000,1,2,Fire King's Greatsword,203,100,7,1,3,1
-23779,3,48000,1,2,Fire King's Greatsword,203,100,7,1,4,1
-23780,3,48000,1,2,White Wings' Greatsword,203,100,7,1,0,1
-23781,3,48000,1,2,White Wings' Greatsword,203,100,7,1,1,1
-23782,3,48000,1,2,White Wings' Greatsword,203,100,7,1,2,1
-23783,3,48000,1,2,White Wings' Greatsword,203,100,7,1,3,1
-23784,3,48000,1,2,White Wings' Greatsword,203,100,7,1,4,1
-23785,3,48000,1,2,Golden Greatsword,203,100,7,1,0,1
-23786,3,48000,1,2,Golden Greatsword,203,100,7,1,1,1
-23787,3,48000,1,2,Golden Greatsword,203,100,7,1,2,1
-23788,3,48000,1,2,Golden Greatsword,203,100,7,1,3,1
-23789,3,48000,1,2,Golden Greatsword,203,100,7,1,4,1
-23790,3,48000,1,7,Blackshatter Greatsword,203,100,7,1,0,1
-23791,3,48000,1,7,Blackshatter Greatsword,203,100,7,1,1,1
-23792,3,48000,1,7,Blackshatter Greatsword,203,100,7,1,2,1
-23793,3,48000,1,7,Blackshatter Greatsword,203,100,7,1,3,1
-23794,3,48000,1,7,Blackshatter Greatsword,203,100,7,1,4,1
-23799,3,50000,1,2,Lost Continent's Rover Blade,203,1,7,4,4,1
-23804,3,50000,1,2,"Ancient Muse's Blade, Left Behind",203,1,7,4,4,1
-23806,3,50000,1,7,Frozen Crystal Elga Blade,203,1,7,4,4,1
-23807,3,48000,1,2,Spirit's Greatshield,204,100,5,1,0,1
-23808,3,48000,1,2,Spirit's Greatshield,204,100,5,1,1,1
-23809,3,48000,1,2,Spirit's Greatshield,204,100,5,1,2,1
-23810,3,48000,1,2,Spirit's Greatshield,204,100,5,1,3,1
-23811,3,48000,1,2,Spirit's Greatshield,204,100,5,1,4,1
-23812,3,48000,1,2,Fire King's Greatshield,204,100,5,1,0,1
-23813,3,48000,1,2,Fire King's Greatshield,204,100,5,1,1,1
-23814,3,48000,1,2,Fire King's Greatshield,204,100,5,1,2,1
-23815,3,48000,1,2,Fire King's Greatshield,204,100,5,1,3,1
-23816,3,48000,1,2,Fire King's Greatshield,204,100,5,1,4,1
-23817,3,48000,1,2,White Wings' Greatshield,204,100,5,1,0,1
-23818,3,48000,1,2,White Wings' Greatshield,204,100,5,1,1,1
-23819,3,48000,1,2,White Wings' Greatshield,204,100,5,1,2,1
-23820,3,48000,1,2,White Wings' Greatshield,204,100,5,1,3,1
-23821,3,48000,1,2,White Wings' Greatshield,204,100,5,1,4,1
-23822,3,48000,1,2,Golden Shield,204,100,5,1,0,1
-23823,3,48000,1,2,Golden Shield,204,100,5,1,1,1
-23824,3,48000,1,2,Golden Shield,204,100,5,1,2,1
-23825,3,48000,1,2,Golden Shield,204,100,5,1,3,1
-23826,3,48000,1,2,Golden Shield,204,100,5,1,4,1
-23827,3,48000,1,7,Blackshatter Greatshield,204,100,5,1,0,1
-23828,3,48000,1,7,Blackshatter Greatshield,204,100,5,1,1,1
-23829,3,48000,1,7,Blackshatter Greatshield,204,100,5,1,2,1
-23830,3,48000,1,7,Blackshatter Greatshield,204,100,5,1,3,1
-23831,3,48000,1,7,Blackshatter Greatshield,204,100,5,1,4,1
-23832,3,50000,1,2,Lost Continent's Rover Wall,204,1,5,4,4,1
-23833,3,50000,1,2,"Ancient Muse's Wall, Left Behind",204,1,5,4,4,1
-23834,3,50000,1,7,Frozen Crystal Elga Wall,204,1,5,4,4,1
-23835,3,10000,1,8,Olfring Guard (Willow Green),204,1,5,4,4,1
-23873,3,48000,1,2,Spirit's Daggers,206,100,2,1,0,1
-23874,3,48000,1,2,Spirit's Daggers,206,100,2,1,1,1
-23875,3,48000,1,2,Spirit's Daggers,206,100,2,1,2,1
-23876,3,48000,1,2,Spirit's Daggers,206,100,2,1,3,1
-23877,3,48000,1,2,Spirit's Daggers,206,100,2,1,4,1
-23878,3,48000,1,2,Fire King's Daggers,206,100,2,1,0,1
-23879,3,48000,1,2,Fire King's Daggers,206,100,2,1,1,1
-23880,3,48000,1,2,Fire King's Daggers,206,100,2,1,2,1
-23881,3,48000,1,2,Fire King's Daggers,206,100,2,1,3,1
-23882,3,48000,1,2,Fire King's Daggers,206,100,2,1,4,1
-23883,3,48000,1,2,White Wings' Daggers,206,100,2,1,0,1
-23884,3,48000,1,2,White Wings' Daggers,206,100,2,1,1,1
-23885,3,48000,1,2,White Wings' Daggers,206,100,2,1,2,1
-23886,3,48000,1,2,White Wings' Daggers,206,100,2,1,3,1
-23887,3,48000,1,2,White Wings' Daggers,206,100,2,1,4,1
-23888,3,48000,1,2,Golden Daggers,206,100,2,1,0,1
-23889,3,48000,1,2,Golden Daggers,206,100,2,1,1,1
-23890,3,48000,1,2,Golden Daggers,206,100,2,1,2,1
-23891,3,48000,1,2,Golden Daggers,206,100,2,1,3,1
-23892,3,48000,1,2,Golden Daggers,206,100,2,1,4,1
-23893,3,48000,1,7,Blackshatter Daggers,206,100,2,1,0,1
-23894,3,48000,1,7,Blackshatter Daggers,206,100,2,1,1,1
-23895,3,48000,1,7,Blackshatter Daggers,206,100,2,1,2,1
-23896,3,48000,1,7,Blackshatter Daggers,206,100,2,1,3,1
-23897,3,48000,1,7,Blackshatter Daggers,206,100,2,1,4,1
-23898,3,50000,1,2,Lost Continent's Rover Daggers,206,1,2,4,4,1
-23899,3,50000,1,2,"Ancient Muse's Daggers, Left Behind",206,1,2,4,4,1
-23900,3,50000,1,7,Frozen Crystal Elga Daggers,206,1,2,4,4,1
-23901,3,48000,1,2,Spirit's Bow,207,100,3,1,0,1
-23902,3,48000,1,2,Spirit's Bow,207,100,3,1,1,1
-23903,3,48000,1,2,Spirit's Bow,207,100,3,1,2,1
-23904,3,48000,1,2,Spirit's Bow,207,100,3,1,3,1
-23905,3,48000,1,2,Spirit's Bow,207,100,3,1,4,1
-23906,3,48000,1,2,Fire King's Bow,207,100,3,1,0,1
-23907,3,48000,1,2,Fire King's Bow,207,100,3,1,1,1
-23908,3,48000,1,2,Fire King's Bow,207,100,3,1,2,1
-23909,3,48000,1,2,Fire King's Bow,207,100,3,1,3,1
-23910,3,48000,1,2,Fire King's Bow,207,100,3,1,4,1
-23911,3,48000,1,2,White Wings' Bow,207,100,3,1,0,1
-23912,3,48000,1,2,White Wings' Bow,207,100,3,1,1,1
-23913,3,48000,1,2,White Wings' Bow,207,100,3,1,2,1
-23914,3,48000,1,2,White Wings' Bow,207,100,3,1,3,1
-23915,3,48000,1,2,White Wings' Bow,207,100,3,1,4,1
-23916,3,48000,1,2,Golden Bow,207,100,3,1,0,1
-23917,3,48000,1,2,Golden Bow,207,100,3,1,1,1
-23918,3,48000,1,2,Golden Bow,207,100,3,1,2,1
-23919,3,48000,1,2,Golden Bow,207,100,3,1,3,1
-23920,3,48000,1,2,Golden Bow,207,100,3,1,4,1
-23921,3,48000,1,7,Blackshatter Bow,207,100,3,1,0,1
-23922,3,48000,1,7,Blackshatter Bow,207,100,3,1,1,1
-23923,3,48000,1,7,Blackshatter Bow,207,100,3,1,2,1
-23924,3,48000,1,7,Blackshatter Bow,207,100,3,1,3,1
-23925,3,48000,1,7,Blackshatter Bow,207,100,3,1,4,1
-23926,3,50000,1,2,Lost Continent's Rover Arrow,207,1,3,4,4,1
-23927,3,50000,1,2,"Ancient Muse's Arrow, Left Behind",207,1,3,4,4,1
-23928,3,50000,1,7,Frozen Crystal Elga Arrow,207,1,3,4,4,1
-23929,3,10000,1,8,Olfring Bow (Willow Green),207,1,3,4,4,1
-23930,3,48000,1,2,Magick Gauntlet of the Spirit,208,100,9,1,0,1
-23931,3,48000,1,2,Magick Gauntlet of the Spirit,208,100,9,1,1,1
-23932,3,48000,1,2,Magick Gauntlet of the Spirit,208,100,9,1,2,1
-23933,3,48000,1,2,Magick Gauntlet of the Spirit,208,100,9,1,3,1
-23934,3,48000,1,2,Magick Gauntlet of the Spirit,208,100,9,1,4,1
-23935,3,48000,1,2,Fire King's Magick Gauntlet,208,100,9,1,0,1
-23936,3,48000,1,2,Fire King's Magick Gauntlet,208,100,9,1,1,1
-23937,3,48000,1,2,Fire King's Magick Gauntlet,208,100,9,1,2,1
-23938,3,48000,1,2,Fire King's Magick Gauntlet,208,100,9,1,3,1
-23939,3,48000,1,2,Fire King's Magick Gauntlet,208,100,9,1,4,1
-23940,3,48000,1,2,White Wings' Magick Gauntlet,208,100,9,1,0,1
-23941,3,48000,1,2,White Wings' Magick Gauntlet,208,100,9,1,1,1
-23942,3,48000,1,2,White Wings' Magick Gauntlet,208,100,9,1,2,1
-23943,3,48000,1,2,White Wings' Magick Gauntlet,208,100,9,1,3,1
-23944,3,48000,1,2,White Wings' Magick Gauntlet,208,100,9,1,4,1
-23945,3,48000,1,2,Golden Magick Gauntlet,208,100,9,1,0,1
-23946,3,48000,1,2,Golden Magick Gauntlet,208,100,9,1,1,1
-23947,3,48000,1,2,Golden Magick Gauntlet,208,100,9,1,2,1
-23948,3,48000,1,2,Golden Magick Gauntlet,208,100,9,1,3,1
-23949,3,48000,1,2,Golden Magick Gauntlet,208,100,9,1,4,1
-23950,3,48000,1,7,Blackshatter Magick Gauntlet,208,100,9,1,0,1
-23951,3,48000,1,7,Blackshatter Magick Gauntlet,208,100,9,1,1,1
-23952,3,48000,1,7,Blackshatter Magick Gauntlet,208,100,9,1,2,1
-23953,3,48000,1,7,Blackshatter Magick Gauntlet,208,100,9,1,3,1
-23954,3,48000,1,7,Blackshatter Magick Gauntlet,208,100,9,1,4,1
-23955,3,50000,1,2,Lost Continent's Rover Hands,208,1,9,4,4,1
-23956,3,50000,1,2,"Ancient Muse's Gloves, Left Behind",208,1,9,4,4,1
-23957,3,50000,1,7,Frozen Crystal Elga Hands,208,1,9,4,4,1
-23958,3,48000,1,2,Spirit's Magick Bow,209,100,8,1,0,1
-23959,3,48000,1,2,Spirit's Magick Bow,209,100,8,1,1,1
-23960,3,48000,1,2,Spirit's Magick Bow,209,100,8,1,2,1
-23961,3,48000,1,2,Spirit's Magick Bow,209,100,8,1,3,1
-23962,3,48000,1,2,Spirit's Magick Bow,209,100,8,1,4,1
-23963,3,48000,1,2,Fire King's Magick Bow,209,100,8,1,0,1
-23964,3,48000,1,2,Fire King's Magick Bow,209,100,8,1,1,1
-23965,3,48000,1,2,Fire King's Magick Bow,209,100,8,1,2,1
-23966,3,48000,1,2,Fire King's Magick Bow,209,100,8,1,3,1
-23967,3,48000,1,2,Fire King's Magick Bow,209,100,8,1,4,1
-23968,3,48000,1,2,White Wings's Magick Bow,209,100,8,1,0,1
-23969,3,48000,1,2,White Wings's Magick Bow,209,100,8,1,1,1
-23970,3,48000,1,2,White Wings's Magick Bow,209,100,8,1,2,1
-23971,3,48000,1,2,White Wings's Magick Bow,209,100,8,1,3,1
-23972,3,48000,1,2,White Wings's Magick Bow,209,100,8,1,4,1
-23973,3,48000,1,2,Golden Magick Bow,209,100,8,1,0,1
-23974,3,48000,1,2,Golden Magick Bow,209,100,8,1,1,1
-23975,3,48000,1,2,Golden Magick Bow,209,100,8,1,2,1
-23976,3,48000,1,2,Golden Magick Bow,209,100,8,1,3,1
-23977,3,48000,1,2,Golden Magick Bow,209,100,8,1,4,1
-23978,3,48000,1,7,Blackshatter Magick Bow,209,100,8,1,0,1
-23979,3,48000,1,7,Blackshatter Magick Bow,209,100,8,1,1,1
-23980,3,48000,1,7,Blackshatter Magick Bow,209,100,8,1,2,1
-23981,3,48000,1,7,Blackshatter Magick Bow,209,100,8,1,3,1
-23982,3,48000,1,7,Blackshatter Magick Bow,209,100,8,1,4,1
-23983,3,50000,1,2,Lost Continent's Rover Spell,209,1,8,4,4,1
-23984,3,50000,1,2,"Ancient Muse's Spell, Left Behind",209,1,8,4,4,1
-23985,3,50000,1,7,Frozen Crystal Elga Spell,209,1,8,4,4,1
-23986,3,48000,1,2,Spirit's Staff,211,100,4,1,0,1
-23987,3,48000,1,2,Spirit's Staff,211,100,4,1,1,1
-23988,3,48000,1,2,Spirit's Staff,211,100,4,1,2,1
-23989,3,48000,1,2,Spirit's Staff,211,100,4,1,3,1
-23990,3,48000,1,2,Spirit's Staff,211,100,4,1,4,1
-23991,3,48000,1,2,Fire King's Staff,211,100,4,1,0,1
-23992,3,48000,1,2,Fire King's Staff,211,100,4,1,1,1
-23993,3,48000,1,2,Fire King's Staff,211,100,4,1,2,1
-23994,3,48000,1,2,Fire King's Staff,211,100,4,1,3,1
-23995,3,48000,1,2,Fire King's Staff,211,100,4,1,4,1
-23996,3,48000,1,2,White Wings' Staff,211,100,4,1,0,1
-23997,3,48000,1,2,White Wings' Staff,211,100,4,1,1,1
-23998,3,48000,1,2,White Wings' Staff,211,100,4,1,2,1
-23999,3,48000,1,2,White Wings' Staff,211,100,4,1,3,1
-24000,3,48000,1,2,White Wings' Staff,211,100,4,1,4,1
-24001,3,48000,1,2,Golden Staff,211,100,4,1,0,1
-24002,3,48000,1,2,Golden Staff,211,100,4,1,1,1
-24003,3,48000,1,2,Golden Staff,211,100,4,1,2,1
-24004,3,48000,1,2,Golden Staff,211,100,4,1,3,1
-24005,3,48000,1,2,Golden Staff,211,100,4,1,4,1
-24006,3,48000,1,7,Blackshatter Staff,211,100,4,1,0,1
-24007,3,48000,1,7,Blackshatter Staff,211,100,4,1,1,1
-24008,3,48000,1,7,Blackshatter Staff,211,100,4,1,2,1
-24009,3,48000,1,7,Blackshatter Staff,211,100,4,1,3,1
-24010,3,48000,1,7,Blackshatter Staff,211,100,4,1,4,1
-24011,3,50000,1,2,Lost Continent's Rover Staff,211,1,4,4,4,1
-24012,3,50000,1,2,"Ancient Muse's Staff, Left Behind",211,1,4,4,4,1
-24013,3,50000,1,7,Frozen Crystal Elga Staff,211,1,4,4,4,1
-24014,3,10000,1,8,Olfring Cane (Willow Green),211,1,4,4,4,1
-24015,3,48000,1,2,Spirit's Archistaff,212,100,6,1,0,1
-24016,3,48000,1,2,Spirit's Archistaff,212,100,6,1,1,1
-24017,3,48000,1,2,Spirit's Archistaff,212,100,6,1,2,1
-24018,3,48000,1,2,Spirit's Archistaff,212,100,6,1,3,1
-24019,3,48000,1,2,Spirit's Archistaff,212,100,6,1,4,1
-24020,3,48000,1,2,Fire King's Archistaff,212,100,6,1,0,1
-24021,3,48000,1,2,Fire King's Archistaff,212,100,6,1,1,1
-24022,3,48000,1,2,Fire King's Archistaff,212,100,6,1,2,1
-24023,3,48000,1,2,Fire King's Archistaff,212,100,6,1,3,1
-24024,3,48000,1,2,Fire King's Archistaff,212,100,6,1,4,1
-24025,3,48000,1,2,White Wings' Archistaff,212,100,6,1,0,1
-24026,3,48000,1,2,White Wings' Archistaff,212,100,6,1,1,1
-24027,3,48000,1,2,White Wings' Archistaff,212,100,6,1,2,1
-24028,3,48000,1,2,White Wings' Archistaff,212,100,6,1,3,1
-24029,3,48000,1,2,White Wings' Archistaff,212,100,6,1,4,1
-24030,3,48000,1,2,Golden Archistaff,212,100,6,1,0,1
-24031,3,48000,1,2,Golden Archistaff,212,100,6,1,1,1
-24032,3,48000,1,2,Golden Archistaff,212,100,6,1,2,1
-24033,3,48000,1,2,Golden Archistaff,212,100,6,1,3,1
-24034,3,48000,1,2,Golden Archistaff,212,100,6,1,4,1
-24035,3,48000,1,7,Blackshatter Archistaff,212,100,6,1,0,1
-24036,3,48000,1,7,Blackshatter Archistaff,212,100,6,1,1,1
-24037,3,48000,1,7,Blackshatter Archistaff,212,100,6,1,2,1
-24038,3,48000,1,7,Blackshatter Archistaff,212,100,6,1,3,1
-24039,3,48000,1,7,Blackshatter Archistaff,212,100,6,1,4,1
-24040,3,50000,1,2,Lost Continent's Rover Wand,212,1,6,4,4,1
-24041,3,50000,1,2,"Ancient Muse's Relic, Left Behind",212,1,6,4,4,1
-24042,3,50000,1,7,Frozen Crystal Elga Wand,212,1,6,4,4,1
-24043,3,48000,1,2,Spirit's Spear,213,100,10,1,0,1
-24044,3,48000,1,2,Spirit's Spear,213,100,10,1,1,1
-24045,3,48000,1,2,Spirit's Spear,213,100,10,1,2,1
-24046,3,48000,1,2,Spirit's Spear,213,100,10,1,3,1
-24047,3,48000,1,2,Spirit's Spear,213,100,10,1,4,1
-24048,3,48000,1,2,Fire King's Spear,213,100,10,1,0,1
-24049,3,48000,1,2,Fire King's Spear,213,100,10,1,1,1
-24050,3,48000,1,2,Fire King's Spear,213,100,10,1,2,1
-24051,3,48000,1,2,Fire King's Spear,213,100,10,1,3,1
-24052,3,48000,1,2,Fire King's Spear,213,100,10,1,4,1
-24053,3,48000,1,2,White Wings' Spear,213,100,10,1,0,1
-24054,3,48000,1,2,White Wings' Spear,213,100,10,1,1,1
-24055,3,48000,1,2,White Wings' Spear,213,100,10,1,2,1
-24056,3,48000,1,2,White Wings' Spear,213,100,10,1,3,1
-24057,3,48000,1,2,White Wings' Spear,213,100,10,1,4,1
-24058,3,48000,1,2,Golden Spear,213,100,10,1,0,1
-24059,3,48000,1,2,Golden Spear,213,100,10,1,1,1
-24060,3,48000,1,2,Golden Spear,213,100,10,1,2,1
-24061,3,48000,1,2,Golden Spear,213,100,10,1,3,1
-24062,3,48000,1,2,Golden Spear,213,100,10,1,4,1
-24063,3,48000,1,7,Blackshatter Spear,213,100,10,1,0,1
-24064,3,48000,1,7,Blackshatter Spear,213,100,10,1,1,1
-24065,3,48000,1,7,Blackshatter Spear,213,100,10,1,2,1
-24066,3,48000,1,7,Blackshatter Spear,213,100,10,1,3,1
-24067,3,48000,1,7,Blackshatter Spear,213,100,10,1,4,1
-24068,3,50000,1,2,Lost Continent's Rover Lance,213,1,10,4,4,1
-24069,3,50000,1,2,"Ancient Muse's Lance, Left Behind",213,1,10,4,4,1
-24070,3,50000,1,7,Frozen Crystal Elga Lance,213,1,10,4,4,1
-24071,3,48000,1,2,Spirit's Magick Sword,215,100,11,1,0,1
-24072,3,48000,1,2,Spirit's Magick Sword,215,100,11,1,1,1
-24073,3,48000,1,2,Spirit's Magick Sword,215,100,11,1,2,1
-24074,3,48000,1,2,Spirit's Magick Sword,215,100,11,1,3,1
-24075,3,48000,1,2,Spirit's Magick Sword,215,100,11,1,4,1
-24076,3,48000,1,2,Fire King's Magick Sword,215,100,11,1,0,1
-24077,3,48000,1,2,Fire King's Magick Sword,215,100,11,1,1,1
-24078,3,48000,1,2,Fire King's Magick Sword,215,100,11,1,2,1
-24079,3,48000,1,2,Fire King's Magick Sword,215,100,11,1,3,1
-24080,3,48000,1,2,Fire King's Magick Sword,215,100,11,1,4,1
-24081,3,48000,1,2,White Wings's Magick Sword,215,100,11,1,0,1
-24082,3,48000,1,2,White Wings's Magick Sword,215,100,11,1,1,1
-24083,3,48000,1,2,White Wings's Magick Sword,215,100,11,1,2,1
-24084,3,48000,1,2,White Wings's Magick Sword,215,100,11,1,3,1
-24085,3,48000,1,2,White Wings's Magick Sword,215,100,11,1,4,1
-24086,3,48000,1,2,Golden Magick Sword,215,100,11,1,0,1
-24087,3,48000,1,2,Golden Magick Sword,215,100,11,1,1,1
-24088,3,48000,1,2,Golden Magick Sword,215,100,11,1,2,1
-24089,3,48000,1,2,Golden Magick Sword,215,100,11,1,3,1
-24090,3,48000,1,2,Golden Magick Sword,215,100,11,1,4,1
-24091,3,48000,1,7,Blackshatter Magick Sword,215,100,11,1,0,1
-24092,3,48000,1,7,Blackshatter Magick Sword,215,100,11,1,1,1
-24093,3,48000,1,7,Blackshatter Magick Sword,215,100,11,1,2,1
-24094,3,48000,1,7,Blackshatter Magick Sword,215,100,11,1,3,1
-24095,3,48000,1,7,Blackshatter Magick Sword,215,100,11,1,4,1
-24096,3,50000,1,2,Lost Continent's Rover Scimitar,215,1,11,4,4,1
-24097,3,50000,1,2,"Ancient Muse's Scimitar, Left Behind",215,1,11,4,4,1
-24098,3,50000,1,7,Frozen Crystal Elga Scimitar,215,1,11,4,4,1
+21762,3,10000,1,40,Olfring Breaker (Forest),203,1,7,4,2,1
+21763,3,10000,1,96,Olfring Breaker (Forest),203,1,7,4,3,1
+21764,3,10000,1,117,Olfring Breaker (Forest),203,1,7,4,4,1
+21765,3,10000,1,96,Olfring Daggers (Terra Preta),206,1,2,4,4,1
+21766,3,10000,1,96,Olfring Shooter (Sunlight),209,1,8,4,4,1
+21767,3,10000,1,96,Olfring Shooter (Terra Preta),209,1,8,4,4,1
+21768,3,10000,1,96,Olfring Wand (Terra Preta),212,1,6,4,4,1
+21769,3,10000,1,86,Supreme Olfring Sword (Forest),201,1,1,4,0,1
+21770,3,10000,1,88,Supreme Olfring Sword (Forest),201,1,1,4,1,1
+21771,3,10000,1,90,Supreme Olfring Sword (Forest),201,1,1,4,2,1
+21772,3,10000,1,96,Supreme Olfring Sword (Forest),201,1,1,4,3,1
+21773,3,10000,1,117,Supreme Olfring Sword (Forest),201,1,1,4,4,1
+21781,3,10000,1,110,Adel's Greatsword+,201,1,1,1,4,1
+21782,3,10000,1,110,Ice Sword+,203,1,7,1,4,1
+21783,3,10000,1,110,Olga's Staff,212,1,6,1,4,1
+21784,3,10000,1,110,Obsidian Sword,215,1,11,1,4,1
+23539,3,10000,1,115,Slaying King's Sword,215,1,11,4,4,1
+23540,3,10000,1,115,Thorny Spear of Fresh Blood,213,1,10,4,4,1
+23541,3,10000,1,115,God-Slaying Sword Emperor,215,1,11,4,4,1
+23542,3,10000,1,115,Spuit Lance,213,1,10,4,4,1
+23543,3,10000,1,115,3F+,203,1,7,4,4,1
+23544,3,10000,1,115,Ainz Ooal Gown+,212,1,6,4,4,1
+23712,3,48000,1,130,Spirit's Sword,201,100,1,1,0,1
+23713,3,48000,1,130,Spirit's Sword,201,100,1,1,1,1
+23714,3,48000,1,130,Spirit's Sword,201,100,1,1,2,1
+23715,3,48000,1,130,Spirit's Sword,201,100,1,1,3,1
+23716,3,48000,1,130,Spirit's Sword,201,100,1,1,4,1
+23717,3,48000,1,130,Fire King's Sword,201,100,1,1,0,1
+23718,3,48000,1,130,Fire King's Sword,201,100,1,1,1,1
+23719,3,48000,1,130,Fire King's Sword,201,100,1,1,2,1
+23720,3,48000,1,130,Fire King's Sword,201,100,1,1,3,1
+23721,3,48000,1,130,Fire King's Sword,201,100,1,1,4,1
+23722,3,48000,1,130,White Wings' Sword,201,100,1,1,0,1
+23723,3,48000,1,130,White Wings' Sword,201,100,1,1,1,1
+23724,3,48000,1,130,White Wings' Sword,201,100,1,1,2,1
+23725,3,48000,1,130,White Wings' Sword,201,100,1,1,3,1
+23726,3,48000,1,130,White Wings' Sword,201,100,1,1,4,1
+23727,3,48000,1,130,Golden Sword,201,100,1,1,0,1
+23728,3,48000,1,130,Golden Sword,201,100,1,1,1,1
+23729,3,48000,1,130,Golden Sword,201,100,1,1,2,1
+23730,3,48000,1,130,Golden Sword,201,100,1,1,3,1
+23731,3,48000,1,130,Golden Sword,201,100,1,1,4,1
+23732,3,48000,1,135,Blackshatter Sword,201,100,1,1,0,1
+23733,3,48000,1,135,Blackshatter Sword,201,100,1,1,1,1
+23734,3,48000,1,135,Blackshatter Sword,201,100,1,1,2,1
+23735,3,48000,1,135,Blackshatter Sword,201,100,1,1,3,1
+23736,3,48000,1,135,Blackshatter Sword,201,100,1,1,4,1
+23737,3,50000,1,130,Lost Continent's Rover Sword,201,1,1,4,4,1
+23738,3,50000,1,130,"Ancient Muse's Sword, Left Behind",201,1,1,4,4,1
+23739,3,50000,1,135,Frozen Crystal Elga Sword,201,1,1,4,4,1
+23740,3,10000,1,120,Olfring Sword (Willow Green),201,1,1,4,4,1
+23770,3,48000,1,130,Spirit's Greatsword,203,100,7,1,0,1
+23771,3,48000,1,130,Spirit's Greatsword,203,100,7,1,1,1
+23772,3,48000,1,130,Spirit's Greatsword,203,100,7,1,2,1
+23773,3,48000,1,130,Spirit's Greatsword,203,100,7,1,3,1
+23774,3,48000,1,130,Spirit's Greatsword,203,100,7,1,4,1
+23775,3,48000,1,130,Fire King's Greatsword,203,100,7,1,0,1
+23776,3,48000,1,130,Fire King's Greatsword,203,100,7,1,1,1
+23777,3,48000,1,130,Fire King's Greatsword,203,100,7,1,2,1
+23778,3,48000,1,130,Fire King's Greatsword,203,100,7,1,3,1
+23779,3,48000,1,130,Fire King's Greatsword,203,100,7,1,4,1
+23780,3,48000,1,130,White Wings' Greatsword,203,100,7,1,0,1
+23781,3,48000,1,130,White Wings' Greatsword,203,100,7,1,1,1
+23782,3,48000,1,130,White Wings' Greatsword,203,100,7,1,2,1
+23783,3,48000,1,130,White Wings' Greatsword,203,100,7,1,3,1
+23784,3,48000,1,130,White Wings' Greatsword,203,100,7,1,4,1
+23785,3,48000,1,130,Golden Greatsword,203,100,7,1,0,1
+23786,3,48000,1,130,Golden Greatsword,203,100,7,1,1,1
+23787,3,48000,1,130,Golden Greatsword,203,100,7,1,2,1
+23788,3,48000,1,130,Golden Greatsword,203,100,7,1,3,1
+23789,3,48000,1,130,Golden Greatsword,203,100,7,1,4,1
+23790,3,48000,1,135,Blackshatter Greatsword,203,100,7,1,0,1
+23791,3,48000,1,135,Blackshatter Greatsword,203,100,7,1,1,1
+23792,3,48000,1,135,Blackshatter Greatsword,203,100,7,1,2,1
+23793,3,48000,1,135,Blackshatter Greatsword,203,100,7,1,3,1
+23794,3,48000,1,135,Blackshatter Greatsword,203,100,7,1,4,1
+23799,3,50000,1,130,Lost Continent's Rover Blade,203,1,7,4,4,1
+23804,3,50000,1,130,"Ancient Muse's Blade, Left Behind",203,1,7,4,4,1
+23806,3,50000,1,135,Frozen Crystal Elga Blade,203,1,7,4,4,1
+23807,3,48000,1,130,Spirit's Greatshield,204,100,5,1,0,1
+23808,3,48000,1,130,Spirit's Greatshield,204,100,5,1,1,1
+23809,3,48000,1,130,Spirit's Greatshield,204,100,5,1,2,1
+23810,3,48000,1,130,Spirit's Greatshield,204,100,5,1,3,1
+23811,3,48000,1,130,Spirit's Greatshield,204,100,5,1,4,1
+23812,3,48000,1,130,Fire King's Greatshield,204,100,5,1,0,1
+23813,3,48000,1,130,Fire King's Greatshield,204,100,5,1,1,1
+23814,3,48000,1,130,Fire King's Greatshield,204,100,5,1,2,1
+23815,3,48000,1,130,Fire King's Greatshield,204,100,5,1,3,1
+23816,3,48000,1,130,Fire King's Greatshield,204,100,5,1,4,1
+23817,3,48000,1,130,White Wings' Greatshield,204,100,5,1,0,1
+23818,3,48000,1,130,White Wings' Greatshield,204,100,5,1,1,1
+23819,3,48000,1,130,White Wings' Greatshield,204,100,5,1,2,1
+23820,3,48000,1,130,White Wings' Greatshield,204,100,5,1,3,1
+23821,3,48000,1,130,White Wings' Greatshield,204,100,5,1,4,1
+23822,3,48000,1,130,Golden Shield,204,100,5,1,0,1
+23823,3,48000,1,130,Golden Shield,204,100,5,1,1,1
+23824,3,48000,1,130,Golden Shield,204,100,5,1,2,1
+23825,3,48000,1,130,Golden Shield,204,100,5,1,3,1
+23826,3,48000,1,130,Golden Shield,204,100,5,1,4,1
+23827,3,48000,1,135,Blackshatter Greatshield,204,100,5,1,0,1
+23828,3,48000,1,135,Blackshatter Greatshield,204,100,5,1,1,1
+23829,3,48000,1,135,Blackshatter Greatshield,204,100,5,1,2,1
+23830,3,48000,1,135,Blackshatter Greatshield,204,100,5,1,3,1
+23831,3,48000,1,135,Blackshatter Greatshield,204,100,5,1,4,1
+23832,3,50000,1,130,Lost Continent's Rover Wall,204,1,5,4,4,1
+23833,3,50000,1,130,"Ancient Muse's Wall, Left Behind",204,1,5,4,4,1
+23834,3,50000,1,135,Frozen Crystal Elga Wall,204,1,5,4,4,1
+23835,3,10000,1,120,Olfring Guard (Willow Green),204,1,5,4,4,1
+23873,3,48000,1,130,Spirit's Daggers,206,100,2,1,0,1
+23874,3,48000,1,130,Spirit's Daggers,206,100,2,1,1,1
+23875,3,48000,1,130,Spirit's Daggers,206,100,2,1,2,1
+23876,3,48000,1,130,Spirit's Daggers,206,100,2,1,3,1
+23877,3,48000,1,130,Spirit's Daggers,206,100,2,1,4,1
+23878,3,48000,1,130,Fire King's Daggers,206,100,2,1,0,1
+23879,3,48000,1,130,Fire King's Daggers,206,100,2,1,1,1
+23880,3,48000,1,130,Fire King's Daggers,206,100,2,1,2,1
+23881,3,48000,1,130,Fire King's Daggers,206,100,2,1,3,1
+23882,3,48000,1,130,Fire King's Daggers,206,100,2,1,4,1
+23883,3,48000,1,130,White Wings' Daggers,206,100,2,1,0,1
+23884,3,48000,1,130,White Wings' Daggers,206,100,2,1,1,1
+23885,3,48000,1,130,White Wings' Daggers,206,100,2,1,2,1
+23886,3,48000,1,130,White Wings' Daggers,206,100,2,1,3,1
+23887,3,48000,1,130,White Wings' Daggers,206,100,2,1,4,1
+23888,3,48000,1,130,Golden Daggers,206,100,2,1,0,1
+23889,3,48000,1,130,Golden Daggers,206,100,2,1,1,1
+23890,3,48000,1,130,Golden Daggers,206,100,2,1,2,1
+23891,3,48000,1,130,Golden Daggers,206,100,2,1,3,1
+23892,3,48000,1,130,Golden Daggers,206,100,2,1,4,1
+23893,3,48000,1,135,Blackshatter Daggers,206,100,2,1,0,1
+23894,3,48000,1,135,Blackshatter Daggers,206,100,2,1,1,1
+23895,3,48000,1,135,Blackshatter Daggers,206,100,2,1,2,1
+23896,3,48000,1,135,Blackshatter Daggers,206,100,2,1,3,1
+23897,3,48000,1,135,Blackshatter Daggers,206,100,2,1,4,1
+23898,3,50000,1,130,Lost Continent's Rover Daggers,206,1,2,4,4,1
+23899,3,50000,1,130,"Ancient Muse's Daggers, Left Behind",206,1,2,4,4,1
+23900,3,50000,1,135,Frozen Crystal Elga Daggers,206,1,2,4,4,1
+23901,3,48000,1,130,Spirit's Bow,207,100,3,1,0,1
+23902,3,48000,1,130,Spirit's Bow,207,100,3,1,1,1
+23903,3,48000,1,130,Spirit's Bow,207,100,3,1,2,1
+23904,3,48000,1,130,Spirit's Bow,207,100,3,1,3,1
+23905,3,48000,1,130,Spirit's Bow,207,100,3,1,4,1
+23906,3,48000,1,130,Fire King's Bow,207,100,3,1,0,1
+23907,3,48000,1,130,Fire King's Bow,207,100,3,1,1,1
+23908,3,48000,1,130,Fire King's Bow,207,100,3,1,2,1
+23909,3,48000,1,130,Fire King's Bow,207,100,3,1,3,1
+23910,3,48000,1,130,Fire King's Bow,207,100,3,1,4,1
+23911,3,48000,1,130,White Wings' Bow,207,100,3,1,0,1
+23912,3,48000,1,130,White Wings' Bow,207,100,3,1,1,1
+23913,3,48000,1,130,White Wings' Bow,207,100,3,1,2,1
+23914,3,48000,1,130,White Wings' Bow,207,100,3,1,3,1
+23915,3,48000,1,130,White Wings' Bow,207,100,3,1,4,1
+23916,3,48000,1,130,Golden Bow,207,100,3,1,0,1
+23917,3,48000,1,130,Golden Bow,207,100,3,1,1,1
+23918,3,48000,1,130,Golden Bow,207,100,3,1,2,1
+23919,3,48000,1,130,Golden Bow,207,100,3,1,3,1
+23920,3,48000,1,130,Golden Bow,207,100,3,1,4,1
+23921,3,48000,1,135,Blackshatter Bow,207,100,3,1,0,1
+23922,3,48000,1,135,Blackshatter Bow,207,100,3,1,1,1
+23923,3,48000,1,135,Blackshatter Bow,207,100,3,1,2,1
+23924,3,48000,1,135,Blackshatter Bow,207,100,3,1,3,1
+23925,3,48000,1,135,Blackshatter Bow,207,100,3,1,4,1
+23926,3,50000,1,130,Lost Continent's Rover Arrow,207,1,3,4,4,1
+23927,3,50000,1,130,"Ancient Muse's Arrow, Left Behind",207,1,3,4,4,1
+23928,3,50000,1,135,Frozen Crystal Elga Arrow,207,1,3,4,4,1
+23929,3,10000,1,120,Olfring Bow (Willow Green),207,1,3,4,4,1
+23930,3,48000,1,130,Magick Gauntlet of the Spirit,208,100,9,1,0,1
+23931,3,48000,1,130,Magick Gauntlet of the Spirit,208,100,9,1,1,1
+23932,3,48000,1,130,Magick Gauntlet of the Spirit,208,100,9,1,2,1
+23933,3,48000,1,130,Magick Gauntlet of the Spirit,208,100,9,1,3,1
+23934,3,48000,1,130,Magick Gauntlet of the Spirit,208,100,9,1,4,1
+23935,3,48000,1,130,Fire King's Magick Gauntlet,208,100,9,1,0,1
+23936,3,48000,1,130,Fire King's Magick Gauntlet,208,100,9,1,1,1
+23937,3,48000,1,130,Fire King's Magick Gauntlet,208,100,9,1,2,1
+23938,3,48000,1,130,Fire King's Magick Gauntlet,208,100,9,1,3,1
+23939,3,48000,1,130,Fire King's Magick Gauntlet,208,100,9,1,4,1
+23940,3,48000,1,130,White Wings' Magick Gauntlet,208,100,9,1,0,1
+23941,3,48000,1,130,White Wings' Magick Gauntlet,208,100,9,1,1,1
+23942,3,48000,1,130,White Wings' Magick Gauntlet,208,100,9,1,2,1
+23943,3,48000,1,130,White Wings' Magick Gauntlet,208,100,9,1,3,1
+23944,3,48000,1,130,White Wings' Magick Gauntlet,208,100,9,1,4,1
+23945,3,48000,1,130,Golden Magick Gauntlet,208,100,9,1,0,1
+23946,3,48000,1,130,Golden Magick Gauntlet,208,100,9,1,1,1
+23947,3,48000,1,130,Golden Magick Gauntlet,208,100,9,1,2,1
+23948,3,48000,1,130,Golden Magick Gauntlet,208,100,9,1,3,1
+23949,3,48000,1,130,Golden Magick Gauntlet,208,100,9,1,4,1
+23950,3,48000,1,135,Blackshatter Magick Gauntlet,208,100,9,1,0,1
+23951,3,48000,1,135,Blackshatter Magick Gauntlet,208,100,9,1,1,1
+23952,3,48000,1,135,Blackshatter Magick Gauntlet,208,100,9,1,2,1
+23953,3,48000,1,135,Blackshatter Magick Gauntlet,208,100,9,1,3,1
+23954,3,48000,1,135,Blackshatter Magick Gauntlet,208,100,9,1,4,1
+23955,3,50000,1,130,Lost Continent's Rover Hands,208,1,9,4,4,1
+23956,3,50000,1,130,"Ancient Muse's Gloves, Left Behind",208,1,9,4,4,1
+23957,3,50000,1,135,Frozen Crystal Elga Hands,208,1,9,4,4,1
+23958,3,48000,1,130,Spirit's Magick Bow,209,100,8,1,0,1
+23959,3,48000,1,130,Spirit's Magick Bow,209,100,8,1,1,1
+23960,3,48000,1,130,Spirit's Magick Bow,209,100,8,1,2,1
+23961,3,48000,1,130,Spirit's Magick Bow,209,100,8,1,3,1
+23962,3,48000,1,130,Spirit's Magick Bow,209,100,8,1,4,1
+23963,3,48000,1,130,Fire King's Magick Bow,209,100,8,1,0,1
+23964,3,48000,1,130,Fire King's Magick Bow,209,100,8,1,1,1
+23965,3,48000,1,130,Fire King's Magick Bow,209,100,8,1,2,1
+23966,3,48000,1,130,Fire King's Magick Bow,209,100,8,1,3,1
+23967,3,48000,1,130,Fire King's Magick Bow,209,100,8,1,4,1
+23968,3,48000,1,130,White Wings's Magick Bow,209,100,8,1,0,1
+23969,3,48000,1,130,White Wings's Magick Bow,209,100,8,1,1,1
+23970,3,48000,1,130,White Wings's Magick Bow,209,100,8,1,2,1
+23971,3,48000,1,130,White Wings's Magick Bow,209,100,8,1,3,1
+23972,3,48000,1,130,White Wings's Magick Bow,209,100,8,1,4,1
+23973,3,48000,1,130,Golden Magick Bow,209,100,8,1,0,1
+23974,3,48000,1,130,Golden Magick Bow,209,100,8,1,1,1
+23975,3,48000,1,130,Golden Magick Bow,209,100,8,1,2,1
+23976,3,48000,1,130,Golden Magick Bow,209,100,8,1,3,1
+23977,3,48000,1,130,Golden Magick Bow,209,100,8,1,4,1
+23978,3,48000,1,135,Blackshatter Magick Bow,209,100,8,1,0,1
+23979,3,48000,1,135,Blackshatter Magick Bow,209,100,8,1,1,1
+23980,3,48000,1,135,Blackshatter Magick Bow,209,100,8,1,2,1
+23981,3,48000,1,135,Blackshatter Magick Bow,209,100,8,1,3,1
+23982,3,48000,1,135,Blackshatter Magick Bow,209,100,8,1,4,1
+23983,3,50000,1,130,Lost Continent's Rover Spell,209,1,8,4,4,1
+23984,3,50000,1,130,"Ancient Muse's Spell, Left Behind",209,1,8,4,4,1
+23985,3,50000,1,135,Frozen Crystal Elga Spell,209,1,8,4,4,1
+23986,3,48000,1,130,Spirit's Staff,211,100,4,1,0,1
+23987,3,48000,1,130,Spirit's Staff,211,100,4,1,1,1
+23988,3,48000,1,130,Spirit's Staff,211,100,4,1,2,1
+23989,3,48000,1,130,Spirit's Staff,211,100,4,1,3,1
+23990,3,48000,1,130,Spirit's Staff,211,100,4,1,4,1
+23991,3,48000,1,130,Fire King's Staff,211,100,4,1,0,1
+23992,3,48000,1,130,Fire King's Staff,211,100,4,1,1,1
+23993,3,48000,1,130,Fire King's Staff,211,100,4,1,2,1
+23994,3,48000,1,130,Fire King's Staff,211,100,4,1,3,1
+23995,3,48000,1,130,Fire King's Staff,211,100,4,1,4,1
+23996,3,48000,1,130,White Wings' Staff,211,100,4,1,0,1
+23997,3,48000,1,130,White Wings' Staff,211,100,4,1,1,1
+23998,3,48000,1,130,White Wings' Staff,211,100,4,1,2,1
+23999,3,48000,1,130,White Wings' Staff,211,100,4,1,3,1
+24000,3,48000,1,130,White Wings' Staff,211,100,4,1,4,1
+24001,3,48000,1,130,Golden Staff,211,100,4,1,0,1
+24002,3,48000,1,130,Golden Staff,211,100,4,1,1,1
+24003,3,48000,1,130,Golden Staff,211,100,4,1,2,1
+24004,3,48000,1,130,Golden Staff,211,100,4,1,3,1
+24005,3,48000,1,130,Golden Staff,211,100,4,1,4,1
+24006,3,48000,1,135,Blackshatter Staff,211,100,4,1,0,1
+24007,3,48000,1,135,Blackshatter Staff,211,100,4,1,1,1
+24008,3,48000,1,135,Blackshatter Staff,211,100,4,1,2,1
+24009,3,48000,1,135,Blackshatter Staff,211,100,4,1,3,1
+24010,3,48000,1,135,Blackshatter Staff,211,100,4,1,4,1
+24011,3,50000,1,130,Lost Continent's Rover Staff,211,1,4,4,4,1
+24012,3,50000,1,130,"Ancient Muse's Staff, Left Behind",211,1,4,4,4,1
+24013,3,50000,1,135,Frozen Crystal Elga Staff,211,1,4,4,4,1
+24014,3,10000,1,120,Olfring Cane (Willow Green),211,1,4,4,4,1
+24015,3,48000,1,130,Spirit's Archistaff,212,100,6,1,0,1
+24016,3,48000,1,130,Spirit's Archistaff,212,100,6,1,1,1
+24017,3,48000,1,130,Spirit's Archistaff,212,100,6,1,2,1
+24018,3,48000,1,130,Spirit's Archistaff,212,100,6,1,3,1
+24019,3,48000,1,130,Spirit's Archistaff,212,100,6,1,4,1
+24020,3,48000,1,130,Fire King's Archistaff,212,100,6,1,0,1
+24021,3,48000,1,130,Fire King's Archistaff,212,100,6,1,1,1
+24022,3,48000,1,130,Fire King's Archistaff,212,100,6,1,2,1
+24023,3,48000,1,130,Fire King's Archistaff,212,100,6,1,3,1
+24024,3,48000,1,130,Fire King's Archistaff,212,100,6,1,4,1
+24025,3,48000,1,130,White Wings' Archistaff,212,100,6,1,0,1
+24026,3,48000,1,130,White Wings' Archistaff,212,100,6,1,1,1
+24027,3,48000,1,130,White Wings' Archistaff,212,100,6,1,2,1
+24028,3,48000,1,130,White Wings' Archistaff,212,100,6,1,3,1
+24029,3,48000,1,130,White Wings' Archistaff,212,100,6,1,4,1
+24030,3,48000,1,130,Golden Archistaff,212,100,6,1,0,1
+24031,3,48000,1,130,Golden Archistaff,212,100,6,1,1,1
+24032,3,48000,1,130,Golden Archistaff,212,100,6,1,2,1
+24033,3,48000,1,130,Golden Archistaff,212,100,6,1,3,1
+24034,3,48000,1,130,Golden Archistaff,212,100,6,1,4,1
+24035,3,48000,1,135,Blackshatter Archistaff,212,100,6,1,0,1
+24036,3,48000,1,135,Blackshatter Archistaff,212,100,6,1,1,1
+24037,3,48000,1,135,Blackshatter Archistaff,212,100,6,1,2,1
+24038,3,48000,1,135,Blackshatter Archistaff,212,100,6,1,3,1
+24039,3,48000,1,135,Blackshatter Archistaff,212,100,6,1,4,1
+24040,3,50000,1,130,Lost Continent's Rover Wand,212,1,6,4,4,1
+24041,3,50000,1,130,"Ancient Muse's Relic, Left Behind",212,1,6,4,4,1
+24042,3,50000,1,135,Frozen Crystal Elga Wand,212,1,6,4,4,1
+24043,3,48000,1,130,Spirit's Spear,213,100,10,1,0,1
+24044,3,48000,1,130,Spirit's Spear,213,100,10,1,1,1
+24045,3,48000,1,130,Spirit's Spear,213,100,10,1,2,1
+24046,3,48000,1,130,Spirit's Spear,213,100,10,1,3,1
+24047,3,48000,1,130,Spirit's Spear,213,100,10,1,4,1
+24048,3,48000,1,130,Fire King's Spear,213,100,10,1,0,1
+24049,3,48000,1,130,Fire King's Spear,213,100,10,1,1,1
+24050,3,48000,1,130,Fire King's Spear,213,100,10,1,2,1
+24051,3,48000,1,130,Fire King's Spear,213,100,10,1,3,1
+24052,3,48000,1,130,Fire King's Spear,213,100,10,1,4,1
+24053,3,48000,1,130,White Wings' Spear,213,100,10,1,0,1
+24054,3,48000,1,130,White Wings' Spear,213,100,10,1,1,1
+24055,3,48000,1,130,White Wings' Spear,213,100,10,1,2,1
+24056,3,48000,1,130,White Wings' Spear,213,100,10,1,3,1
+24057,3,48000,1,130,White Wings' Spear,213,100,10,1,4,1
+24058,3,48000,1,130,Golden Spear,213,100,10,1,0,1
+24059,3,48000,1,130,Golden Spear,213,100,10,1,1,1
+24060,3,48000,1,130,Golden Spear,213,100,10,1,2,1
+24061,3,48000,1,130,Golden Spear,213,100,10,1,3,1
+24062,3,48000,1,130,Golden Spear,213,100,10,1,4,1
+24063,3,48000,1,135,Blackshatter Spear,213,100,10,1,0,1
+24064,3,48000,1,135,Blackshatter Spear,213,100,10,1,1,1
+24065,3,48000,1,135,Blackshatter Spear,213,100,10,1,2,1
+24066,3,48000,1,135,Blackshatter Spear,213,100,10,1,3,1
+24067,3,48000,1,135,Blackshatter Spear,213,100,10,1,4,1
+24068,3,50000,1,130,Lost Continent's Rover Lance,213,1,10,4,4,1
+24069,3,50000,1,130,"Ancient Muse's Lance, Left Behind",213,1,10,4,4,1
+24070,3,50000,1,135,Frozen Crystal Elga Lance,213,1,10,4,4,1
+24071,3,48000,1,130,Spirit's Magick Sword,215,100,11,1,0,1
+24072,3,48000,1,130,Spirit's Magick Sword,215,100,11,1,1,1
+24073,3,48000,1,130,Spirit's Magick Sword,215,100,11,1,2,1
+24074,3,48000,1,130,Spirit's Magick Sword,215,100,11,1,3,1
+24075,3,48000,1,130,Spirit's Magick Sword,215,100,11,1,4,1
+24076,3,48000,1,130,Fire King's Magick Sword,215,100,11,1,0,1
+24077,3,48000,1,130,Fire King's Magick Sword,215,100,11,1,1,1
+24078,3,48000,1,130,Fire King's Magick Sword,215,100,11,1,2,1
+24079,3,48000,1,130,Fire King's Magick Sword,215,100,11,1,3,1
+24080,3,48000,1,130,Fire King's Magick Sword,215,100,11,1,4,1
+24081,3,48000,1,130,White Wings's Magick Sword,215,100,11,1,0,1
+24082,3,48000,1,130,White Wings's Magick Sword,215,100,11,1,1,1
+24083,3,48000,1,130,White Wings's Magick Sword,215,100,11,1,2,1
+24084,3,48000,1,130,White Wings's Magick Sword,215,100,11,1,3,1
+24085,3,48000,1,130,White Wings's Magick Sword,215,100,11,1,4,1
+24086,3,48000,1,130,Golden Magick Sword,215,100,11,1,0,1
+24087,3,48000,1,130,Golden Magick Sword,215,100,11,1,1,1
+24088,3,48000,1,130,Golden Magick Sword,215,100,11,1,2,1
+24089,3,48000,1,130,Golden Magick Sword,215,100,11,1,3,1
+24090,3,48000,1,130,Golden Magick Sword,215,100,11,1,4,1
+24091,3,48000,1,135,Blackshatter Magick Sword,215,100,11,1,0,1
+24092,3,48000,1,135,Blackshatter Magick Sword,215,100,11,1,1,1
+24093,3,48000,1,135,Blackshatter Magick Sword,215,100,11,1,2,1
+24094,3,48000,1,135,Blackshatter Magick Sword,215,100,11,1,3,1
+24095,3,48000,1,135,Blackshatter Magick Sword,215,100,11,1,4,1
+24096,3,50000,1,130,Lost Continent's Rover Scimitar,215,1,11,4,4,1
+24097,3,50000,1,130,"Ancient Muse's Scimitar, Left Behind",215,1,11,4,4,1
+24098,3,50000,1,135,Frozen Crystal Elga Scimitar,215,1,11,4,4,1
 24853,3,50000,1,10,Ultra-Rich Chocolate Sword,201,1,1,4,4,1
 24855,3,50000,1,10,Ultra-Rich Chocolate Blade,203,1,7,4,4,1
 24856,3,50000,1,10,Ultra-Rich Chocolate Wall,204,1,5,4,4,1
@@ -10441,257 +10441,257 @@
 24863,3,50000,1,10,Ultra-Rich Chocolate Wand,212,1,6,4,4,1
 24864,3,50000,1,10,Ultra-Rich Chocolate Lance,213,1,10,4,4,1
 24865,3,50000,1,10,Ultra-Rich Chocolate Scimitar,215,1,11,4,4,1
-24943,3,10000,1,14,Olfring Sword (Crimson),201,1,1,4,4,1
-24945,3,10000,1,14,Olfring Guard (Crimson),204,1,5,4,4,1
-24947,3,10000,1,14,Olfring Bow (Crimson),207,1,3,4,4,1
-24948,3,10000,1,14,Olfring Cane (Crimson),211,1,4,4,4,1
-24949,3,10000,1,14,Olfring Sword (Snow),201,1,1,4,4,1
-24951,3,10000,1,14,Olfring Guard (Snow),204,1,5,4,4,1
-24953,3,10000,1,14,Olfring Bow (Snow),207,1,3,4,4,1
-24954,3,10000,1,14,Olfring Cane (Snow),211,1,4,4,4,1
-24955,3,10000,1,8,Olfring Sword (DiCE),201,1,1,4,4,1
-24957,3,10000,1,8,Olfring Guard (DiCE),204,1,5,4,4,1
-24959,3,10000,1,8,Olfring Bow (DiCE),207,1,3,4,4,1
-24960,3,10000,1,8,Olfring Cane (DiCE),211,1,4,4,4,1
-24961,3,10000,1,14,Olfring Sword (Spirit),201,1,1,4,4,1
-24963,3,10000,1,14,Olfring Guard (Spirit),204,1,5,4,4,1
-24965,3,10000,1,14,Olfring Bow (Spirit),207,1,3,4,4,1
-24966,3,10000,1,14,Olfring Cane (Spirit),211,1,4,4,4,1
-24967,3,10000,1,14,Olfring Sword (染),201,1,1,4,4,1
-24969,3,10000,1,14,Olfring Guard (染),204,1,5,4,4,1
-24971,3,10000,1,14,Olfring Bow (染),207,1,3,4,4,1
-24972,3,10000,1,14,Olfring Cane (染),211,1,4,4,4,1
-24973,3,50000,1,2,Sword of Kraken,201,1,1,4,4,1
-24974,3,50000,1,2,Sword of Legend,201,1,1,4,4,1
-24975,3,50000,1,7,Sword of Ice Age,201,1,1,4,4,1
-24979,3,50000,1,2,Blade of Kraken,203,1,7,4,4,1
-24980,3,50000,1,2,Blade of Legend,203,1,7,4,4,1
-24982,3,50000,1,7,Blade of Ice Age,203,1,7,4,4,1
-24983,3,50000,1,2,Wall of Kraken,204,1,5,4,4,1
-24984,3,50000,1,2,Wall of Legend,204,1,5,4,4,1
-24985,3,50000,1,7,Wall of Ice Age,204,1,5,4,4,1
-24989,3,50000,1,2,Daggers of Kraken,206,1,2,4,4,1
-24990,3,50000,1,2,Daggers of Legend,206,1,2,4,4,1
-24991,3,50000,1,7,Daggers of Ice Age,206,1,2,4,4,1
-24992,3,50000,1,2,Arrow of Kraken,207,1,3,4,4,1
-24993,3,50000,1,2,Arrow of Legend,207,1,3,4,4,1
-24994,3,50000,1,7,Arrow of Ice Age,207,1,3,4,4,1
-24995,3,50000,1,2,Hand of Kraken,208,1,9,4,4,1
-24996,3,50000,1,2,Hand of Legend,208,1,9,4,4,1
-24997,3,50000,1,7,Hand of Ice Age,208,1,9,4,4,1
-24998,3,50000,1,2,Spell of Kraken,209,1,8,4,4,1
-24999,3,50000,1,2,Spell of Legend,209,1,8,4,4,1
-25000,3,50000,1,7,Spell of Ice Age,209,1,8,4,4,1
-25001,3,50000,1,2,Staff of Kraken,211,1,4,4,4,1
-25002,3,50000,1,2,Staff of Legend,211,1,4,4,4,1
-25003,3,50000,1,7,Staff of Ice Age,211,1,4,4,4,1
-25004,3,50000,1,2,Wand of Kraken,212,1,6,4,4,1
-25005,3,50000,1,2,Wand of Legend,212,1,6,4,4,1
-25006,3,50000,1,7,Wand of Ice Age,212,1,6,4,4,1
-25007,3,50000,1,2,Lance of Kraken,213,1,10,4,4,1
-25008,3,50000,1,2,Lance of Legend,213,1,10,4,4,1
-25009,3,50000,1,7,Lance of Ice Age,213,1,10,4,4,1
-25010,3,50000,1,2,Scimitar of Kraken,215,1,11,4,4,1
-25011,3,50000,1,2,Scimitar of Legend,215,1,11,4,4,1
-25012,3,50000,1,7,Scimitar of Ice Age,215,1,11,4,4,1
-25029,3,48500,1,12,Savage Courage Assault Sword,201,105,1,1,0,1
-25030,3,48500,1,12,Savage Courage Assault Sword,201,105,1,1,1,1
-25031,3,48500,1,12,Savage Courage Assault Sword,201,105,1,1,2,1
-25032,3,48500,1,12,Savage Courage Assault Sword,201,105,1,1,3,1
-25033,3,48500,1,12,Savage Courage Assault Sword,201,105,1,1,4,1
-25034,3,49000,1,1,Solitary Assault Sword,201,110,1,1,0,1
-25035,3,49000,1,1,Solitary Assault Sword,201,110,1,1,1,1
-25036,3,49000,1,1,Solitary Assault Sword,201,110,1,1,2,1
-25037,3,49000,1,1,Solitary Assault Sword,201,110,1,1,3,1
-25038,3,49000,1,1,Solitary Assault Sword,201,110,1,1,4,1
-25039,3,49500,1,6,Hero's Assault Sword,201,115,1,1,0,1
-25040,3,49500,1,6,Hero's Assault Sword,201,115,1,1,1,1
-25041,3,49500,1,6,Hero's Assault Sword,201,115,1,1,2,1
-25042,3,49500,1,6,Hero's Assault Sword,201,115,1,1,3,1
-25043,3,49500,1,6,Hero's Assault Sword,201,115,1,1,4,1
-25059,3,48500,1,12,Savage Courage Assault Blade,203,105,7,1,0,1
-25060,3,48500,1,12,Savage Courage Assault Blade,203,105,7,1,1,1
-25061,3,48500,1,12,Savage Courage Assault Blade,203,105,7,1,2,1
-25062,3,48500,1,12,Savage Courage Assault Blade,203,105,7,1,3,1
-25063,3,48500,1,12,Savage Courage Assault Blade,203,105,7,1,4,1
-25064,3,49000,1,1,Solitary Assault Blade,203,110,7,1,0,1
-25065,3,49000,1,1,Solitary Assault Blade,203,110,7,1,1,1
-25066,3,49000,1,1,Solitary Assault Blade,203,110,7,1,2,1
-25067,3,49000,1,1,Solitary Assault Blade,203,110,7,1,3,1
-25068,3,49000,1,1,Solitary Assault Blade,203,110,7,1,4,1
-25069,3,49500,1,6,Hero's Assault Blade,203,115,7,1,0,1
-25070,3,49500,1,6,Hero's Assault Blade,203,115,7,1,1,1
-25071,3,49500,1,6,Hero's Assault Blade,203,115,7,1,2,1
-25072,3,49500,1,6,Hero's Assault Blade,203,115,7,1,3,1
-25073,3,49500,1,6,Hero's Assault Blade,203,115,7,1,4,1
-25074,3,48500,1,12,Savage Courage Ranger Wall,204,105,5,1,0,1
-25075,3,48500,1,12,Savage Courage Ranger Wall,204,105,5,1,1,1
-25076,3,48500,1,12,Savage Courage Ranger Wall,204,105,5,1,2,1
-25077,3,48500,1,12,Savage Courage Ranger Wall,204,105,5,1,3,1
-25078,3,48500,1,12,Savage Courage Ranger Wall,204,105,5,1,4,1
-25079,3,49000,1,1,Solitary Ranger's Wall,204,110,5,1,0,1
-25080,3,49000,1,1,Solitary Ranger's Wall,204,110,5,1,1,1
-25081,3,49000,1,1,Solitary Ranger's Wall,204,110,5,1,2,1
-25082,3,49000,1,1,Solitary Ranger's Wall,204,110,5,1,3,1
-25083,3,49000,1,1,Solitary Ranger's Wall,204,110,5,1,4,1
-25084,3,49500,1,6,Hero's Ranger Wall,204,115,5,1,0,1
-25085,3,49500,1,6,Hero's Ranger Wall,204,115,5,1,1,1
-25086,3,49500,1,6,Hero's Ranger Wall,204,115,5,1,2,1
-25087,3,49500,1,6,Hero's Ranger Wall,204,115,5,1,3,1
-25088,3,49500,1,6,Hero's Ranger Wall,204,115,5,1,4,1
-25104,3,48500,1,12,Savage Courage Snipe dagger,206,105,2,1,0,1
-25105,3,48500,1,12,Savage Courage Snipe dagger,206,105,2,1,1,1
-25106,3,48500,1,12,Savage Courage Snipe dagger,206,105,2,1,2,1
-25107,3,48500,1,12,Savage Courage Snipe dagger,206,105,2,1,3,1
-25108,3,48500,1,12,Savage Courage Snipe dagger,206,105,2,1,4,1
-25109,3,49000,1,1,Solitary's Snipe Daggers,206,110,2,1,0,1
-25110,3,49000,1,1,Solitary's Snipe Daggers,206,110,2,1,1,1
-25111,3,49000,1,1,Solitary's Snipe Daggers,206,110,2,1,2,1
-25112,3,49000,1,1,Solitary's Snipe Daggers,206,110,2,1,3,1
-25113,3,49000,1,1,Solitary's Snipe Daggers,206,110,2,1,4,1
-25114,3,49500,1,6,Hero's Snipe Daggers,206,115,2,1,0,1
-25115,3,49500,1,6,Hero's Snipe Daggers,206,115,2,1,1,1
-25116,3,49500,1,6,Hero's Snipe Daggers,206,115,2,1,2,1
-25117,3,49500,1,6,Hero's Snipe Daggers,206,115,2,1,3,1
-25118,3,49500,1,6,Hero's Snipe Daggers,206,115,2,1,4,1
-25119,3,48500,1,12,Savage Courage Snipe Arrow,207,105,3,1,0,1
-25120,3,48500,1,12,Savage Courage Snipe Arrow,207,105,3,1,1,1
-25121,3,48500,1,12,Savage Courage Snipe Arrow,207,105,3,1,2,1
-25122,3,48500,1,12,Savage Courage Snipe Arrow,207,105,3,1,3,1
-25123,3,48500,1,12,Savage Courage Snipe Arrow,207,105,3,1,4,1
-25124,3,49000,1,1,Solitary Snipe Arrow,207,110,3,1,0,1
-25125,3,49000,1,1,Solitary Snipe Arrow,207,110,3,1,1,1
-25126,3,49000,1,1,Solitary Snipe Arrow,207,110,3,1,2,1
-25127,3,49000,1,1,Solitary Snipe Arrow,207,110,3,1,3,1
-25128,3,49000,1,1,Solitary Snipe Arrow,207,110,3,1,4,1
-25129,3,49500,1,6,Hero's Snipe Arrow,207,115,3,1,0,1
-25130,3,49500,1,6,Hero's Snipe Arrow,207,115,3,1,1,1
-25131,3,49500,1,6,Hero's Snipe Arrow,207,115,3,1,2,1
-25132,3,49500,1,6,Hero's Snipe Arrow,207,115,3,1,3,1
-25133,3,49500,1,6,Hero's Snipe Arrow,207,115,3,1,4,1
-25134,3,48500,1,12,Savage Courage Ranger Hands,208,105,9,1,0,1
-25135,3,48500,1,12,Savage Courage Ranger Hands,208,105,9,1,1,1
-25136,3,48500,1,12,Savage Courage Ranger Hands,208,105,9,1,2,1
-25137,3,48500,1,12,Savage Courage Ranger Hands,208,105,9,1,3,1
-25138,3,48500,1,12,Savage Courage Ranger Hands,208,105,9,1,4,1
-25139,3,49000,1,1,Solitary Ranger's Hands,208,110,9,1,0,1
-25140,3,49000,1,1,Solitary Ranger's Hands,208,110,9,1,1,1
-25141,3,49000,1,1,Solitary Ranger's Hands,208,110,9,1,2,1
-25142,3,49000,1,1,Solitary Ranger's Hands,208,110,9,1,3,1
-25143,3,49000,1,1,Solitary Ranger's Hands,208,110,9,1,4,1
-25144,3,49500,1,6,Hero's Ranger Hands,208,115,9,1,0,1
-25145,3,49500,1,6,Hero's Ranger Hands,208,115,9,1,1,1
-25146,3,49500,1,6,Hero's Ranger Hands,208,115,9,1,2,1
-25147,3,49500,1,6,Hero's Ranger Hands,208,115,9,1,3,1
-25148,3,49500,1,6,Hero's Ranger Hands,208,115,9,1,4,1
-25149,3,48500,1,12,Savage Courage Magic Spell,209,105,8,1,0,1
-25150,3,48500,1,12,Savage Courage Magic Spell,209,105,8,1,1,1
-25151,3,48500,1,12,Savage Courage Magic Spell,209,105,8,1,2,1
-25152,3,48500,1,12,Savage Courage Magic Spell,209,105,8,1,3,1
-25153,3,48500,1,12,Savage Courage Magic Spell,209,105,8,1,4,1
-25154,3,49000,1,1,Solitary Magic Spell,209,110,8,1,0,1
-25155,3,49000,1,1,Solitary Magic Spell,209,110,8,1,1,1
-25156,3,49000,1,1,Solitary Magic Spell,209,110,8,1,2,1
-25157,3,49000,1,1,Solitary Magic Spell,209,110,8,1,3,1
-25158,3,49000,1,1,Solitary Magic Spell,209,110,8,1,4,1
-25159,3,49500,1,6,Hero's Magic Spell,209,115,8,1,0,1
-25160,3,49500,1,6,Hero's Magic Spell,209,115,8,1,1,1
-25161,3,49500,1,6,Hero's Magic Spell,209,115,8,1,2,1
-25162,3,49500,1,6,Hero's Magic Spell,209,115,8,1,3,1
-25163,3,49500,1,6,Hero's Magic Spell,209,115,8,1,4,1
-25164,3,48500,1,12,Savage Courage Magic Staff,211,105,4,1,0,1
-25165,3,48500,1,12,Savage Courage Magic Staff,211,105,4,1,1,1
-25166,3,48500,1,12,Savage Courage Magic Staff,211,105,4,1,2,1
-25167,3,48500,1,12,Savage Courage Magic Staff,211,105,4,1,3,1
-25168,3,48500,1,12,Savage Courage Magic Staff,211,105,4,1,4,1
-25169,3,49000,1,1,Solitary Magic Staff,211,110,4,1,0,1
-25170,3,49000,1,1,Solitary Magic Staff,211,110,4,1,1,1
-25171,3,49000,1,1,Solitary Magic Staff,211,110,4,1,2,1
-25172,3,49000,1,1,Solitary Magic Staff,211,110,4,1,3,1
-25173,3,49000,1,1,Solitary Magic Staff,211,110,4,1,4,1
-25174,3,49500,1,6,Hero's Magic Staff,211,115,4,1,0,1
-25175,3,49500,1,6,Hero's Magic Staff,211,115,4,1,1,1
-25176,3,49500,1,6,Hero's Magic Staff,211,115,4,1,2,1
-25177,3,49500,1,6,Hero's Magic Staff,211,115,4,1,3,1
-25178,3,49500,1,6,Hero's Magic Staff,211,115,4,1,4,1
-25179,3,48500,1,12,Savage Courage Magic Wand,212,105,6,1,0,1
-25180,3,48500,1,12,Savage Courage Magic Wand,212,105,6,1,1,1
-25181,3,48500,1,12,Savage Courage Magic Wand,212,105,6,1,2,1
-25182,3,48500,1,12,Savage Courage Magic Wand,212,105,6,1,3,1
-25183,3,48500,1,12,Savage Courage Magic Wand,212,105,6,1,4,1
-25184,3,49000,1,1,Solitary Magic Wand,212,110,6,1,0,1
-25185,3,49000,1,1,Solitary Magic Wand,212,110,6,1,1,1
-25186,3,49000,1,1,Solitary Magic Wand,212,110,6,1,2,1
-25187,3,49000,1,1,Solitary Magic Wand,212,110,6,1,3,1
-25188,3,49000,1,1,Solitary Magic Wand,212,110,6,1,4,1
-25189,3,49500,1,6,Hero's Magic Wand,212,115,6,1,0,1
-25190,3,49500,1,6,Hero's Magic Wand,212,115,6,1,1,1
-25191,3,49500,1,6,Hero's Magic Wand,212,115,6,1,2,1
-25192,3,49500,1,6,Hero's Magic Wand,212,115,6,1,3,1
-25193,3,49500,1,6,Hero's Magic Wand,212,115,6,1,4,1
-25194,3,48500,1,12,Savage Courage Snipe Lance,213,105,10,1,0,1
-25195,3,48500,1,12,Savage Courage Snipe Lance,213,105,10,1,1,1
-25196,3,48500,1,12,Savage Courage Snipe Lance,213,105,10,1,2,1
-25197,3,48500,1,12,Savage Courage Snipe Lance,213,105,10,1,3,1
-25198,3,48500,1,12,Savage Courage Snipe Lance,213,105,10,1,4,1
-25199,3,49000,1,1,Solitary's Snipe Lance,213,110,10,1,0,1
-25200,3,49000,1,1,Solitary's Snipe Lance,213,110,10,1,1,1
-25201,3,49000,1,1,Solitary's Snipe Lance,213,110,10,1,2,1
-25202,3,49000,1,1,Solitary's Snipe Lance,213,110,10,1,3,1
-25203,3,49000,1,1,Solitary's Snipe Lance,213,110,10,1,4,1
-25204,3,49500,1,6,Hero's Snipe Lance,213,115,10,1,0,1
-25205,3,49500,1,6,Hero's Snipe Lance,213,115,10,1,1,1
-25206,3,49500,1,6,Hero's Snipe Lance,213,115,10,1,2,1
-25207,3,49500,1,6,Hero's Snipe Lance,213,115,10,1,3,1
-25208,3,49500,1,6,Hero's Snipe Lance,213,115,10,1,4,1
-25209,3,48500,1,12,Savage Courage Ranger Scimitar,215,105,11,1,0,1
-25210,3,48500,1,12,Savage Courage Ranger Scimitar,215,105,11,1,1,1
-25211,3,48500,1,12,Savage Courage Ranger Scimitar,215,105,11,1,2,1
-25212,3,48500,1,12,Savage Courage Ranger Scimitar,215,105,11,1,3,1
-25213,3,48500,1,12,Savage Courage Ranger Scimitar,215,105,11,1,4,1
-25214,3,49000,1,1,Solitary Ranger's Scimitar,215,110,11,1,0,1
-25215,3,49000,1,1,Solitary Ranger's Scimitar,215,110,11,1,1,1
-25216,3,49000,1,1,Solitary Ranger's Scimitar,215,110,11,1,2,1
-25217,3,49000,1,1,Solitary Ranger's Scimitar,215,110,11,1,3,1
-25218,3,49000,1,1,Solitary Ranger's Scimitar,215,110,11,1,4,1
-25219,3,49500,1,6,Hero's Ranger Scimitar,215,115,11,1,0,1
-25220,3,49500,1,6,Hero's Ranger Scimitar,215,115,11,1,1,1
-25221,3,49500,1,6,Hero's Ranger Scimitar,215,115,11,1,2,1
-25222,3,49500,1,6,Hero's Ranger Scimitar,215,115,11,1,3,1
-25223,3,49500,1,6,Hero's Ranger Scimitar,215,115,11,1,4,1
-25578,3,50000,1,12,Sword of Guardian,201,1,1,4,4,1
-25580,3,50000,1,12,Saber of Guardian,203,1,7,4,4,1
-25581,3,50000,1,12,Wall of Guardian,204,1,5,4,4,1
-25583,3,50000,1,12,Daggers of Guardian,206,1,2,4,4,1
-25584,3,50000,1,12,Bow of Guardian,207,1,3,4,4,1
-25585,3,50000,1,12,Arm of Guardian,208,1,9,4,4,1
-25586,3,50000,1,12,Spell of Guardian,209,1,8,4,4,1
-25587,3,50000,1,12,Staff of Guardian,211,1,4,4,4,1
-25588,3,50000,1,12,Wand of Guardian,212,1,6,4,4,1
-25589,3,50000,1,12,Lance of Guardian,213,1,10,4,4,1
-25590,3,50000,1,12,Edge of Guardian,215,1,11,4,4,1
-25591,3,50000,1,1,Fortress Guard's Fortified Sword,201,1,1,4,4,1
-25593,3,50000,1,1,Fortress Guard's Fortified Greatsword,203,1,7,4,4,1
-25594,3,50000,1,1,Fortress Guard's Fortified Greatshield,204,1,5,4,4,1
-25596,3,50000,1,1,Fortress Guard's Fortified Dagger,206,1,2,4,4,1
-25597,3,50000,1,1,Fortress Guard's Fortified Bow,207,1,3,4,4,1
-25598,3,50000,1,1,Fortress Guard's Fortified Gauntlets,208,1,9,4,4,1
-25599,3,50000,1,1,Fortress Guard's Fortified Magick Bow,209,1,8,4,4,1
-25600,3,50000,1,1,Fortress Guard's Fortified Staff,211,1,4,4,4,1
-25601,3,50000,1,1,Fortress Guard's Fortified Archistaff,212,1,6,4,4,1
-25602,3,50000,1,1,Fortress Guard's Fortified Spear,213,1,10,4,4,1
-25603,3,50000,1,1,Fortress Guard's Fortified Blade,215,1,11,4,4,1
-25604,3,50000,1,6,High Ancient Sword,201,1,1,4,4,1
-25606,3,50000,1,6,High Ancient Saber,203,1,7,4,4,1
-25607,3,50000,1,6,High Ancient Wall,204,1,5,4,4,1
-25609,3,50000,1,6,High Ancient Daggers,206,1,2,4,4,1
-25610,3,50000,1,6,High Ancient Bow,207,1,3,4,4,1
-25611,3,50000,1,6,High Ancient Arm,208,1,9,4,4,1
-25612,3,50000,1,6,High Ancient Spell,209,1,8,4,4,1
-25613,3,50000,1,6,High Ancient Staff,211,1,4,4,4,1
-25614,3,50000,1,6,High Ancient Wand,212,1,6,4,4,1
-25615,3,50000,1,6,High Ancient Lance,213,1,10,4,4,1
-25616,3,50000,1,6,High Ancient Scimitar,215,1,11,4,4,1
+24943,3,10000,1,110,Olfring Sword (Crimson),201,1,1,4,4,1
+24945,3,10000,1,110,Olfring Guard (Crimson),204,1,5,4,4,1
+24947,3,10000,1,110,Olfring Bow (Crimson),207,1,3,4,4,1
+24948,3,10000,1,110,Olfring Cane (Crimson),211,1,4,4,4,1
+24949,3,10000,1,110,Olfring Sword (Snow),201,1,1,4,4,1
+24951,3,10000,1,110,Olfring Guard (Snow),204,1,5,4,4,1
+24953,3,10000,1,110,Olfring Bow (Snow),207,1,3,4,4,1
+24954,3,10000,1,110,Olfring Cane (Snow),211,1,4,4,4,1
+24955,3,10000,1,120,Olfring Sword (DiCE),201,1,1,4,4,1
+24957,3,10000,1,120,Olfring Guard (DiCE),204,1,5,4,4,1
+24959,3,10000,1,120,Olfring Bow (DiCE),207,1,3,4,4,1
+24960,3,10000,1,120,Olfring Cane (DiCE),211,1,4,4,4,1
+24961,3,10000,1,110,Olfring Sword (Spirit),201,1,1,4,4,1
+24963,3,10000,1,110,Olfring Guard (Spirit),204,1,5,4,4,1
+24965,3,10000,1,110,Olfring Bow (Spirit),207,1,3,4,4,1
+24966,3,10000,1,110,Olfring Cane (Spirit),211,1,4,4,4,1
+24967,3,10000,1,110,Olfring Sword (染),201,1,1,4,4,1
+24969,3,10000,1,110,Olfring Guard (染),204,1,5,4,4,1
+24971,3,10000,1,110,Olfring Bow (染),207,1,3,4,4,1
+24972,3,10000,1,110,Olfring Cane (染),211,1,4,4,4,1
+24973,3,50000,1,130,Sword of Kraken,201,1,1,4,4,1
+24974,3,50000,1,130,Sword of Legend,201,1,1,4,4,1
+24975,3,50000,1,135,Sword of Ice Age,201,1,1,4,4,1
+24979,3,50000,1,130,Blade of Kraken,203,1,7,4,4,1
+24980,3,50000,1,130,Blade of Legend,203,1,7,4,4,1
+24982,3,50000,1,135,Blade of Ice Age,203,1,7,4,4,1
+24983,3,50000,1,130,Wall of Kraken,204,1,5,4,4,1
+24984,3,50000,1,130,Wall of Legend,204,1,5,4,4,1
+24985,3,50000,1,135,Wall of Ice Age,204,1,5,4,4,1
+24989,3,50000,1,130,Daggers of Kraken,206,1,2,4,4,1
+24990,3,50000,1,130,Daggers of Legend,206,1,2,4,4,1
+24991,3,50000,1,135,Daggers of Ice Age,206,1,2,4,4,1
+24992,3,50000,1,130,Arrow of Kraken,207,1,3,4,4,1
+24993,3,50000,1,130,Arrow of Legend,207,1,3,4,4,1
+24994,3,50000,1,135,Arrow of Ice Age,207,1,3,4,4,1
+24995,3,50000,1,130,Hand of Kraken,208,1,9,4,4,1
+24996,3,50000,1,130,Hand of Legend,208,1,9,4,4,1
+24997,3,50000,1,135,Hand of Ice Age,208,1,9,4,4,1
+24998,3,50000,1,130,Spell of Kraken,209,1,8,4,4,1
+24999,3,50000,1,130,Spell of Legend,209,1,8,4,4,1
+25000,3,50000,1,135,Spell of Ice Age,209,1,8,4,4,1
+25001,3,50000,1,130,Staff of Kraken,211,1,4,4,4,1
+25002,3,50000,1,130,Staff of Legend,211,1,4,4,4,1
+25003,3,50000,1,135,Staff of Ice Age,211,1,4,4,4,1
+25004,3,50000,1,130,Wand of Kraken,212,1,6,4,4,1
+25005,3,50000,1,130,Wand of Legend,212,1,6,4,4,1
+25006,3,50000,1,135,Wand of Ice Age,212,1,6,4,4,1
+25007,3,50000,1,130,Lance of Kraken,213,1,10,4,4,1
+25008,3,50000,1,130,Lance of Legend,213,1,10,4,4,1
+25009,3,50000,1,135,Lance of Ice Age,213,1,10,4,4,1
+25010,3,50000,1,130,Scimitar of Kraken,215,1,11,4,4,1
+25011,3,50000,1,130,Scimitar of Legend,215,1,11,4,4,1
+25012,3,50000,1,135,Scimitar of Ice Age,215,1,11,4,4,1
+25029,3,48500,1,140,Savage Courage Assault Sword,201,105,1,1,0,1
+25030,3,48500,1,140,Savage Courage Assault Sword,201,105,1,1,1,1
+25031,3,48500,1,140,Savage Courage Assault Sword,201,105,1,1,2,1
+25032,3,48500,1,140,Savage Courage Assault Sword,201,105,1,1,3,1
+25033,3,48500,1,140,Savage Courage Assault Sword,201,105,1,1,4,1
+25034,3,49000,1,145,Solitary Assault Sword,201,110,1,1,0,1
+25035,3,49000,1,145,Solitary Assault Sword,201,110,1,1,1,1
+25036,3,49000,1,145,Solitary Assault Sword,201,110,1,1,2,1
+25037,3,49000,1,145,Solitary Assault Sword,201,110,1,1,3,1
+25038,3,49000,1,145,Solitary Assault Sword,201,110,1,1,4,1
+25039,3,49500,1,150,Hero's Assault Sword,201,115,1,1,0,1
+25040,3,49500,1,150,Hero's Assault Sword,201,115,1,1,1,1
+25041,3,49500,1,150,Hero's Assault Sword,201,115,1,1,2,1
+25042,3,49500,1,150,Hero's Assault Sword,201,115,1,1,3,1
+25043,3,49500,1,150,Hero's Assault Sword,201,115,1,1,4,1
+25059,3,48500,1,140,Savage Courage Assault Blade,203,105,7,1,0,1
+25060,3,48500,1,140,Savage Courage Assault Blade,203,105,7,1,1,1
+25061,3,48500,1,140,Savage Courage Assault Blade,203,105,7,1,2,1
+25062,3,48500,1,140,Savage Courage Assault Blade,203,105,7,1,3,1
+25063,3,48500,1,140,Savage Courage Assault Blade,203,105,7,1,4,1
+25064,3,49000,1,145,Solitary Assault Blade,203,110,7,1,0,1
+25065,3,49000,1,145,Solitary Assault Blade,203,110,7,1,1,1
+25066,3,49000,1,145,Solitary Assault Blade,203,110,7,1,2,1
+25067,3,49000,1,145,Solitary Assault Blade,203,110,7,1,3,1
+25068,3,49000,1,145,Solitary Assault Blade,203,110,7,1,4,1
+25069,3,49500,1,150,Hero's Assault Blade,203,115,7,1,0,1
+25070,3,49500,1,150,Hero's Assault Blade,203,115,7,1,1,1
+25071,3,49500,1,150,Hero's Assault Blade,203,115,7,1,2,1
+25072,3,49500,1,150,Hero's Assault Blade,203,115,7,1,3,1
+25073,3,49500,1,150,Hero's Assault Blade,203,115,7,1,4,1
+25074,3,48500,1,140,Savage Courage Ranger Wall,204,105,5,1,0,1
+25075,3,48500,1,140,Savage Courage Ranger Wall,204,105,5,1,1,1
+25076,3,48500,1,140,Savage Courage Ranger Wall,204,105,5,1,2,1
+25077,3,48500,1,140,Savage Courage Ranger Wall,204,105,5,1,3,1
+25078,3,48500,1,140,Savage Courage Ranger Wall,204,105,5,1,4,1
+25079,3,49000,1,145,Solitary Ranger's Wall,204,110,5,1,0,1
+25080,3,49000,1,145,Solitary Ranger's Wall,204,110,5,1,1,1
+25081,3,49000,1,145,Solitary Ranger's Wall,204,110,5,1,2,1
+25082,3,49000,1,145,Solitary Ranger's Wall,204,110,5,1,3,1
+25083,3,49000,1,145,Solitary Ranger's Wall,204,110,5,1,4,1
+25084,3,49500,1,150,Hero's Ranger Wall,204,115,5,1,0,1
+25085,3,49500,1,150,Hero's Ranger Wall,204,115,5,1,1,1
+25086,3,49500,1,150,Hero's Ranger Wall,204,115,5,1,2,1
+25087,3,49500,1,150,Hero's Ranger Wall,204,115,5,1,3,1
+25088,3,49500,1,150,Hero's Ranger Wall,204,115,5,1,4,1
+25104,3,48500,1,140,Savage Courage Snipe dagger,206,105,2,1,0,1
+25105,3,48500,1,140,Savage Courage Snipe dagger,206,105,2,1,1,1
+25106,3,48500,1,140,Savage Courage Snipe dagger,206,105,2,1,2,1
+25107,3,48500,1,140,Savage Courage Snipe dagger,206,105,2,1,3,1
+25108,3,48500,1,140,Savage Courage Snipe dagger,206,105,2,1,4,1
+25109,3,49000,1,145,Solitary's Snipe Daggers,206,110,2,1,0,1
+25110,3,49000,1,145,Solitary's Snipe Daggers,206,110,2,1,1,1
+25111,3,49000,1,145,Solitary's Snipe Daggers,206,110,2,1,2,1
+25112,3,49000,1,145,Solitary's Snipe Daggers,206,110,2,1,3,1
+25113,3,49000,1,145,Solitary's Snipe Daggers,206,110,2,1,4,1
+25114,3,49500,1,150,Hero's Snipe Daggers,206,115,2,1,0,1
+25115,3,49500,1,150,Hero's Snipe Daggers,206,115,2,1,1,1
+25116,3,49500,1,150,Hero's Snipe Daggers,206,115,2,1,2,1
+25117,3,49500,1,150,Hero's Snipe Daggers,206,115,2,1,3,1
+25118,3,49500,1,150,Hero's Snipe Daggers,206,115,2,1,4,1
+25119,3,48500,1,140,Savage Courage Snipe Arrow,207,105,3,1,0,1
+25120,3,48500,1,140,Savage Courage Snipe Arrow,207,105,3,1,1,1
+25121,3,48500,1,140,Savage Courage Snipe Arrow,207,105,3,1,2,1
+25122,3,48500,1,140,Savage Courage Snipe Arrow,207,105,3,1,3,1
+25123,3,48500,1,140,Savage Courage Snipe Arrow,207,105,3,1,4,1
+25124,3,49000,1,145,Solitary Snipe Arrow,207,110,3,1,0,1
+25125,3,49000,1,145,Solitary Snipe Arrow,207,110,3,1,1,1
+25126,3,49000,1,145,Solitary Snipe Arrow,207,110,3,1,2,1
+25127,3,49000,1,145,Solitary Snipe Arrow,207,110,3,1,3,1
+25128,3,49000,1,145,Solitary Snipe Arrow,207,110,3,1,4,1
+25129,3,49500,1,150,Hero's Snipe Arrow,207,115,3,1,0,1
+25130,3,49500,1,150,Hero's Snipe Arrow,207,115,3,1,1,1
+25131,3,49500,1,150,Hero's Snipe Arrow,207,115,3,1,2,1
+25132,3,49500,1,150,Hero's Snipe Arrow,207,115,3,1,3,1
+25133,3,49500,1,150,Hero's Snipe Arrow,207,115,3,1,4,1
+25134,3,48500,1,140,Savage Courage Ranger Hands,208,105,9,1,0,1
+25135,3,48500,1,140,Savage Courage Ranger Hands,208,105,9,1,1,1
+25136,3,48500,1,140,Savage Courage Ranger Hands,208,105,9,1,2,1
+25137,3,48500,1,140,Savage Courage Ranger Hands,208,105,9,1,3,1
+25138,3,48500,1,140,Savage Courage Ranger Hands,208,105,9,1,4,1
+25139,3,49000,1,145,Solitary Ranger's Hands,208,110,9,1,0,1
+25140,3,49000,1,145,Solitary Ranger's Hands,208,110,9,1,1,1
+25141,3,49000,1,145,Solitary Ranger's Hands,208,110,9,1,2,1
+25142,3,49000,1,145,Solitary Ranger's Hands,208,110,9,1,3,1
+25143,3,49000,1,145,Solitary Ranger's Hands,208,110,9,1,4,1
+25144,3,49500,1,150,Hero's Ranger Hands,208,115,9,1,0,1
+25145,3,49500,1,150,Hero's Ranger Hands,208,115,9,1,1,1
+25146,3,49500,1,150,Hero's Ranger Hands,208,115,9,1,2,1
+25147,3,49500,1,150,Hero's Ranger Hands,208,115,9,1,3,1
+25148,3,49500,1,150,Hero's Ranger Hands,208,115,9,1,4,1
+25149,3,48500,1,140,Savage Courage Magic Spell,209,105,8,1,0,1
+25150,3,48500,1,140,Savage Courage Magic Spell,209,105,8,1,1,1
+25151,3,48500,1,140,Savage Courage Magic Spell,209,105,8,1,2,1
+25152,3,48500,1,140,Savage Courage Magic Spell,209,105,8,1,3,1
+25153,3,48500,1,140,Savage Courage Magic Spell,209,105,8,1,4,1
+25154,3,49000,1,145,Solitary Magic Spell,209,110,8,1,0,1
+25155,3,49000,1,145,Solitary Magic Spell,209,110,8,1,1,1
+25156,3,49000,1,145,Solitary Magic Spell,209,110,8,1,2,1
+25157,3,49000,1,145,Solitary Magic Spell,209,110,8,1,3,1
+25158,3,49000,1,145,Solitary Magic Spell,209,110,8,1,4,1
+25159,3,49500,1,150,Hero's Magic Spell,209,115,8,1,0,1
+25160,3,49500,1,150,Hero's Magic Spell,209,115,8,1,1,1
+25161,3,49500,1,150,Hero's Magic Spell,209,115,8,1,2,1
+25162,3,49500,1,150,Hero's Magic Spell,209,115,8,1,3,1
+25163,3,49500,1,150,Hero's Magic Spell,209,115,8,1,4,1
+25164,3,48500,1,140,Savage Courage Magic Staff,211,105,4,1,0,1
+25165,3,48500,1,140,Savage Courage Magic Staff,211,105,4,1,1,1
+25166,3,48500,1,140,Savage Courage Magic Staff,211,105,4,1,2,1
+25167,3,48500,1,140,Savage Courage Magic Staff,211,105,4,1,3,1
+25168,3,48500,1,140,Savage Courage Magic Staff,211,105,4,1,4,1
+25169,3,49000,1,145,Solitary Magic Staff,211,110,4,1,0,1
+25170,3,49000,1,145,Solitary Magic Staff,211,110,4,1,1,1
+25171,3,49000,1,145,Solitary Magic Staff,211,110,4,1,2,1
+25172,3,49000,1,145,Solitary Magic Staff,211,110,4,1,3,1
+25173,3,49000,1,145,Solitary Magic Staff,211,110,4,1,4,1
+25174,3,49500,1,150,Hero's Magic Staff,211,115,4,1,0,1
+25175,3,49500,1,150,Hero's Magic Staff,211,115,4,1,1,1
+25176,3,49500,1,150,Hero's Magic Staff,211,115,4,1,2,1
+25177,3,49500,1,150,Hero's Magic Staff,211,115,4,1,3,1
+25178,3,49500,1,150,Hero's Magic Staff,211,115,4,1,4,1
+25179,3,48500,1,140,Savage Courage Magic Wand,212,105,6,1,0,1
+25180,3,48500,1,140,Savage Courage Magic Wand,212,105,6,1,1,1
+25181,3,48500,1,140,Savage Courage Magic Wand,212,105,6,1,2,1
+25182,3,48500,1,140,Savage Courage Magic Wand,212,105,6,1,3,1
+25183,3,48500,1,140,Savage Courage Magic Wand,212,105,6,1,4,1
+25184,3,49000,1,145,Solitary Magic Wand,212,110,6,1,0,1
+25185,3,49000,1,145,Solitary Magic Wand,212,110,6,1,1,1
+25186,3,49000,1,145,Solitary Magic Wand,212,110,6,1,2,1
+25187,3,49000,1,145,Solitary Magic Wand,212,110,6,1,3,1
+25188,3,49000,1,145,Solitary Magic Wand,212,110,6,1,4,1
+25189,3,49500,1,150,Hero's Magic Wand,212,115,6,1,0,1
+25190,3,49500,1,150,Hero's Magic Wand,212,115,6,1,1,1
+25191,3,49500,1,150,Hero's Magic Wand,212,115,6,1,2,1
+25192,3,49500,1,150,Hero's Magic Wand,212,115,6,1,3,1
+25193,3,49500,1,150,Hero's Magic Wand,212,115,6,1,4,1
+25194,3,48500,1,140,Savage Courage Snipe Lance,213,105,10,1,0,1
+25195,3,48500,1,140,Savage Courage Snipe Lance,213,105,10,1,1,1
+25196,3,48500,1,140,Savage Courage Snipe Lance,213,105,10,1,2,1
+25197,3,48500,1,140,Savage Courage Snipe Lance,213,105,10,1,3,1
+25198,3,48500,1,140,Savage Courage Snipe Lance,213,105,10,1,4,1
+25199,3,49000,1,145,Solitary's Snipe Lance,213,110,10,1,0,1
+25200,3,49000,1,145,Solitary's Snipe Lance,213,110,10,1,1,1
+25201,3,49000,1,145,Solitary's Snipe Lance,213,110,10,1,2,1
+25202,3,49000,1,145,Solitary's Snipe Lance,213,110,10,1,3,1
+25203,3,49000,1,145,Solitary's Snipe Lance,213,110,10,1,4,1
+25204,3,49500,1,150,Hero's Snipe Lance,213,115,10,1,0,1
+25205,3,49500,1,150,Hero's Snipe Lance,213,115,10,1,1,1
+25206,3,49500,1,150,Hero's Snipe Lance,213,115,10,1,2,1
+25207,3,49500,1,150,Hero's Snipe Lance,213,115,10,1,3,1
+25208,3,49500,1,150,Hero's Snipe Lance,213,115,10,1,4,1
+25209,3,48500,1,140,Savage Courage Ranger Scimitar,215,105,11,1,0,1
+25210,3,48500,1,140,Savage Courage Ranger Scimitar,215,105,11,1,1,1
+25211,3,48500,1,140,Savage Courage Ranger Scimitar,215,105,11,1,2,1
+25212,3,48500,1,140,Savage Courage Ranger Scimitar,215,105,11,1,3,1
+25213,3,48500,1,140,Savage Courage Ranger Scimitar,215,105,11,1,4,1
+25214,3,49000,1,145,Solitary Ranger's Scimitar,215,110,11,1,0,1
+25215,3,49000,1,145,Solitary Ranger's Scimitar,215,110,11,1,1,1
+25216,3,49000,1,145,Solitary Ranger's Scimitar,215,110,11,1,2,1
+25217,3,49000,1,145,Solitary Ranger's Scimitar,215,110,11,1,3,1
+25218,3,49000,1,145,Solitary Ranger's Scimitar,215,110,11,1,4,1
+25219,3,49500,1,150,Hero's Ranger Scimitar,215,115,11,1,0,1
+25220,3,49500,1,150,Hero's Ranger Scimitar,215,115,11,1,1,1
+25221,3,49500,1,150,Hero's Ranger Scimitar,215,115,11,1,2,1
+25222,3,49500,1,150,Hero's Ranger Scimitar,215,115,11,1,3,1
+25223,3,49500,1,150,Hero's Ranger Scimitar,215,115,11,1,4,1
+25578,3,50000,1,140,Sword of Guardian,201,1,1,4,4,1
+25580,3,50000,1,140,Saber of Guardian,203,1,7,4,4,1
+25581,3,50000,1,140,Wall of Guardian,204,1,5,4,4,1
+25583,3,50000,1,140,Daggers of Guardian,206,1,2,4,4,1
+25584,3,50000,1,140,Bow of Guardian,207,1,3,4,4,1
+25585,3,50000,1,140,Arm of Guardian,208,1,9,4,4,1
+25586,3,50000,1,140,Spell of Guardian,209,1,8,4,4,1
+25587,3,50000,1,140,Staff of Guardian,211,1,4,4,4,1
+25588,3,50000,1,140,Wand of Guardian,212,1,6,4,4,1
+25589,3,50000,1,140,Lance of Guardian,213,1,10,4,4,1
+25590,3,50000,1,140,Edge of Guardian,215,1,11,4,4,1
+25591,3,50000,1,145,Fortress Guard's Fortified Sword,201,1,1,4,4,1
+25593,3,50000,1,145,Fortress Guard's Fortified Greatsword,203,1,7,4,4,1
+25594,3,50000,1,145,Fortress Guard's Fortified Greatshield,204,1,5,4,4,1
+25596,3,50000,1,145,Fortress Guard's Fortified Dagger,206,1,2,4,4,1
+25597,3,50000,1,145,Fortress Guard's Fortified Bow,207,1,3,4,4,1
+25598,3,50000,1,145,Fortress Guard's Fortified Gauntlets,208,1,9,4,4,1
+25599,3,50000,1,145,Fortress Guard's Fortified Magick Bow,209,1,8,4,4,1
+25600,3,50000,1,145,Fortress Guard's Fortified Staff,211,1,4,4,4,1
+25601,3,50000,1,145,Fortress Guard's Fortified Archistaff,212,1,6,4,4,1
+25602,3,50000,1,145,Fortress Guard's Fortified Spear,213,1,10,4,4,1
+25603,3,50000,1,145,Fortress Guard's Fortified Blade,215,1,11,4,4,1
+25604,3,50000,1,150,High Ancient Sword,201,1,1,4,4,1
+25606,3,50000,1,150,High Ancient Saber,203,1,7,4,4,1
+25607,3,50000,1,150,High Ancient Wall,204,1,5,4,4,1
+25609,3,50000,1,150,High Ancient Daggers,206,1,2,4,4,1
+25610,3,50000,1,150,High Ancient Bow,207,1,3,4,4,1
+25611,3,50000,1,150,High Ancient Arm,208,1,9,4,4,1
+25612,3,50000,1,150,High Ancient Spell,209,1,8,4,4,1
+25613,3,50000,1,150,High Ancient Staff,211,1,4,4,4,1
+25614,3,50000,1,150,High Ancient Wand,212,1,6,4,4,1
+25615,3,50000,1,150,High Ancient Lance,213,1,10,4,4,1
+25616,3,50000,1,150,High Ancient Scimitar,215,1,11,4,4,1
 69,3,74,1,2,Pelta,202,6,1,0,0,1
 1681,3,74,1,2,Pelta,202,6,1,0,1,1
 2704,3,74,1,2,Pelta,202,6,1,0,2,1
@@ -11084,576 +11084,576 @@
 11685,3,5000,1,12,Alchemy Inductor,205,1,5,0,2,1
 11686,3,5000,1,12,Alchemy Inductor,205,1,5,0,3,1
 11687,3,5000,1,12,Alchemy Inductor,205,1,5,0,4,1
-11876,3,8452,1,4,Burly Spike,202,65,1,0,0,1
-11877,3,8452,1,4,Burly Spike,202,65,1,0,1,1
-11878,3,8452,1,4,Burly Spike,202,65,1,0,2,1
-11879,3,8452,1,4,Burly Spike,202,65,1,0,3,1
-11880,3,8452,1,4,Burly Spike,202,65,1,0,4,1
-11881,3,8452,1,9,Sturm,202,65,1,0,0,1
-11882,3,8452,1,9,Sturm,202,65,1,0,1,1
-11883,3,8452,1,9,Sturm,202,65,1,0,2,1
-11884,3,8452,1,9,Sturm,202,65,1,0,3,1
-11885,3,8452,1,9,Sturm,202,65,1,0,4,1
-11886,3,8452,1,14,Forge Brightness,202,65,1,0,0,1
-11887,3,8452,1,14,Forge Brightness,202,65,1,0,1,1
-11888,3,8452,1,14,Forge Brightness,202,65,1,0,2,1
-11889,3,8452,1,14,Forge Brightness,202,65,1,0,3,1
-11890,3,8452,1,14,Forge Brightness,202,65,1,0,4,1
-11891,3,8980,1,14,Lone Wolf Shield,202,67,1,0,0,1
-11892,3,8980,1,14,Lone Wolf Shield,202,67,1,0,1,1
-11893,3,8980,1,14,Lone Wolf Shield,202,67,1,0,2,1
-11894,3,8980,1,14,Lone Wolf Shield,202,67,1,0,3,1
-11895,3,8980,1,14,Lone Wolf Shield,202,67,1,0,4,1
-11896,3,9802,1,3,Pelta Shield,202,70,1,0,0,1
-11897,3,9802,1,3,Pelta Shield,202,70,1,0,1,1
-11898,3,9802,1,3,Pelta Shield,202,70,1,0,2,1
-11899,3,9802,1,3,Pelta Shield,202,70,1,0,3,1
-11900,3,9802,1,3,Pelta Shield,202,70,1,0,4,1
-11901,3,9802,1,8,Shield of Tyrant,202,70,1,0,0,1
-11902,3,9802,1,8,Shield of Tyrant,202,70,1,0,1,1
-11903,3,9802,1,8,Shield of Tyrant,202,70,1,0,2,1
-11904,3,9802,1,8,Shield of Tyrant,202,70,1,0,3,1
-11905,3,9802,1,8,Shield of Tyrant,202,70,1,0,4,1
-11906,3,9802,1,13,Immaculate Guard,202,70,1,0,0,1
-11907,3,9802,1,13,Immaculate Guard,202,70,1,0,1,1
-11908,3,9802,1,13,Immaculate Guard,202,70,1,0,2,1
-11909,3,9802,1,13,Immaculate Guard,202,70,1,0,3,1
-11910,3,9802,1,13,Immaculate Guard,202,70,1,0,4,1
-12051,3,8452,1,4,Limelight,205,65,5,0,0,1
-12052,3,8452,1,4,Limelight,205,65,5,0,1,1
-12053,3,8452,1,4,Limelight,205,65,5,0,2,1
-12054,3,8452,1,4,Limelight,205,65,5,0,3,1
-12055,3,8452,1,4,Limelight,205,65,5,0,4,1
-12056,3,8452,1,9,Vortex,205,65,5,0,0,1
-12057,3,8452,1,9,Vortex,205,65,5,0,1,1
-12058,3,8452,1,9,Vortex,205,65,5,0,2,1
-12059,3,8452,1,9,Vortex,205,65,5,0,3,1
-12060,3,8452,1,9,Vortex,205,65,5,0,4,1
-12061,3,8452,1,14,Divine Attractor,205,65,5,0,0,1
-12062,3,8452,1,14,Divine Attractor,205,65,5,0,1,1
-12063,3,8452,1,14,Divine Attractor,205,65,5,0,2,1
-12064,3,8452,1,14,Divine Attractor,205,65,5,0,3,1
-12065,3,8452,1,14,Divine Attractor,205,65,5,0,4,1
-12066,3,8980,1,14,Polaris Drop,205,67,5,0,0,1
-12067,3,8980,1,14,Polaris Drop,205,67,5,0,1,1
-12068,3,8980,1,14,Polaris Drop,205,67,5,0,2,1
-12069,3,8980,1,14,Polaris Drop,205,67,5,0,3,1
-12070,3,8980,1,14,Polaris Drop,205,67,5,0,4,1
-12071,3,9802,1,3,Judgement,205,70,5,0,0,1
-12072,3,9802,1,3,Judgement,205,70,5,0,1,1
-12073,3,9802,1,3,Judgement,205,70,5,0,2,1
-12074,3,9802,1,3,Judgement,205,70,5,0,3,1
-12075,3,9802,1,3,Judgement,205,70,5,0,4,1
-12076,3,9802,1,8,Rod of Tyrant,205,70,5,0,0,1
-12077,3,9802,1,8,Rod of Tyrant,205,70,5,0,1,1
-12078,3,9802,1,8,Rod of Tyrant,205,70,5,0,2,1
-12079,3,9802,1,8,Rod of Tyrant,205,70,5,0,3,1
-12080,3,9802,1,8,Rod of Tyrant,205,70,5,0,4,1
-12081,3,9802,1,13,Conscience Torch,205,70,5,0,0,1
-12082,3,9802,1,13,Conscience Torch,205,70,5,0,1,1
-12083,3,9802,1,13,Conscience Torch,205,70,5,0,2,1
-12084,3,9802,1,13,Conscience Torch,205,70,5,0,3,1
-12085,3,9802,1,13,Conscience Torch,205,70,5,0,4,1
-13982,3,5000,1,6,Ceremonial Shell (Heaven),202,1,1,0,0,1
-13983,3,5000,1,6,Ceremonial Shell (Heaven),202,1,1,0,1,1
-13984,3,5000,1,6,Ceremonial Shell (Heaven),202,1,1,0,2,1
-13985,3,5000,1,6,Ceremonial Shell (Heaven),202,1,1,0,3,1
-13986,3,5000,1,6,Ceremonial Shell (Heaven),202,1,1,0,4,1
-13987,3,5000,1,3,Ritual Shell [Heaven],202,1,1,0,0,1
-13988,3,5000,1,3,Ritual Shell [Heaven],202,1,1,0,1,1
-13989,3,5000,1,3,Ritual Shell [Heaven],202,1,1,0,2,1
-13990,3,5000,1,3,Ritual Shell [Heaven],202,1,1,0,3,1
-13991,3,5000,1,3,Ritual Shell [Heaven],202,1,1,0,4,1
-14012,3,5000,1,6,Ceremonial Rod (Red),205,1,5,0,0,1
-14013,3,5000,1,6,Ceremonial Rod (Red),205,1,5,0,1,1
-14014,3,5000,1,6,Ceremonial Rod (Red),205,1,5,0,2,1
-14015,3,5000,1,6,Ceremonial Rod (Red),205,1,5,0,3,1
-14016,3,5000,1,6,Ceremonial Rod (Red),205,1,5,0,4,1
-14017,3,5000,1,3,Ritual Rod [Crimson],205,1,5,0,0,1
-14018,3,5000,1,3,Ritual Rod [Crimson],205,1,5,0,1,1
-14019,3,5000,1,3,Ritual Rod [Crimson],205,1,5,0,2,1
-14020,3,5000,1,3,Ritual Rod [Crimson],205,1,5,0,3,1
-14021,3,5000,1,3,Ritual Rod [Crimson],205,1,5,0,4,1
-14035,3,10000,1,0,Salvation Shield,202,1,1,0,0,1
-14036,3,10000,1,0,Salvation Shield,202,1,1,0,1,1
-14037,3,10000,1,0,Salvation Shield,202,1,1,0,2,1
-14038,3,10000,1,0,Salvation Shield,202,1,1,0,3,1
-14039,3,10000,1,0,Salvation Shield,202,1,1,0,4,1
-14040,3,10000,1,15,Obsidian Shield,202,1,1,0,0,1
-14041,3,10000,1,15,Obsidian Shield,202,1,1,0,1,1
-14042,3,10000,1,15,Obsidian Shield,202,1,1,0,2,1
-14043,3,10000,1,15,Obsidian Shield,202,1,1,0,3,1
-14044,3,10000,1,15,Obsidian Shield,202,1,1,0,4,1
-14069,3,10000,1,0,Salvation Rod,205,1,5,0,0,1
-14070,3,10000,1,0,Salvation Rod,205,1,5,0,1,1
-14071,3,10000,1,0,Salvation Rod,205,1,5,0,2,1
-14072,3,10000,1,0,Salvation Rod,205,1,5,0,3,1
-14073,3,10000,1,0,Salvation Rod,205,1,5,0,4,1
-14074,3,10000,1,15,Obsidian Rod,205,1,5,0,0,1
-14075,3,10000,1,15,Obsidian Rod,205,1,5,0,1,1
-14076,3,10000,1,15,Obsidian Rod,205,1,5,0,2,1
-14077,3,10000,1,15,Obsidian Rod,205,1,5,0,3,1
-14078,3,10000,1,15,Obsidian Rod,205,1,5,0,4,1
-14307,3,10370,1,13,Shield of Tribe,202,72,1,0,0,1
-14308,3,10370,1,13,Shield of Tribe,202,72,1,0,1,1
-14309,3,10370,1,13,Shield of Tribe,202,72,1,0,2,1
-14310,3,10370,1,13,Shield of Tribe,202,72,1,0,3,1
-14311,3,10370,1,13,Shield of Tribe,202,72,1,0,4,1
-14312,3,11252,1,2,Hardened Pelta,202,75,1,0,0,1
-14313,3,11252,1,2,Hardened Pelta,202,75,1,0,1,1
-14314,3,11252,1,2,Hardened Pelta,202,75,1,0,2,1
-14315,3,11252,1,2,Hardened Pelta,202,75,1,0,3,1
-14316,3,11252,1,2,Hardened Pelta,202,75,1,0,4,1
-14317,3,11252,1,7,Prevent Shell,202,75,1,0,0,1
-14318,3,11252,1,7,Prevent Shell,202,75,1,0,1,1
-14319,3,11252,1,7,Prevent Shell,202,75,1,0,2,1
-14320,3,11252,1,7,Prevent Shell,202,75,1,0,3,1
-14321,3,11252,1,7,Prevent Shell,202,75,1,0,4,1
-14322,3,11252,1,12,Verdant Guard,202,75,1,0,0,1
-14323,3,11252,1,12,Verdant Guard,202,75,1,0,1,1
-14324,3,11252,1,12,Verdant Guard,202,75,1,0,2,1
-14325,3,11252,1,12,Verdant Guard,202,75,1,0,3,1
-14326,3,11252,1,12,Verdant Guard,202,75,1,0,4,1
-14327,3,11860,1,12,Damascus Shield,202,77,1,0,0,1
-14328,3,11860,1,12,Damascus Shield,202,77,1,0,1,1
-14329,3,11860,1,12,Damascus Shield,202,77,1,0,2,1
-14330,3,11860,1,12,Damascus Shield,202,77,1,0,3,1
-14331,3,11860,1,12,Damascus Shield,202,77,1,0,4,1
-14332,3,12802,1,1,Strenuous Guard,202,80,1,0,0,1
-14333,3,12802,1,1,Strenuous Guard,202,80,1,0,1,1
-14334,3,12802,1,1,Strenuous Guard,202,80,1,0,2,1
-14335,3,12802,1,1,Strenuous Guard,202,80,1,0,3,1
-14336,3,12802,1,1,Strenuous Guard,202,80,1,0,4,1
-14337,3,12802,1,6,Demon Shield,202,80,1,0,0,1
-14338,3,12802,1,6,Demon Shield,202,80,1,0,1,1
-14339,3,12802,1,6,Demon Shield,202,80,1,0,2,1
-14340,3,12802,1,6,Demon Shield,202,80,1,0,3,1
-14341,3,12802,1,6,Demon Shield,202,80,1,0,4,1
-14342,3,12802,1,11,Core of Shell,202,80,1,0,0,1
-14343,3,12802,1,11,Core of Shell,202,80,1,0,1,1
-14344,3,12802,1,11,Core of Shell,202,80,1,0,2,1
-14345,3,12802,1,11,Core of Shell,202,80,1,0,3,1
-14346,3,12802,1,11,Core of Shell,202,80,1,0,4,1
-14422,3,10370,1,13,Rod of Tribe,205,72,5,0,0,1
-14423,3,10370,1,13,Rod of Tribe,205,72,5,0,1,1
-14424,3,10370,1,13,Rod of Tribe,205,72,5,0,2,1
-14425,3,10370,1,13,Rod of Tribe,205,72,5,0,3,1
-14426,3,10370,1,13,Rod of Tribe,205,72,5,0,4,1
-14427,3,11252,1,2,Quadruple Rod,205,75,5,0,0,1
-14428,3,11252,1,2,Quadruple Rod,205,75,5,0,1,1
-14429,3,11252,1,2,Quadruple Rod,205,75,5,0,2,1
-14430,3,11252,1,2,Quadruple Rod,205,75,5,0,3,1
-14431,3,11252,1,2,Quadruple Rod,205,75,5,0,4,1
-14432,3,11252,1,7,Rod of the Departed,205,75,5,0,0,1
-14433,3,11252,1,7,Rod of the Departed,205,75,5,0,1,1
-14434,3,11252,1,7,Rod of the Departed,205,75,5,0,2,1
-14435,3,11252,1,7,Rod of the Departed,205,75,5,0,3,1
-14436,3,11252,1,7,Rod of the Departed,205,75,5,0,4,1
-14437,3,11252,1,12,Verdant Star,205,75,5,0,0,1
-14438,3,11252,1,12,Verdant Star,205,75,5,0,1,1
-14439,3,11252,1,12,Verdant Star,205,75,5,0,2,1
-14440,3,11252,1,12,Verdant Star,205,75,5,0,3,1
-14441,3,11252,1,12,Verdant Star,205,75,5,0,4,1
-14442,3,11860,1,12,Étincelle Supernova,205,77,5,0,0,1
-14443,3,11860,1,12,Étincelle Supernova,205,77,5,0,1,1
-14444,3,11860,1,12,Étincelle Supernova,205,77,5,0,2,1
-14445,3,11860,1,12,Étincelle Supernova,205,77,5,0,3,1
-14446,3,11860,1,12,Étincelle Supernova,205,77,5,0,4,1
-14447,3,12802,1,1,Rod of the Seven Stars,205,80,5,0,0,1
-14448,3,12802,1,1,Rod of the Seven Stars,205,80,5,0,1,1
-14449,3,12802,1,1,Rod of the Seven Stars,205,80,5,0,2,1
-14450,3,12802,1,1,Rod of the Seven Stars,205,80,5,0,3,1
-14451,3,12802,1,1,Rod of the Seven Stars,205,80,5,0,4,1
-14452,3,12802,1,6,Fiend Rod,205,80,5,0,0,1
-14453,3,12802,1,6,Fiend Rod,205,80,5,0,1,1
-14454,3,12802,1,6,Fiend Rod,205,80,5,0,2,1
-14455,3,12802,1,6,Fiend Rod,205,80,5,0,3,1
-14456,3,12802,1,6,Fiend Rod,205,80,5,0,4,1
-14457,3,12802,1,11,Core of Rod,205,80,5,0,0,1
-14458,3,12802,1,11,Core of Rod,205,80,5,0,1,1
-14459,3,12802,1,11,Core of Rod,205,80,5,0,2,1
-14460,3,12802,1,11,Core of Rod,205,80,5,0,3,1
-14461,3,12802,1,11,Core of Rod,205,80,5,0,4,1
-15703,3,10000,1,13,Arisen's Repeller,202,1,1,0,0,1
-15704,3,10000,1,13,Arisen's Repeller,202,1,1,0,1,1
-15705,3,10000,1,13,Arisen's Repeller,202,1,1,0,2,1
-15706,3,10000,1,13,Arisen's Repeller,202,1,1,0,3,1
-15707,3,10000,1,13,Arisen's Repeller,202,1,1,0,4,1
-15708,3,10000,1,12,Shield of Radiance,202,1,1,0,0,1
-15709,3,10000,1,12,Shield of Radiance,202,1,1,0,1,1
-15710,3,10000,1,12,Shield of Radiance,202,1,1,0,2,1
-15711,3,10000,1,12,Shield of Radiance,202,1,1,0,3,1
-15712,3,10000,1,12,Shield of Radiance,202,1,1,0,4,1
-15763,3,10000,1,13,Arisen's Inductor,205,1,5,0,0,1
-15764,3,10000,1,13,Arisen's Inductor,205,1,5,0,1,1
-15765,3,10000,1,13,Arisen's Inductor,205,1,5,0,2,1
-15766,3,10000,1,13,Arisen's Inductor,205,1,5,0,3,1
-15767,3,10000,1,13,Arisen's Inductor,205,1,5,0,4,1
-15768,3,10000,1,12,Rod of Radiance,205,1,5,0,0,1
-15769,3,10000,1,12,Rod of Radiance,205,1,5,0,1,1
-15770,3,10000,1,12,Rod of Radiance,205,1,5,0,2,1
-15771,3,10000,1,12,Rod of Radiance,205,1,5,0,3,1
-15772,3,10000,1,12,Rod of Radiance,205,1,5,0,4,1
+11876,3,8452,1,20,Burly Spike,202,65,1,0,0,1
+11877,3,8452,1,20,Burly Spike,202,65,1,0,1,1
+11878,3,8452,1,20,Burly Spike,202,65,1,0,2,1
+11879,3,8452,1,20,Burly Spike,202,65,1,0,3,1
+11880,3,8452,1,20,Burly Spike,202,65,1,0,4,1
+11881,3,8452,1,25,Sturm,202,65,1,0,0,1
+11882,3,8452,1,25,Sturm,202,65,1,0,1,1
+11883,3,8452,1,25,Sturm,202,65,1,0,2,1
+11884,3,8452,1,25,Sturm,202,65,1,0,3,1
+11885,3,8452,1,25,Sturm,202,65,1,0,4,1
+11886,3,8452,1,30,Forge Brightness,202,65,1,0,0,1
+11887,3,8452,1,30,Forge Brightness,202,65,1,0,1,1
+11888,3,8452,1,30,Forge Brightness,202,65,1,0,2,1
+11889,3,8452,1,30,Forge Brightness,202,65,1,0,3,1
+11890,3,8452,1,30,Forge Brightness,202,65,1,0,4,1
+11891,3,8980,1,30,Lone Wolf Shield,202,67,1,0,0,1
+11892,3,8980,1,30,Lone Wolf Shield,202,67,1,0,1,1
+11893,3,8980,1,30,Lone Wolf Shield,202,67,1,0,2,1
+11894,3,8980,1,30,Lone Wolf Shield,202,67,1,0,3,1
+11895,3,8980,1,30,Lone Wolf Shield,202,67,1,0,4,1
+11896,3,9802,1,35,Pelta Shield,202,70,1,0,0,1
+11897,3,9802,1,35,Pelta Shield,202,70,1,0,1,1
+11898,3,9802,1,35,Pelta Shield,202,70,1,0,2,1
+11899,3,9802,1,35,Pelta Shield,202,70,1,0,3,1
+11900,3,9802,1,35,Pelta Shield,202,70,1,0,4,1
+11901,3,9802,1,40,Shield of Tyrant,202,70,1,0,0,1
+11902,3,9802,1,40,Shield of Tyrant,202,70,1,0,1,1
+11903,3,9802,1,40,Shield of Tyrant,202,70,1,0,2,1
+11904,3,9802,1,40,Shield of Tyrant,202,70,1,0,3,1
+11905,3,9802,1,40,Shield of Tyrant,202,70,1,0,4,1
+11906,3,9802,1,45,Immaculate Guard,202,70,1,0,0,1
+11907,3,9802,1,45,Immaculate Guard,202,70,1,0,1,1
+11908,3,9802,1,45,Immaculate Guard,202,70,1,0,2,1
+11909,3,9802,1,45,Immaculate Guard,202,70,1,0,3,1
+11910,3,9802,1,45,Immaculate Guard,202,70,1,0,4,1
+12051,3,8452,1,20,Limelight,205,65,5,0,0,1
+12052,3,8452,1,20,Limelight,205,65,5,0,1,1
+12053,3,8452,1,20,Limelight,205,65,5,0,2,1
+12054,3,8452,1,20,Limelight,205,65,5,0,3,1
+12055,3,8452,1,20,Limelight,205,65,5,0,4,1
+12056,3,8452,1,25,Vortex,205,65,5,0,0,1
+12057,3,8452,1,25,Vortex,205,65,5,0,1,1
+12058,3,8452,1,25,Vortex,205,65,5,0,2,1
+12059,3,8452,1,25,Vortex,205,65,5,0,3,1
+12060,3,8452,1,25,Vortex,205,65,5,0,4,1
+12061,3,8452,1,30,Divine Attractor,205,65,5,0,0,1
+12062,3,8452,1,30,Divine Attractor,205,65,5,0,1,1
+12063,3,8452,1,30,Divine Attractor,205,65,5,0,2,1
+12064,3,8452,1,30,Divine Attractor,205,65,5,0,3,1
+12065,3,8452,1,30,Divine Attractor,205,65,5,0,4,1
+12066,3,8980,1,30,Polaris Drop,205,67,5,0,0,1
+12067,3,8980,1,30,Polaris Drop,205,67,5,0,1,1
+12068,3,8980,1,30,Polaris Drop,205,67,5,0,2,1
+12069,3,8980,1,30,Polaris Drop,205,67,5,0,3,1
+12070,3,8980,1,30,Polaris Drop,205,67,5,0,4,1
+12071,3,9802,1,35,Judgement,205,70,5,0,0,1
+12072,3,9802,1,35,Judgement,205,70,5,0,1,1
+12073,3,9802,1,35,Judgement,205,70,5,0,2,1
+12074,3,9802,1,35,Judgement,205,70,5,0,3,1
+12075,3,9802,1,35,Judgement,205,70,5,0,4,1
+12076,3,9802,1,40,Rod of Tyrant,205,70,5,0,0,1
+12077,3,9802,1,40,Rod of Tyrant,205,70,5,0,1,1
+12078,3,9802,1,40,Rod of Tyrant,205,70,5,0,2,1
+12079,3,9802,1,40,Rod of Tyrant,205,70,5,0,3,1
+12080,3,9802,1,40,Rod of Tyrant,205,70,5,0,4,1
+12081,3,9802,1,45,Conscience Torch,205,70,5,0,0,1
+12082,3,9802,1,45,Conscience Torch,205,70,5,0,1,1
+12083,3,9802,1,45,Conscience Torch,205,70,5,0,2,1
+12084,3,9802,1,45,Conscience Torch,205,70,5,0,3,1
+12085,3,9802,1,45,Conscience Torch,205,70,5,0,4,1
+13982,3,5000,1,22,Ceremonial Shell (Heaven),202,1,1,0,0,1
+13983,3,5000,1,22,Ceremonial Shell (Heaven),202,1,1,0,1,1
+13984,3,5000,1,22,Ceremonial Shell (Heaven),202,1,1,0,2,1
+13985,3,5000,1,22,Ceremonial Shell (Heaven),202,1,1,0,3,1
+13986,3,5000,1,22,Ceremonial Shell (Heaven),202,1,1,0,4,1
+13987,3,5000,1,35,Ritual Shell [Heaven],202,1,1,0,0,1
+13988,3,5000,1,35,Ritual Shell [Heaven],202,1,1,0,1,1
+13989,3,5000,1,35,Ritual Shell [Heaven],202,1,1,0,2,1
+13990,3,5000,1,35,Ritual Shell [Heaven],202,1,1,0,3,1
+13991,3,5000,1,35,Ritual Shell [Heaven],202,1,1,0,4,1
+14012,3,5000,1,22,Ceremonial Rod (Red),205,1,5,0,0,1
+14013,3,5000,1,22,Ceremonial Rod (Red),205,1,5,0,1,1
+14014,3,5000,1,22,Ceremonial Rod (Red),205,1,5,0,2,1
+14015,3,5000,1,22,Ceremonial Rod (Red),205,1,5,0,3,1
+14016,3,5000,1,22,Ceremonial Rod (Red),205,1,5,0,4,1
+14017,3,5000,1,35,Ritual Rod [Crimson],205,1,5,0,0,1
+14018,3,5000,1,35,Ritual Rod [Crimson],205,1,5,0,1,1
+14019,3,5000,1,35,Ritual Rod [Crimson],205,1,5,0,2,1
+14020,3,5000,1,35,Ritual Rod [Crimson],205,1,5,0,3,1
+14021,3,5000,1,35,Ritual Rod [Crimson],205,1,5,0,4,1
+14035,3,10000,1,16,Salvation Shield,202,1,1,0,0,1
+14036,3,10000,1,16,Salvation Shield,202,1,1,0,1,1
+14037,3,10000,1,16,Salvation Shield,202,1,1,0,2,1
+14038,3,10000,1,16,Salvation Shield,202,1,1,0,3,1
+14039,3,10000,1,16,Salvation Shield,202,1,1,0,4,1
+14040,3,10000,1,31,Obsidian Shield,202,1,1,0,0,1
+14041,3,10000,1,31,Obsidian Shield,202,1,1,0,1,1
+14042,3,10000,1,31,Obsidian Shield,202,1,1,0,2,1
+14043,3,10000,1,31,Obsidian Shield,202,1,1,0,3,1
+14044,3,10000,1,31,Obsidian Shield,202,1,1,0,4,1
+14069,3,10000,1,16,Salvation Rod,205,1,5,0,0,1
+14070,3,10000,1,16,Salvation Rod,205,1,5,0,1,1
+14071,3,10000,1,16,Salvation Rod,205,1,5,0,2,1
+14072,3,10000,1,16,Salvation Rod,205,1,5,0,3,1
+14073,3,10000,1,16,Salvation Rod,205,1,5,0,4,1
+14074,3,10000,1,31,Obsidian Rod,205,1,5,0,0,1
+14075,3,10000,1,31,Obsidian Rod,205,1,5,0,1,1
+14076,3,10000,1,31,Obsidian Rod,205,1,5,0,2,1
+14077,3,10000,1,31,Obsidian Rod,205,1,5,0,3,1
+14078,3,10000,1,31,Obsidian Rod,205,1,5,0,4,1
+14307,3,10370,1,45,Shield of Tribe,202,72,1,0,0,1
+14308,3,10370,1,45,Shield of Tribe,202,72,1,0,1,1
+14309,3,10370,1,45,Shield of Tribe,202,72,1,0,2,1
+14310,3,10370,1,45,Shield of Tribe,202,72,1,0,3,1
+14311,3,10370,1,45,Shield of Tribe,202,72,1,0,4,1
+14312,3,11252,1,50,Hardened Pelta,202,75,1,0,0,1
+14313,3,11252,1,50,Hardened Pelta,202,75,1,0,1,1
+14314,3,11252,1,50,Hardened Pelta,202,75,1,0,2,1
+14315,3,11252,1,50,Hardened Pelta,202,75,1,0,3,1
+14316,3,11252,1,50,Hardened Pelta,202,75,1,0,4,1
+14317,3,11252,1,55,Prevent Shell,202,75,1,0,0,1
+14318,3,11252,1,55,Prevent Shell,202,75,1,0,1,1
+14319,3,11252,1,55,Prevent Shell,202,75,1,0,2,1
+14320,3,11252,1,55,Prevent Shell,202,75,1,0,3,1
+14321,3,11252,1,55,Prevent Shell,202,75,1,0,4,1
+14322,3,11252,1,60,Verdant Guard,202,75,1,0,0,1
+14323,3,11252,1,60,Verdant Guard,202,75,1,0,1,1
+14324,3,11252,1,60,Verdant Guard,202,75,1,0,2,1
+14325,3,11252,1,60,Verdant Guard,202,75,1,0,3,1
+14326,3,11252,1,60,Verdant Guard,202,75,1,0,4,1
+14327,3,11860,1,60,Damascus Shield,202,77,1,0,0,1
+14328,3,11860,1,60,Damascus Shield,202,77,1,0,1,1
+14329,3,11860,1,60,Damascus Shield,202,77,1,0,2,1
+14330,3,11860,1,60,Damascus Shield,202,77,1,0,3,1
+14331,3,11860,1,60,Damascus Shield,202,77,1,0,4,1
+14332,3,12802,1,65,Strenuous Guard,202,80,1,0,0,1
+14333,3,12802,1,65,Strenuous Guard,202,80,1,0,1,1
+14334,3,12802,1,65,Strenuous Guard,202,80,1,0,2,1
+14335,3,12802,1,65,Strenuous Guard,202,80,1,0,3,1
+14336,3,12802,1,65,Strenuous Guard,202,80,1,0,4,1
+14337,3,12802,1,70,Demon Shield,202,80,1,0,0,1
+14338,3,12802,1,70,Demon Shield,202,80,1,0,1,1
+14339,3,12802,1,70,Demon Shield,202,80,1,0,2,1
+14340,3,12802,1,70,Demon Shield,202,80,1,0,3,1
+14341,3,12802,1,70,Demon Shield,202,80,1,0,4,1
+14342,3,12802,1,75,Core of Shell,202,80,1,0,0,1
+14343,3,12802,1,75,Core of Shell,202,80,1,0,1,1
+14344,3,12802,1,75,Core of Shell,202,80,1,0,2,1
+14345,3,12802,1,75,Core of Shell,202,80,1,0,3,1
+14346,3,12802,1,75,Core of Shell,202,80,1,0,4,1
+14422,3,10370,1,45,Rod of Tribe,205,72,5,0,0,1
+14423,3,10370,1,45,Rod of Tribe,205,72,5,0,1,1
+14424,3,10370,1,45,Rod of Tribe,205,72,5,0,2,1
+14425,3,10370,1,45,Rod of Tribe,205,72,5,0,3,1
+14426,3,10370,1,45,Rod of Tribe,205,72,5,0,4,1
+14427,3,11252,1,50,Quadruple Rod,205,75,5,0,0,1
+14428,3,11252,1,50,Quadruple Rod,205,75,5,0,1,1
+14429,3,11252,1,50,Quadruple Rod,205,75,5,0,2,1
+14430,3,11252,1,50,Quadruple Rod,205,75,5,0,3,1
+14431,3,11252,1,50,Quadruple Rod,205,75,5,0,4,1
+14432,3,11252,1,55,Rod of the Departed,205,75,5,0,0,1
+14433,3,11252,1,55,Rod of the Departed,205,75,5,0,1,1
+14434,3,11252,1,55,Rod of the Departed,205,75,5,0,2,1
+14435,3,11252,1,55,Rod of the Departed,205,75,5,0,3,1
+14436,3,11252,1,55,Rod of the Departed,205,75,5,0,4,1
+14437,3,11252,1,60,Verdant Star,205,75,5,0,0,1
+14438,3,11252,1,60,Verdant Star,205,75,5,0,1,1
+14439,3,11252,1,60,Verdant Star,205,75,5,0,2,1
+14440,3,11252,1,60,Verdant Star,205,75,5,0,3,1
+14441,3,11252,1,60,Verdant Star,205,75,5,0,4,1
+14442,3,11860,1,60,Étincelle Supernova,205,77,5,0,0,1
+14443,3,11860,1,60,Étincelle Supernova,205,77,5,0,1,1
+14444,3,11860,1,60,Étincelle Supernova,205,77,5,0,2,1
+14445,3,11860,1,60,Étincelle Supernova,205,77,5,0,3,1
+14446,3,11860,1,60,Étincelle Supernova,205,77,5,0,4,1
+14447,3,12802,1,65,Rod of the Seven Stars,205,80,5,0,0,1
+14448,3,12802,1,65,Rod of the Seven Stars,205,80,5,0,1,1
+14449,3,12802,1,65,Rod of the Seven Stars,205,80,5,0,2,1
+14450,3,12802,1,65,Rod of the Seven Stars,205,80,5,0,3,1
+14451,3,12802,1,65,Rod of the Seven Stars,205,80,5,0,4,1
+14452,3,12802,1,70,Fiend Rod,205,80,5,0,0,1
+14453,3,12802,1,70,Fiend Rod,205,80,5,0,1,1
+14454,3,12802,1,70,Fiend Rod,205,80,5,0,2,1
+14455,3,12802,1,70,Fiend Rod,205,80,5,0,3,1
+14456,3,12802,1,70,Fiend Rod,205,80,5,0,4,1
+14457,3,12802,1,75,Core of Rod,205,80,5,0,0,1
+14458,3,12802,1,75,Core of Rod,205,80,5,0,1,1
+14459,3,12802,1,75,Core of Rod,205,80,5,0,2,1
+14460,3,12802,1,75,Core of Rod,205,80,5,0,3,1
+14461,3,12802,1,75,Core of Rod,205,80,5,0,4,1
+15703,3,10000,1,45,Arisen's Repeller,202,1,1,0,0,1
+15704,3,10000,1,45,Arisen's Repeller,202,1,1,0,1,1
+15705,3,10000,1,45,Arisen's Repeller,202,1,1,0,2,1
+15706,3,10000,1,45,Arisen's Repeller,202,1,1,0,3,1
+15707,3,10000,1,45,Arisen's Repeller,202,1,1,0,4,1
+15708,3,10000,1,60,Shield of Radiance,202,1,1,0,0,1
+15709,3,10000,1,60,Shield of Radiance,202,1,1,0,1,1
+15710,3,10000,1,60,Shield of Radiance,202,1,1,0,2,1
+15711,3,10000,1,60,Shield of Radiance,202,1,1,0,3,1
+15712,3,10000,1,60,Shield of Radiance,202,1,1,0,4,1
+15763,3,10000,1,45,Arisen's Inductor,205,1,5,0,0,1
+15764,3,10000,1,45,Arisen's Inductor,205,1,5,0,1,1
+15765,3,10000,1,45,Arisen's Inductor,205,1,5,0,2,1
+15766,3,10000,1,45,Arisen's Inductor,205,1,5,0,3,1
+15767,3,10000,1,45,Arisen's Inductor,205,1,5,0,4,1
+15768,3,10000,1,60,Rod of Radiance,205,1,5,0,0,1
+15769,3,10000,1,60,Rod of Radiance,205,1,5,0,1,1
+15770,3,10000,1,60,Rod of Radiance,205,1,5,0,2,1
+15771,3,10000,1,60,Rod of Radiance,205,1,5,0,3,1
+15772,3,10000,1,60,Rod of Radiance,205,1,5,0,4,1
 16473,3,100,1,1,Mark of the Arisen (Decoration),202,1,1,0,4,1
 16476,3,100,1,1,Fury Rondeau (Decoration),205,1,5,0,4,1
-16648,3,5000,1,12,Olfring Shell (Blue-green),202,1,1,0,0,1
-16649,3,5000,1,12,Olfring Shell (Blue-green),202,1,1,0,1,1
-16650,3,5000,1,12,Olfring Shell (Blue-green),202,1,1,0,2,1
-16651,3,5000,1,12,Olfring Shell (Blue-green),202,1,1,0,3,1
-16652,3,5000,1,12,Olfring Shell (Blue-green),202,1,1,0,4,1
-16653,3,5000,1,2,Olfring Shell+ (Heaven),202,1,1,0,0,1
-16654,3,5000,1,2,Olfring Shell+ (Heaven),202,1,1,0,1,1
-16655,3,5000,1,2,Olfring Shell+ (Heaven),202,1,1,0,2,1
-16656,3,5000,1,2,Olfring Shell+ (Heaven),202,1,1,0,3,1
-16657,3,5000,1,2,Olfring Shell+ (Heaven),202,1,1,0,4,1
-16658,3,5000,1,1,Ceremonial Shell+ (Heaven),202,1,1,0,0,1
-16659,3,5000,1,1,Ceremonial Shell+ (Heaven),202,1,1,0,1,1
-16660,3,5000,1,1,Ceremonial Shell+ (Heaven),202,1,1,0,2,1
-16661,3,5000,1,1,Ceremonial Shell+ (Heaven),202,1,1,0,3,1
-16662,3,5000,1,1,Ceremonial Shell+ (Heaven),202,1,1,0,4,1
-16673,3,5000,1,2,Olfring Rod+ (Red),205,1,5,0,0,1
-16674,3,5000,1,2,Olfring Rod+ (Red),205,1,5,0,1,1
-16675,3,5000,1,2,Olfring Rod+ (Red),205,1,5,0,2,1
-16676,3,5000,1,2,Olfring Rod+ (Red),205,1,5,0,3,1
-16677,3,5000,1,2,Olfring Rod+ (Red),205,1,5,0,4,1
-16678,3,5000,1,1,Ceremonial Rod+ (Red),205,1,5,0,0,1
-16679,3,5000,1,1,Ceremonial Rod+ (Red),205,1,5,0,1,1
-16680,3,5000,1,1,Ceremonial Rod+ (Red),205,1,5,0,2,1
-16681,3,5000,1,1,Ceremonial Rod+ (Red),205,1,5,0,3,1
-16682,3,5000,1,1,Ceremonial Rod+ (Red),205,1,5,0,4,1
-16766,3,214,1,13,Melty Shield,202,1,1,0,4,1
-16767,3,314,1,13,Sincere Shield,202,1,1,0,4,1
-16772,3,214,1,13,Melty Rod,205,1,5,0,4,1
-16773,3,314,1,13,Sincere Rod,205,1,5,0,4,1
-17406,3,6394,1,0,Nobility's Guard,202,80,1,0,0,1
-17407,3,6394,1,0,Nobility's Guard,202,80,1,0,1,1
-17408,3,6394,1,0,Nobility's Guard,202,80,1,0,2,1
-17409,3,6394,1,0,Nobility's Guard,202,80,1,0,3,1
-17410,3,6394,1,0,Nobility's Guard,202,80,1,0,4,1
-17411,3,6854,1,5,Pyxis Guard,202,83,1,0,0,1
-17412,3,6854,1,5,Pyxis Guard,202,83,1,0,1,1
-17413,3,6854,1,5,Pyxis Guard,202,83,1,0,2,1
-17414,3,6854,1,5,Pyxis Guard,202,83,1,0,3,1
-17415,3,6854,1,5,Pyxis Guard,202,83,1,0,4,1
-17416,3,7161,1,10,Mehrdad,202,85,1,0,0,1
-17417,3,7161,1,10,Mehrdad,202,85,1,0,1,1
-17418,3,7161,1,10,Mehrdad,202,85,1,0,2,1
-17419,3,7161,1,10,Mehrdad,202,85,1,0,3,1
-17420,3,7161,1,10,Mehrdad,202,85,1,0,4,1
-17451,3,6394,1,0,Nobility's Rod,205,80,5,0,0,1
-17452,3,6394,1,0,Nobility's Rod,205,80,5,0,1,1
-17453,3,6394,1,0,Nobility's Rod,205,80,5,0,2,1
-17454,3,6394,1,0,Nobility's Rod,205,80,5,0,3,1
-17455,3,6394,1,0,Nobility's Rod,205,80,5,0,4,1
-17456,3,6854,1,5,Khidir's Torch,205,83,5,0,0,1
-17457,3,6854,1,5,Khidir's Torch,205,83,5,0,1,1
-17458,3,6854,1,5,Khidir's Torch,205,83,5,0,2,1
-17459,3,6854,1,5,Khidir's Torch,205,83,5,0,3,1
-17460,3,6854,1,5,Khidir's Torch,205,83,5,0,4,1
-17461,3,7161,1,10,Roshanak,205,85,5,0,0,1
-17462,3,7161,1,10,Roshanak,205,85,5,0,1,1
-17463,3,7161,1,10,Roshanak,205,85,5,0,2,1
-17464,3,7161,1,10,Roshanak,205,85,5,0,3,1
-17465,3,7161,1,10,Roshanak,205,85,5,0,4,1
+16648,3,5000,1,60,Olfring Shell (Blue-green),202,1,1,0,0,1
+16649,3,5000,1,60,Olfring Shell (Blue-green),202,1,1,0,1,1
+16650,3,5000,1,60,Olfring Shell (Blue-green),202,1,1,0,2,1
+16651,3,5000,1,60,Olfring Shell (Blue-green),202,1,1,0,3,1
+16652,3,5000,1,60,Olfring Shell (Blue-green),202,1,1,0,4,1
+16653,3,5000,1,50,Olfring Shell+ (Heaven),202,1,1,0,0,1
+16654,3,5000,1,50,Olfring Shell+ (Heaven),202,1,1,0,1,1
+16655,3,5000,1,50,Olfring Shell+ (Heaven),202,1,1,0,2,1
+16656,3,5000,1,50,Olfring Shell+ (Heaven),202,1,1,0,3,1
+16657,3,5000,1,50,Olfring Shell+ (Heaven),202,1,1,0,4,1
+16658,3,5000,1,65,Ceremonial Shell+ (Heaven),202,1,1,0,0,1
+16659,3,5000,1,65,Ceremonial Shell+ (Heaven),202,1,1,0,1,1
+16660,3,5000,1,65,Ceremonial Shell+ (Heaven),202,1,1,0,2,1
+16661,3,5000,1,65,Ceremonial Shell+ (Heaven),202,1,1,0,3,1
+16662,3,5000,1,65,Ceremonial Shell+ (Heaven),202,1,1,0,4,1
+16673,3,5000,1,50,Olfring Rod+ (Red),205,1,5,0,0,1
+16674,3,5000,1,50,Olfring Rod+ (Red),205,1,5,0,1,1
+16675,3,5000,1,50,Olfring Rod+ (Red),205,1,5,0,2,1
+16676,3,5000,1,50,Olfring Rod+ (Red),205,1,5,0,3,1
+16677,3,5000,1,50,Olfring Rod+ (Red),205,1,5,0,4,1
+16678,3,5000,1,65,Ceremonial Rod+ (Red),205,1,5,0,0,1
+16679,3,5000,1,65,Ceremonial Rod+ (Red),205,1,5,0,1,1
+16680,3,5000,1,65,Ceremonial Rod+ (Red),205,1,5,0,2,1
+16681,3,5000,1,65,Ceremonial Rod+ (Red),205,1,5,0,3,1
+16682,3,5000,1,65,Ceremonial Rod+ (Red),205,1,5,0,4,1
+16766,3,214,1,45,Melty Shield,202,1,1,0,4,1
+16767,3,314,1,45,Sincere Shield,202,1,1,0,4,1
+16772,3,214,1,45,Melty Rod,205,1,5,0,4,1
+16773,3,314,1,45,Sincere Rod,205,1,5,0,4,1
+17406,3,6394,1,80,Nobility's Guard,202,80,1,0,0,1
+17407,3,6394,1,80,Nobility's Guard,202,80,1,0,1,1
+17408,3,6394,1,80,Nobility's Guard,202,80,1,0,2,1
+17409,3,6394,1,80,Nobility's Guard,202,80,1,0,3,1
+17410,3,6394,1,80,Nobility's Guard,202,80,1,0,4,1
+17411,3,6854,1,85,Pyxis Guard,202,83,1,0,0,1
+17412,3,6854,1,85,Pyxis Guard,202,83,1,0,1,1
+17413,3,6854,1,85,Pyxis Guard,202,83,1,0,2,1
+17414,3,6854,1,85,Pyxis Guard,202,83,1,0,3,1
+17415,3,6854,1,85,Pyxis Guard,202,83,1,0,4,1
+17416,3,7161,1,90,Mehrdad,202,85,1,0,0,1
+17417,3,7161,1,90,Mehrdad,202,85,1,0,1,1
+17418,3,7161,1,90,Mehrdad,202,85,1,0,2,1
+17419,3,7161,1,90,Mehrdad,202,85,1,0,3,1
+17420,3,7161,1,90,Mehrdad,202,85,1,0,4,1
+17451,3,6394,1,80,Nobility's Rod,205,80,5,0,0,1
+17452,3,6394,1,80,Nobility's Rod,205,80,5,0,1,1
+17453,3,6394,1,80,Nobility's Rod,205,80,5,0,2,1
+17454,3,6394,1,80,Nobility's Rod,205,80,5,0,3,1
+17455,3,6394,1,80,Nobility's Rod,205,80,5,0,4,1
+17456,3,6854,1,85,Khidir's Torch,205,83,5,0,0,1
+17457,3,6854,1,85,Khidir's Torch,205,83,5,0,1,1
+17458,3,6854,1,85,Khidir's Torch,205,83,5,0,2,1
+17459,3,6854,1,85,Khidir's Torch,205,83,5,0,3,1
+17460,3,6854,1,85,Khidir's Torch,205,83,5,0,4,1
+17461,3,7161,1,90,Roshanak,205,85,5,0,0,1
+17462,3,7161,1,90,Roshanak,205,85,5,0,1,1
+17463,3,7161,1,90,Roshanak,205,85,5,0,2,1
+17464,3,7161,1,90,Roshanak,205,85,5,0,3,1
+17465,3,7161,1,90,Roshanak,205,85,5,0,4,1
 19105,3,10000,1,5,Survey Corps Shield,202,1,1,0,0,1
 19106,3,10000,1,8,Survey Corps Shield,202,1,1,0,1,1
 19107,3,10000,1,12,Survey Corps Shield,202,1,1,0,2,1
-19108,3,10000,1,13,Survey Corps Shield,202,1,1,0,3,1
-19109,3,10000,1,11,Survey Corps Shield,202,1,1,0,4,1
-17976,3,35805,1,10,Relief Shield of Resentment,202,85,1,0,0,1
-17977,3,35805,1,10,Relief Shield of Resentment,202,85,1,0,1,1
-17978,3,35805,1,10,Relief Shield of Resentment,202,85,1,0,2,1
-17979,3,35805,1,10,Relief Shield of Resentment,202,85,1,0,3,1
-17980,3,35805,1,10,Relief Shield of Resentment,202,85,1,0,4,1
-17981,3,37794,1,15,Guard of Ghirkud,202,88,1,0,0,1
-17982,3,37794,1,15,Guard of Ghirkud,202,88,1,0,1,1
-17983,3,37794,1,15,Guard of Ghirkud,202,88,1,0,2,1
-17984,3,37794,1,15,Guard of Ghirkud,202,88,1,0,3,1
-17985,3,37794,1,15,Guard of Ghirkud,202,88,1,0,4,1
-17986,3,39783,1,2,Farzaneh Guard,202,90,1,0,0,1
-17987,3,39783,1,2,Farzaneh Guard,202,90,1,0,1,1
-17988,3,39783,1,2,Farzaneh Guard,202,90,1,0,2,1
-17989,3,39783,1,2,Farzaneh Guard,202,90,1,0,3,1
-17990,3,39783,1,2,Farzaneh Guard,202,90,1,0,4,1
-18021,3,35805,1,10,Malachite Rod of Resentment,205,85,5,0,0,1
-18022,3,35805,1,10,Malachite Rod of Resentment,205,85,5,0,1,1
-18023,3,35805,1,10,Malachite Rod of Resentment,205,85,5,0,2,1
-18024,3,35805,1,10,Malachite Rod of Resentment,205,85,5,0,3,1
-18025,3,35805,1,10,Malachite Rod of Resentment,205,85,5,0,4,1
-18026,3,37794,1,15,Torch of Horos,205,88,5,0,0,1
-18027,3,37794,1,15,Torch of Horos,205,88,5,0,1,1
-18028,3,37794,1,15,Torch of Horos,205,88,5,0,2,1
-18029,3,37794,1,15,Torch of Horos,205,88,5,0,3,1
-18030,3,37794,1,15,Torch of Horos,205,88,5,0,4,1
-18031,3,39783,1,2,Maryam Rod,205,90,5,0,0,1
-18032,3,39783,1,2,Maryam Rod,205,90,5,0,1,1
-18033,3,39783,1,2,Maryam Rod,205,90,5,0,2,1
-18034,3,39783,1,2,Maryam Rod,205,90,5,0,3,1
-18035,3,39783,1,2,Maryam Rod,205,90,5,0,4,1
-18520,3,16000,1,13,Black Venom Shield,202,1,1,0,0,1
-18521,3,16000,1,2,Black Venom Shield,202,1,1,0,1,1
-18522,3,16000,1,7,Black Venom Shield,202,1,1,0,2,1
-18523,3,16000,1,12,Black Venom Shield,202,1,1,0,3,1
-18524,3,16000,1,6,Black Venom Shield,202,1,1,0,4,1
-18535,3,16000,1,13,Black Venom Rod,205,1,5,0,0,1
-18536,3,16000,1,2,Black Venom Rod,205,1,5,0,1,1
-18537,3,16000,1,7,Black Venom Rod,205,1,5,0,2,1
-18538,3,16000,1,12,Black Venom Rod,205,1,5,0,3,1
-18539,3,16000,1,6,Black Venom Rod,205,1,5,0,4,1
-18670,3,7161,1,10,Avatara,202,85,1,0,0,1
-18671,3,7161,1,10,Avatara,202,85,1,0,1,1
-18672,3,7161,1,10,Avatara,202,85,1,0,2,1
-18673,3,7161,1,10,Avatara,202,85,1,0,3,1
-18674,3,7161,1,10,Avatara,202,85,1,0,4,1
-18685,3,7161,1,10,Torch of Haoma,205,85,5,0,0,1
-18686,3,7161,1,10,Torch of Haoma,205,85,5,0,1,1
-18687,3,7161,1,10,Torch of Haoma,205,85,5,0,2,1
-18688,3,7161,1,10,Torch of Haoma,205,85,5,0,3,1
-18689,3,7161,1,10,Torch of Haoma,205,85,5,0,4,1
+19108,3,10000,1,45,Survey Corps Shield,202,1,1,0,3,1
+19109,3,10000,1,75,Survey Corps Shield,202,1,1,0,4,1
+17976,3,35805,1,90,Relief Shield of Resentment,202,85,1,0,0,1
+17977,3,35805,1,90,Relief Shield of Resentment,202,85,1,0,1,1
+17978,3,35805,1,90,Relief Shield of Resentment,202,85,1,0,2,1
+17979,3,35805,1,90,Relief Shield of Resentment,202,85,1,0,3,1
+17980,3,35805,1,90,Relief Shield of Resentment,202,85,1,0,4,1
+17981,3,37794,1,95,Guard of Ghirkud,202,88,1,0,0,1
+17982,3,37794,1,95,Guard of Ghirkud,202,88,1,0,1,1
+17983,3,37794,1,95,Guard of Ghirkud,202,88,1,0,2,1
+17984,3,37794,1,95,Guard of Ghirkud,202,88,1,0,3,1
+17985,3,37794,1,95,Guard of Ghirkud,202,88,1,0,4,1
+17986,3,39783,1,98,Farzaneh Guard,202,90,1,0,0,1
+17987,3,39783,1,98,Farzaneh Guard,202,90,1,0,1,1
+17988,3,39783,1,98,Farzaneh Guard,202,90,1,0,2,1
+17989,3,39783,1,98,Farzaneh Guard,202,90,1,0,3,1
+17990,3,39783,1,98,Farzaneh Guard,202,90,1,0,4,1
+18021,3,35805,1,90,Malachite Rod of Resentment,205,85,5,0,0,1
+18022,3,35805,1,90,Malachite Rod of Resentment,205,85,5,0,1,1
+18023,3,35805,1,90,Malachite Rod of Resentment,205,85,5,0,2,1
+18024,3,35805,1,90,Malachite Rod of Resentment,205,85,5,0,3,1
+18025,3,35805,1,90,Malachite Rod of Resentment,205,85,5,0,4,1
+18026,3,37794,1,95,Torch of Horos,205,88,5,0,0,1
+18027,3,37794,1,95,Torch of Horos,205,88,5,0,1,1
+18028,3,37794,1,95,Torch of Horos,205,88,5,0,2,1
+18029,3,37794,1,95,Torch of Horos,205,88,5,0,3,1
+18030,3,37794,1,95,Torch of Horos,205,88,5,0,4,1
+18031,3,39783,1,98,Maryam Rod,205,90,5,0,0,1
+18032,3,39783,1,98,Maryam Rod,205,90,5,0,1,1
+18033,3,39783,1,98,Maryam Rod,205,90,5,0,2,1
+18034,3,39783,1,98,Maryam Rod,205,90,5,0,3,1
+18035,3,39783,1,98,Maryam Rod,205,90,5,0,4,1
+18520,3,16000,1,45,Black Venom Shield,202,1,1,0,0,1
+18521,3,16000,1,50,Black Venom Shield,202,1,1,0,1,1
+18522,3,16000,1,55,Black Venom Shield,202,1,1,0,2,1
+18523,3,16000,1,60,Black Venom Shield,202,1,1,0,3,1
+18524,3,16000,1,70,Black Venom Shield,202,1,1,0,4,1
+18535,3,16000,1,45,Black Venom Rod,205,1,5,0,0,1
+18536,3,16000,1,50,Black Venom Rod,205,1,5,0,1,1
+18537,3,16000,1,55,Black Venom Rod,205,1,5,0,2,1
+18538,3,16000,1,60,Black Venom Rod,205,1,5,0,3,1
+18539,3,16000,1,70,Black Venom Rod,205,1,5,0,4,1
+18670,3,7161,1,90,Avatara,202,85,1,0,0,1
+18671,3,7161,1,90,Avatara,202,85,1,0,1,1
+18672,3,7161,1,90,Avatara,202,85,1,0,2,1
+18673,3,7161,1,90,Avatara,202,85,1,0,3,1
+18674,3,7161,1,90,Avatara,202,85,1,0,4,1
+18685,3,7161,1,90,Torch of Haoma,205,85,5,0,0,1
+18686,3,7161,1,90,Torch of Haoma,205,85,5,0,1,1
+18687,3,7161,1,90,Torch of Haoma,205,85,5,0,2,1
+18688,3,7161,1,90,Torch of Haoma,205,85,5,0,3,1
+18689,3,7161,1,90,Torch of Haoma,205,85,5,0,4,1
 19490,3,5000,1,7,Olfring Shell (Forest),202,1,1,0,0,1
 19491,3,5000,1,9,Olfring Shell (Forest),202,1,1,0,1,1
 19492,3,5000,1,12,Olfring Shell (Forest),202,1,1,0,2,1
-19493,3,5000,1,12,Olfring Shell (Forest),202,1,1,0,3,1
-19494,3,5000,1,2,Olfring Shell (Forest),202,1,1,0,4,1
-19468,3,5000,1,8,Olfring Shell (Sea),202,1,1,0,4,1
-19469,3,5000,1,0,Olfring Shell (Radiance),202,1,1,0,4,1
-19470,3,5000,1,2,Olfring Shell (Star),202,1,1,0,4,1
-19471,3,5000,1,8,Olfring Shell (Terra Preta),202,1,1,0,4,1
-19475,3,5000,1,8,Olfring Rod (Sunlight),205,1,5,0,4,1
-19476,3,5000,1,8,Olfring Rod (Sea),205,1,5,0,4,1
-19477,3,5000,1,2,Olfring Rod (Terra Preta),205,1,5,0,4,1
-19522,3,5000,1,8,Olfring Rod (Iron),205,1,5,0,4,1
-19537,3,5000,1,7,Olfring Rod (Radiance),205,1,5,0,4,1
-19538,3,5000,1,0,Olfring Rod (Star),205,1,5,0,4,1
-19529,3,5000,1,7,Olfring Shell (Sunlight),202,1,1,0,4,1
-19570,3,10000,1,9,Holy Night's Wreath Shield,202,1,1,0,0,1
+19493,3,5000,1,60,Olfring Shell (Forest),202,1,1,0,3,1
+19494,3,5000,1,82,Olfring Shell (Forest),202,1,1,0,4,1
+19468,3,5000,1,40,Olfring Shell (Sea),202,1,1,0,4,1
+19469,3,5000,1,80,Olfring Shell (Radiance),202,1,1,0,4,1
+19470,3,5000,1,82,Olfring Shell (Star),202,1,1,0,4,1
+19471,3,5000,1,40,Olfring Shell (Terra Preta),202,1,1,0,4,1
+19475,3,5000,1,40,Olfring Rod (Sunlight),205,1,5,0,4,1
+19476,3,5000,1,40,Olfring Rod (Sea),205,1,5,0,4,1
+19477,3,5000,1,82,Olfring Rod (Terra Preta),205,1,5,0,4,1
+19522,3,5000,1,40,Olfring Rod (Iron),205,1,5,0,4,1
+19537,3,5000,1,55,Olfring Rod (Radiance),205,1,5,0,4,1
+19538,3,5000,1,80,Olfring Rod (Star),205,1,5,0,4,1
+19529,3,5000,1,55,Olfring Shell (Sunlight),202,1,1,0,4,1
+19570,3,10000,1,25,Holy Night's Wreath Shield,202,1,1,0,0,1
 19571,3,10000,1,14,White Sweetheart's Cookie Bouclier,202,1,1,0,0,1
-19576,3,10000,1,9,Holy Night's Star Rod,205,1,5,0,0,1
+19576,3,10000,1,25,Holy Night's Star Rod,205,1,5,0,0,1
 19577,3,10000,1,14,White Sweetheart's Jewel Rod,205,1,5,0,0,1
-19622,3,50000,1,0,Blue Storm Mithril Shield,202,1,1,0,4,1
-19623,3,50000,1,3,Shield of Vanguard,202,1,1,0,4,1
-19624,3,50000,1,0,Blue Storm Mithril Rod,205,1,5,0,4,1
-19625,3,50000,1,3,Rod of Vanguard,205,1,5,0,4,1
-19665,3,39783,1,4,Epic Sohrab,202,90,1,0,0,1
-19666,3,39783,1,4,Epic Sohrab,202,90,1,0,1,1
-19667,3,39783,1,4,Epic Sohrab,202,90,1,0,2,1
-19668,3,39783,1,4,Epic Sohrab,202,90,1,0,3,1
-19669,3,39783,1,4,Epic Sohrab,202,90,1,0,4,1
-19670,3,50000,1,10,Adamas Military Expedition Shield,202,1,1,0,4,1
-19671,3,50000,1,13,Shield of Agitator,202,1,1,0,4,1
-19767,3,7956,1,4,Red Dawn's Steel Shield,202,90,1,0,0,1
-19768,3,7956,1,4,Red Dawn's Steel Shield,202,90,1,0,1,1
-19769,3,7956,1,4,Red Dawn's Steel Shield,202,90,1,0,2,1
-19770,3,7956,1,4,Red Dawn's Steel Shield,202,90,1,0,3,1
-19771,3,7956,1,4,Red Dawn's Steel Shield,202,90,1,0,4,1
-19772,3,8354,1,9,Guard of Vermilion,202,93,1,0,0,1
-19773,3,8354,1,9,Guard of Vermilion,202,93,1,0,1,1
-19774,3,8354,1,9,Guard of Vermilion,202,93,1,0,2,1
-19775,3,8354,1,9,Guard of Vermilion,202,93,1,0,3,1
-19776,3,8354,1,9,Guard of Vermilion,202,93,1,0,4,1
-19777,3,8592,1,12,Irade of Pavese,202,95,1,0,0,1
-19778,3,8592,1,12,Irade of Pavese,202,95,1,0,1,1
-19779,3,8592,1,12,Irade of Pavese,202,95,1,0,2,1
-19780,3,8592,1,12,Irade of Pavese,202,95,1,0,3,1
-19781,3,8592,1,12,Irade of Pavese,202,95,1,0,4,1
-19782,3,8752,1,14,Pastry Pavise,202,95,1,0,0,1
-19783,3,8752,1,14,Pastry Pavise,202,95,1,0,1,1
-19784,3,8752,1,14,Pastry Pavise,202,95,1,0,2,1
-19785,3,8752,1,14,Pastry Pavise,202,95,1,0,3,1
-19786,3,8752,1,14,Pastry Pavise,202,95,1,0,4,1
-19787,3,50000,1,6,Intellect's Weise Guard,202,1,1,0,4,1
-19788,3,50000,1,9,Shield of Kenntnis,202,1,1,0,4,1
-20125,3,8752,1,14,Shield of Altura,202,95,1,0,0,1
-20126,3,8752,1,14,Shield of Altura,202,95,1,0,1,1
-20127,3,8752,1,14,Shield of Altura,202,95,1,0,2,1
-20128,3,8752,1,14,Shield of Altura,202,95,1,0,3,1
-20129,3,8752,1,14,Shield of Altura,202,95,1,0,4,1
-20130,3,9149,1,3,Rousing Schlucht Shield,202,98,1,0,0,1
-20131,3,9149,1,3,Rousing Schlucht Shield,202,98,1,0,1,1
-20132,3,9149,1,3,Rousing Schlucht Shield,202,98,1,0,2,1
-20133,3,9149,1,3,Rousing Schlucht Shield,202,98,1,0,3,1
-20134,3,9149,1,3,Rousing Schlucht Shield,202,98,1,0,4,1
-20135,3,9388,1,6,Brave Shield,202,100,1,0,0,1
-20136,3,9388,1,6,Brave Shield,202,100,1,0,1,1
-20137,3,9388,1,6,Brave Shield,202,100,1,0,2,1
-20138,3,9388,1,6,Brave Shield,202,100,1,0,3,1
-20139,3,9388,1,6,Brave Shield,202,100,1,0,4,1
-20140,3,9547,1,8,Krater,202,100,1,0,0,1
-20141,3,9547,1,8,Krater,202,100,1,0,1,1
-20142,3,9547,1,8,Krater,202,100,1,0,2,1
-20143,3,9547,1,8,Krater,202,100,1,0,3,1
-20144,3,9547,1,8,Krater,202,100,1,0,4,1
-20145,3,50000,1,0,Honnête Shield of Purity,202,1,1,0,4,1
-20146,3,50000,1,3,Shield of Fedeltà,202,1,1,0,4,1
-19686,3,50000,1,4,Raoxshna's Veil,205,90,5,0,0,1
-19687,3,50000,1,4,Raoxshna's Veil,205,90,5,0,1,1
-19688,3,50000,1,4,Raoxshna's Veil,205,90,5,0,2,1
-19689,3,50000,1,4,Raoxshna's Veil,205,90,5,0,3,1
-19690,3,50000,1,4,Raoxshna's Veil,205,90,5,0,4,1
-19691,3,50000,1,10,Adamas Military Expedition Rod,205,1,5,0,4,1
-19692,3,50000,1,13,Rod of Agitator,205,1,5,0,4,1
-19837,3,7956,1,4,Red Dawn's Steel Rod,205,90,5,0,0,1
-19838,3,7956,1,4,Red Dawn's Steel Rod,205,90,5,0,1,1
-19839,3,7956,1,4,Red Dawn's Steel Rod,205,90,5,0,2,1
-19840,3,7956,1,4,Red Dawn's Steel Rod,205,90,5,0,3,1
-19841,3,7956,1,4,Red Dawn's Steel Rod,205,90,5,0,4,1
-19842,3,8354,1,9,Rod of Vermilion,205,93,5,0,0,1
-19843,3,8354,1,9,Rod of Vermilion,205,93,5,0,1,1
-19844,3,8354,1,9,Rod of Vermilion,205,93,5,0,2,1
-19845,3,8354,1,9,Rod of Vermilion,205,93,5,0,3,1
-19846,3,8354,1,9,Rod of Vermilion,205,93,5,0,4,1
-19847,3,8592,1,12,Işık Rod,205,95,5,0,0,1
-19848,3,8592,1,12,Işık Rod,205,95,5,0,1,1
-19849,3,8592,1,12,Işık Rod,205,95,5,0,2,1
-19850,3,8592,1,12,Işık Rod,205,95,5,0,3,1
-19851,3,8592,1,12,Işık Rod,205,95,5,0,4,1
-19852,3,8752,1,14,Rod of Ethane,205,95,5,0,0,1
-19853,3,8752,1,14,Rod of Ethane,205,95,5,0,1,1
-19854,3,8752,1,14,Rod of Ethane,205,95,5,0,2,1
-19855,3,8752,1,14,Rod of Ethane,205,95,5,0,3,1
-19856,3,8752,1,14,Rod of Ethane,205,95,5,0,4,1
-19857,3,50000,1,6,Intellect's Weise Rod,205,1,5,0,4,1
-19858,3,50000,1,9,Rod of Kenntnis,205,1,5,0,4,1
-20195,3,8752,1,14,Rod of Altura,205,95,5,0,0,1
-20196,3,8752,1,14,Rod of Altura,205,95,5,0,1,1
-20197,3,8752,1,14,Rod of Altura,205,95,5,0,2,1
-20198,3,8752,1,14,Rod of Altura,205,95,5,0,3,1
-20199,3,8752,1,14,Rod of Altura,205,95,5,0,4,1
-20200,3,9149,1,3,Rousing Schlucht Rod,205,98,5,0,0,1
-20201,3,9149,1,3,Rousing Schlucht Rod,205,98,5,0,1,1
-20202,3,9149,1,3,Rousing Schlucht Rod,205,98,5,0,2,1
-20203,3,9149,1,3,Rousing Schlucht Rod,205,98,5,0,3,1
-20204,3,9149,1,3,Rousing Schlucht Rod,205,98,5,0,4,1
-20205,3,9388,1,6,Fierte Rod,205,100,5,0,0,1
-20206,3,9388,1,6,Fierte Rod,205,100,5,0,1,1
-20207,3,9388,1,6,Fierte Rod,205,100,5,0,2,1
-20208,3,9388,1,6,Fierte Rod,205,100,5,0,3,1
-20209,3,9388,1,6,Fierte Rod,205,100,5,0,4,1
-20210,3,9547,1,8,Flamme,205,100,5,0,0,1
-20211,3,9547,1,8,Flamme,205,100,5,0,1,1
-20212,3,9547,1,8,Flamme,205,100,5,0,2,1
-20213,3,9547,1,8,Flamme,205,100,5,0,3,1
-20214,3,9547,1,8,Flamme,205,100,5,0,4,1
-20215,3,50000,1,0,Honnête Rod of Purity,205,1,5,0,4,1
-20216,3,50000,1,3,Torch of Fedeltà,205,1,5,0,4,1
-21672,3,10000,1,9,Skull Knight's Shield,202,1,1,0,0,1
-21747,3,10000,1,9,Supreme Olfring Shell (Star),202,1,1,0,4,1
-21749,3,10000,1,0,Olfring Shell (Scarlet),202,1,1,0,4,1
-21751,3,10000,1,0,Olfring Shell (Iron),202,1,1,0,4,1
-21753,3,10000,1,0,Olfring Rod (Indigo),205,1,5,0,4,1
-21755,3,10000,1,0,Olfring Rod (Pure),205,1,5,0,4,1
-23741,3,48000,1,2,Spirit's Shield,202,100,1,0,0,1
-23742,3,48000,1,2,Spirit's Shield,202,100,1,0,1,1
-23743,3,48000,1,2,Spirit's Shield,202,100,1,0,2,1
-23744,3,48000,1,2,Spirit's Shield,202,100,1,0,3,1
-23745,3,48000,1,2,Spirit's Shield,202,100,1,0,4,1
-23746,3,48000,1,2,Fire King's Shield,202,100,1,0,0,1
-23747,3,48000,1,2,Fire King's Shield,202,100,1,0,1,1
-23748,3,48000,1,2,Fire King's Shield,202,100,1,0,2,1
-23749,3,48000,1,2,Fire King's Shield,202,100,1,0,3,1
-23750,3,48000,1,2,Fire King's Shield,202,100,1,0,4,1
-23751,3,48000,1,2,White Wings' Shield,202,100,1,0,0,1
-23752,3,48000,1,2,White Wings' Shield,202,100,1,0,1,1
-23753,3,48000,1,2,White Wings' Shield,202,100,1,0,2,1
-23754,3,48000,1,2,White Wings' Shield,202,100,1,0,3,1
-23755,3,48000,1,2,White Wings' Shield,202,100,1,0,4,1
-23756,3,48000,1,2,Golden Shield,202,100,1,0,0,1
-23757,3,48000,1,2,Golden Shield,202,100,1,0,1,1
-23758,3,48000,1,2,Golden Shield,202,100,1,0,2,1
-23759,3,48000,1,2,Golden Shield,202,100,1,0,3,1
-23760,3,48000,1,2,Golden Shield,202,100,1,0,4,1
-23761,3,48000,1,7,Blackshatter Shield,202,100,1,0,0,1
-23762,3,48000,1,7,Blackshatter Shield,202,100,1,0,1,1
-23763,3,48000,1,7,Blackshatter Shield,202,100,1,0,2,1
-23764,3,48000,1,7,Blackshatter Shield,202,100,1,0,3,1
-23765,3,48000,1,7,Blackshatter Shield,202,100,1,0,4,1
-23766,3,50000,1,2,Lost Continent's Rover Shield,202,1,1,0,4,1
-23767,3,50000,1,2,"Ancient Muse's Shield, Left Behind",202,1,1,0,4,1
-23768,3,50000,1,7,Frozen Crystal Elga Shield,202,1,1,0,4,1
-23769,3,10000,1,8,Olfring Shell (Willow Green),202,1,1,0,4,1
-23836,3,48000,1,2,Spirit's Rod,205,100,5,0,0,1
-23837,3,48000,1,2,Spirit's Rod,205,100,5,0,1,1
-23838,3,48000,1,2,Spirit's Rod,205,100,5,0,2,1
-23839,3,48000,1,2,Spirit's Rod,205,100,5,0,3,1
-23840,3,48000,1,2,Spirit's Rod,205,100,5,0,4,1
-23841,3,48000,1,2,Fire King's Rod,205,100,5,0,0,1
-23842,3,48000,1,2,Fire King's Rod,205,100,5,0,1,1
-23843,3,48000,1,2,Fire King's Rod,205,100,5,0,2,1
-23844,3,48000,1,2,Fire King's Rod,205,100,5,0,3,1
-23845,3,48000,1,2,Fire King's Rod,205,100,5,0,4,1
-23846,3,48000,1,2,White Wings' Rod,205,100,5,0,0,1
-23847,3,48000,1,2,White Wings' Rod,205,100,5,0,1,1
-23848,3,48000,1,2,White Wings' Rod,205,100,5,0,2,1
-23849,3,48000,1,2,White Wings' Rod,205,100,5,0,3,1
-23850,3,48000,1,2,White Wings' Rod,205,100,5,0,4,1
-23851,3,48000,1,2,Golden Rod,205,100,5,0,0,1
-23852,3,48000,1,2,Golden Rod,205,100,5,0,1,1
-23853,3,48000,1,2,Golden Rod,205,100,5,0,2,1
-23854,3,48000,1,2,Golden Rod,205,100,5,0,3,1
-23855,3,48000,1,2,Golden Rod,205,100,5,0,4,1
-23856,3,48000,1,7,Blackshatter Rod,205,100,5,0,0,1
-23857,3,48000,1,7,Blackshatter Rod,205,100,5,0,1,1
-23858,3,48000,1,7,Blackshatter Rod,205,100,5,0,2,1
-23859,3,48000,1,7,Blackshatter Rod,205,100,5,0,3,1
-23860,3,48000,1,7,Blackshatter Rod,205,100,5,0,4,1
-23865,3,50000,1,2,Lost Continent's Rover Torch,205,1,5,0,4,1
-23866,3,50000,1,2,"Ancient Muse's Rod, Left Behind",205,1,5,0,4,1
-23867,3,50000,1,7,Frozen Crystal Elga Rod,205,1,5,0,4,1
-23872,3,10000,1,8,Olfring Rod (Willow Green),205,1,5,0,4,1
+19622,3,50000,1,80,Blue Storm Mithril Shield,202,1,1,0,4,1
+19623,3,50000,1,83,Shield of Vanguard,202,1,1,0,4,1
+19624,3,50000,1,80,Blue Storm Mithril Rod,205,1,5,0,4,1
+19625,3,50000,1,83,Rod of Vanguard,205,1,5,0,4,1
+19665,3,39783,1,100,Epic Sohrab,202,90,1,0,0,1
+19666,3,39783,1,100,Epic Sohrab,202,90,1,0,1,1
+19667,3,39783,1,100,Epic Sohrab,202,90,1,0,2,1
+19668,3,39783,1,100,Epic Sohrab,202,90,1,0,3,1
+19669,3,39783,1,100,Epic Sohrab,202,90,1,0,4,1
+19670,3,50000,1,90,Adamas Military Expedition Shield,202,1,1,0,4,1
+19671,3,50000,1,93,Shield of Agitator,202,1,1,0,4,1
+19767,3,7956,1,100,Red Dawn's Steel Shield,202,90,1,0,0,1
+19768,3,7956,1,100,Red Dawn's Steel Shield,202,90,1,0,1,1
+19769,3,7956,1,100,Red Dawn's Steel Shield,202,90,1,0,2,1
+19770,3,7956,1,100,Red Dawn's Steel Shield,202,90,1,0,3,1
+19771,3,7956,1,100,Red Dawn's Steel Shield,202,90,1,0,4,1
+19772,3,8354,1,105,Guard of Vermilion,202,93,1,0,0,1
+19773,3,8354,1,105,Guard of Vermilion,202,93,1,0,1,1
+19774,3,8354,1,105,Guard of Vermilion,202,93,1,0,2,1
+19775,3,8354,1,105,Guard of Vermilion,202,93,1,0,3,1
+19776,3,8354,1,105,Guard of Vermilion,202,93,1,0,4,1
+19777,3,8592,1,108,Irade of Pavese,202,95,1,0,0,1
+19778,3,8592,1,108,Irade of Pavese,202,95,1,0,1,1
+19779,3,8592,1,108,Irade of Pavese,202,95,1,0,2,1
+19780,3,8592,1,108,Irade of Pavese,202,95,1,0,3,1
+19781,3,8592,1,108,Irade of Pavese,202,95,1,0,4,1
+19782,3,8752,1,110,Pastry Pavise,202,95,1,0,0,1
+19783,3,8752,1,110,Pastry Pavise,202,95,1,0,1,1
+19784,3,8752,1,110,Pastry Pavise,202,95,1,0,2,1
+19785,3,8752,1,110,Pastry Pavise,202,95,1,0,3,1
+19786,3,8752,1,110,Pastry Pavise,202,95,1,0,4,1
+19787,3,50000,1,102,Intellect's Weise Guard,202,1,1,0,4,1
+19788,3,50000,1,105,Shield of Kenntnis,202,1,1,0,4,1
+20125,3,8752,1,110,Shield of Altura,202,95,1,0,0,1
+20126,3,8752,1,110,Shield of Altura,202,95,1,0,1,1
+20127,3,8752,1,110,Shield of Altura,202,95,1,0,2,1
+20128,3,8752,1,110,Shield of Altura,202,95,1,0,3,1
+20129,3,8752,1,110,Shield of Altura,202,95,1,0,4,1
+20130,3,9149,1,115,Rousing Schlucht Shield,202,98,1,0,0,1
+20131,3,9149,1,115,Rousing Schlucht Shield,202,98,1,0,1,1
+20132,3,9149,1,115,Rousing Schlucht Shield,202,98,1,0,2,1
+20133,3,9149,1,115,Rousing Schlucht Shield,202,98,1,0,3,1
+20134,3,9149,1,115,Rousing Schlucht Shield,202,98,1,0,4,1
+20135,3,9388,1,118,Brave Shield,202,100,1,0,0,1
+20136,3,9388,1,118,Brave Shield,202,100,1,0,1,1
+20137,3,9388,1,118,Brave Shield,202,100,1,0,2,1
+20138,3,9388,1,118,Brave Shield,202,100,1,0,3,1
+20139,3,9388,1,118,Brave Shield,202,100,1,0,4,1
+20140,3,9547,1,120,Krater,202,100,1,0,0,1
+20141,3,9547,1,120,Krater,202,100,1,0,1,1
+20142,3,9547,1,120,Krater,202,100,1,0,2,1
+20143,3,9547,1,120,Krater,202,100,1,0,3,1
+20144,3,9547,1,120,Krater,202,100,1,0,4,1
+20145,3,50000,1,112,Honnête Shield of Purity,202,1,1,0,4,1
+20146,3,50000,1,115,Shield of Fedeltà,202,1,1,0,4,1
+19686,3,50000,1,100,Raoxshna's Veil,205,90,5,0,0,1
+19687,3,50000,1,100,Raoxshna's Veil,205,90,5,0,1,1
+19688,3,50000,1,100,Raoxshna's Veil,205,90,5,0,2,1
+19689,3,50000,1,100,Raoxshna's Veil,205,90,5,0,3,1
+19690,3,50000,1,100,Raoxshna's Veil,205,90,5,0,4,1
+19691,3,50000,1,90,Adamas Military Expedition Rod,205,1,5,0,4,1
+19692,3,50000,1,93,Rod of Agitator,205,1,5,0,4,1
+19837,3,7956,1,100,Red Dawn's Steel Rod,205,90,5,0,0,1
+19838,3,7956,1,100,Red Dawn's Steel Rod,205,90,5,0,1,1
+19839,3,7956,1,100,Red Dawn's Steel Rod,205,90,5,0,2,1
+19840,3,7956,1,100,Red Dawn's Steel Rod,205,90,5,0,3,1
+19841,3,7956,1,100,Red Dawn's Steel Rod,205,90,5,0,4,1
+19842,3,8354,1,105,Rod of Vermilion,205,93,5,0,0,1
+19843,3,8354,1,105,Rod of Vermilion,205,93,5,0,1,1
+19844,3,8354,1,105,Rod of Vermilion,205,93,5,0,2,1
+19845,3,8354,1,105,Rod of Vermilion,205,93,5,0,3,1
+19846,3,8354,1,105,Rod of Vermilion,205,93,5,0,4,1
+19847,3,8592,1,108,Işık Rod,205,95,5,0,0,1
+19848,3,8592,1,108,Işık Rod,205,95,5,0,1,1
+19849,3,8592,1,108,Işık Rod,205,95,5,0,2,1
+19850,3,8592,1,108,Işık Rod,205,95,5,0,3,1
+19851,3,8592,1,108,Işık Rod,205,95,5,0,4,1
+19852,3,8752,1,110,Rod of Ethane,205,95,5,0,0,1
+19853,3,8752,1,110,Rod of Ethane,205,95,5,0,1,1
+19854,3,8752,1,110,Rod of Ethane,205,95,5,0,2,1
+19855,3,8752,1,110,Rod of Ethane,205,95,5,0,3,1
+19856,3,8752,1,110,Rod of Ethane,205,95,5,0,4,1
+19857,3,50000,1,102,Intellect's Weise Rod,205,1,5,0,4,1
+19858,3,50000,1,105,Rod of Kenntnis,205,1,5,0,4,1
+20195,3,8752,1,110,Rod of Altura,205,95,5,0,0,1
+20196,3,8752,1,110,Rod of Altura,205,95,5,0,1,1
+20197,3,8752,1,110,Rod of Altura,205,95,5,0,2,1
+20198,3,8752,1,110,Rod of Altura,205,95,5,0,3,1
+20199,3,8752,1,110,Rod of Altura,205,95,5,0,4,1
+20200,3,9149,1,115,Rousing Schlucht Rod,205,98,5,0,0,1
+20201,3,9149,1,115,Rousing Schlucht Rod,205,98,5,0,1,1
+20202,3,9149,1,115,Rousing Schlucht Rod,205,98,5,0,2,1
+20203,3,9149,1,115,Rousing Schlucht Rod,205,98,5,0,3,1
+20204,3,9149,1,115,Rousing Schlucht Rod,205,98,5,0,4,1
+20205,3,9388,1,118,Fierte Rod,205,100,5,0,0,1
+20206,3,9388,1,118,Fierte Rod,205,100,5,0,1,1
+20207,3,9388,1,118,Fierte Rod,205,100,5,0,2,1
+20208,3,9388,1,118,Fierte Rod,205,100,5,0,3,1
+20209,3,9388,1,118,Fierte Rod,205,100,5,0,4,1
+20210,3,9547,1,120,Flamme,205,100,5,0,0,1
+20211,3,9547,1,120,Flamme,205,100,5,0,1,1
+20212,3,9547,1,120,Flamme,205,100,5,0,2,1
+20213,3,9547,1,120,Flamme,205,100,5,0,3,1
+20214,3,9547,1,120,Flamme,205,100,5,0,4,1
+20215,3,50000,1,112,Honnête Rod of Purity,205,1,5,0,4,1
+20216,3,50000,1,115,Torch of Fedeltà,205,1,5,0,4,1
+21672,3,10000,1,105,Skull Knight's Shield,202,1,1,0,0,1
+21747,3,10000,1,105,Supreme Olfring Shell (Star),202,1,1,0,4,1
+21749,3,10000,1,96,Olfring Shell (Scarlet),202,1,1,0,4,1
+21751,3,10000,1,96,Olfring Shell (Iron),202,1,1,0,4,1
+21753,3,10000,1,96,Olfring Rod (Indigo),205,1,5,0,4,1
+21755,3,10000,1,96,Olfring Rod (Pure),205,1,5,0,4,1
+23741,3,48000,1,130,Spirit's Shield,202,100,1,0,0,1
+23742,3,48000,1,130,Spirit's Shield,202,100,1,0,1,1
+23743,3,48000,1,130,Spirit's Shield,202,100,1,0,2,1
+23744,3,48000,1,130,Spirit's Shield,202,100,1,0,3,1
+23745,3,48000,1,130,Spirit's Shield,202,100,1,0,4,1
+23746,3,48000,1,130,Fire King's Shield,202,100,1,0,0,1
+23747,3,48000,1,130,Fire King's Shield,202,100,1,0,1,1
+23748,3,48000,1,130,Fire King's Shield,202,100,1,0,2,1
+23749,3,48000,1,130,Fire King's Shield,202,100,1,0,3,1
+23750,3,48000,1,130,Fire King's Shield,202,100,1,0,4,1
+23751,3,48000,1,130,White Wings' Shield,202,100,1,0,0,1
+23752,3,48000,1,130,White Wings' Shield,202,100,1,0,1,1
+23753,3,48000,1,130,White Wings' Shield,202,100,1,0,2,1
+23754,3,48000,1,130,White Wings' Shield,202,100,1,0,3,1
+23755,3,48000,1,130,White Wings' Shield,202,100,1,0,4,1
+23756,3,48000,1,130,Golden Shield,202,100,1,0,0,1
+23757,3,48000,1,130,Golden Shield,202,100,1,0,1,1
+23758,3,48000,1,130,Golden Shield,202,100,1,0,2,1
+23759,3,48000,1,130,Golden Shield,202,100,1,0,3,1
+23760,3,48000,1,130,Golden Shield,202,100,1,0,4,1
+23761,3,48000,1,135,Blackshatter Shield,202,100,1,0,0,1
+23762,3,48000,1,135,Blackshatter Shield,202,100,1,0,1,1
+23763,3,48000,1,135,Blackshatter Shield,202,100,1,0,2,1
+23764,3,48000,1,135,Blackshatter Shield,202,100,1,0,3,1
+23765,3,48000,1,135,Blackshatter Shield,202,100,1,0,4,1
+23766,3,50000,1,130,Lost Continent's Rover Shield,202,1,1,0,4,1
+23767,3,50000,1,130,"Ancient Muse's Shield, Left Behind",202,1,1,0,4,1
+23768,3,50000,1,135,Frozen Crystal Elga Shield,202,1,1,0,4,1
+23769,3,10000,1,120,Olfring Shell (Willow Green),202,1,1,0,4,1
+23836,3,48000,1,130,Spirit's Rod,205,100,5,0,0,1
+23837,3,48000,1,130,Spirit's Rod,205,100,5,0,1,1
+23838,3,48000,1,130,Spirit's Rod,205,100,5,0,2,1
+23839,3,48000,1,130,Spirit's Rod,205,100,5,0,3,1
+23840,3,48000,1,130,Spirit's Rod,205,100,5,0,4,1
+23841,3,48000,1,130,Fire King's Rod,205,100,5,0,0,1
+23842,3,48000,1,130,Fire King's Rod,205,100,5,0,1,1
+23843,3,48000,1,130,Fire King's Rod,205,100,5,0,2,1
+23844,3,48000,1,130,Fire King's Rod,205,100,5,0,3,1
+23845,3,48000,1,130,Fire King's Rod,205,100,5,0,4,1
+23846,3,48000,1,130,White Wings' Rod,205,100,5,0,0,1
+23847,3,48000,1,130,White Wings' Rod,205,100,5,0,1,1
+23848,3,48000,1,130,White Wings' Rod,205,100,5,0,2,1
+23849,3,48000,1,130,White Wings' Rod,205,100,5,0,3,1
+23850,3,48000,1,130,White Wings' Rod,205,100,5,0,4,1
+23851,3,48000,1,130,Golden Rod,205,100,5,0,0,1
+23852,3,48000,1,130,Golden Rod,205,100,5,0,1,1
+23853,3,48000,1,130,Golden Rod,205,100,5,0,2,1
+23854,3,48000,1,130,Golden Rod,205,100,5,0,3,1
+23855,3,48000,1,130,Golden Rod,205,100,5,0,4,1
+23856,3,48000,1,135,Blackshatter Rod,205,100,5,0,0,1
+23857,3,48000,1,135,Blackshatter Rod,205,100,5,0,1,1
+23858,3,48000,1,135,Blackshatter Rod,205,100,5,0,2,1
+23859,3,48000,1,135,Blackshatter Rod,205,100,5,0,3,1
+23860,3,48000,1,135,Blackshatter Rod,205,100,5,0,4,1
+23865,3,50000,1,130,Lost Continent's Rover Torch,205,1,5,0,4,1
+23866,3,50000,1,130,"Ancient Muse's Rod, Left Behind",205,1,5,0,4,1
+23867,3,50000,1,135,Frozen Crystal Elga Rod,205,1,5,0,4,1
+23872,3,10000,1,120,Olfring Rod (Willow Green),205,1,5,0,4,1
 24854,3,50000,1,10,Ultra-Rich Chocolate Shield,202,1,1,0,4,1
 24857,3,50000,1,10,Ultra-Rich Chocolate Rod,205,1,5,0,4,1
-24944,3,10000,1,14,Olfring Shell (Crimson),202,1,1,0,4,1
-24946,3,10000,1,14,Olfring Rod (Crimson),205,1,5,0,4,1
-24950,3,10000,1,14,Olfring Shell (Snow),202,1,1,0,4,1
-24952,3,10000,1,14,Olfring Rod (Snow),205,1,5,0,4,1
-24956,3,10000,1,8,Olfring Shell (DiCE),202,1,1,0,4,1
-24958,3,10000,1,8,Olfring Rod (DiCE),205,1,5,0,4,1
-24962,3,10000,1,14,Olfring Shell (Spirit),202,1,1,0,4,1
-24964,3,10000,1,14,Olfring Rod (Spirit),205,1,5,0,4,1
-24968,3,10000,1,14,Olfring Shell (染),202,1,1,0,4,1
-24970,3,10000,1,14,Olfring Rod (染),205,1,5,0,4,1
-24976,3,50000,1,2,Shield of Kraken,202,1,1,0,4,1
-24977,3,50000,1,2,Shield of Legend,202,1,1,0,4,1
-24978,3,50000,1,7,Shield of Ice Age,202,1,1,0,4,1
-24986,3,50000,1,2,Rod of Kraken,205,1,5,0,4,1
-24987,3,50000,1,2,Rod of Legend,205,1,5,0,4,1
-24988,3,50000,1,7,Rod of Ice Age,205,1,5,0,4,1
-25044,3,48500,1,12,Savage Courage Assault Shield,202,105,1,0,0,1
-25045,3,48500,1,12,Savage Courage Assault Shield,202,105,1,0,1,1
-25046,3,48500,1,12,Savage Courage Assault Shield,202,105,1,0,2,1
-25047,3,48500,1,12,Savage Courage Assault Shield,202,105,1,0,3,1
-25048,3,48500,1,12,Savage Courage Assault Shield,202,105,1,0,4,1
-25049,3,49000,1,1,Solitary Assault Shield,202,110,1,0,0,1
-25050,3,49000,1,1,Solitary Assault Shield,202,110,1,0,1,1
-25051,3,49000,1,1,Solitary Assault Shield,202,110,1,0,2,1
-25052,3,49000,1,1,Solitary Assault Shield,202,110,1,0,3,1
-25053,3,49000,1,1,Solitary Assault Shield,202,110,1,0,4,1
-25054,3,49500,1,6,Hero's Assault Shield,202,115,1,0,0,1
-25055,3,49500,1,6,Hero's Assault Shield,202,115,1,0,1,1
-25056,3,49500,1,6,Hero's Assault Shield,202,115,1,0,2,1
-25057,3,49500,1,6,Hero's Assault Shield,202,115,1,0,3,1
-25058,3,49500,1,6,Hero's Assault Shield,202,115,1,0,4,1
-25089,3,48500,1,12,Savage Courage Ranger Rod,205,105,5,0,0,1
-25090,3,48500,1,12,Savage Courage Ranger Rod,205,105,5,0,1,1
-25091,3,48500,1,12,Savage Courage Ranger Rod,205,105,5,0,2,1
-25092,3,48500,1,12,Savage Courage Ranger Rod,205,105,5,0,3,1
-25093,3,48500,1,12,Savage Courage Ranger Rod,205,105,5,0,4,1
-25094,3,49000,1,1,Solitary Ranger's Rod,205,110,5,0,0,1
-25095,3,49000,1,1,Solitary Ranger's Rod,205,110,5,0,1,1
-25096,3,49000,1,1,Solitary Ranger's Rod,205,110,5,0,2,1
-25097,3,49000,1,1,Solitary Ranger's Rod,205,110,5,0,3,1
-25098,3,49000,1,1,Solitary Ranger's Rod,205,110,5,0,4,1
-25099,3,49500,1,6,Hero's Ranger Rod,205,115,5,0,0,1
-25100,3,49500,1,6,Hero's Ranger Rod,205,115,5,0,1,1
-25101,3,49500,1,6,Hero's Ranger Rod,205,115,5,0,2,1
-25102,3,49500,1,6,Hero's Ranger Rod,205,115,5,0,3,1
-25103,3,49500,1,6,Hero's Ranger Rod,205,115,5,0,4,1
-25579,3,50000,1,12,Shield of Guardian,202,1,1,0,4,1
-25582,3,50000,1,12,Torch of Guardian,205,1,5,0,4,1
-25592,3,50000,1,1,Fortress Guard's Fortified Shield,202,1,1,0,4,1
-25595,3,50000,1,1,Fortress Guard's Fortified Lantern,205,1,5,0,4,1
-25605,3,50000,1,6,High Ancient Shield,202,1,1,0,4,1
-25608,3,50000,1,6,High Ancient Torch,205,1,5,0,4,1
+24944,3,10000,1,110,Olfring Shell (Crimson),202,1,1,0,4,1
+24946,3,10000,1,110,Olfring Rod (Crimson),205,1,5,0,4,1
+24950,3,10000,1,110,Olfring Shell (Snow),202,1,1,0,4,1
+24952,3,10000,1,110,Olfring Rod (Snow),205,1,5,0,4,1
+24956,3,10000,1,120,Olfring Shell (DiCE),202,1,1,0,4,1
+24958,3,10000,1,120,Olfring Rod (DiCE),205,1,5,0,4,1
+24962,3,10000,1,110,Olfring Shell (Spirit),202,1,1,0,4,1
+24964,3,10000,1,110,Olfring Rod (Spirit),205,1,5,0,4,1
+24968,3,10000,1,110,Olfring Shell (染),202,1,1,0,4,1
+24970,3,10000,1,110,Olfring Rod (染),205,1,5,0,4,1
+24976,3,50000,1,130,Shield of Kraken,202,1,1,0,4,1
+24977,3,50000,1,130,Shield of Legend,202,1,1,0,4,1
+24978,3,50000,1,135,Shield of Ice Age,202,1,1,0,4,1
+24986,3,50000,1,130,Rod of Kraken,205,1,5,0,4,1
+24987,3,50000,1,130,Rod of Legend,205,1,5,0,4,1
+24988,3,50000,1,135,Rod of Ice Age,205,1,5,0,4,1
+25044,3,48500,1,140,Savage Courage Assault Shield,202,105,1,0,0,1
+25045,3,48500,1,140,Savage Courage Assault Shield,202,105,1,0,1,1
+25046,3,48500,1,140,Savage Courage Assault Shield,202,105,1,0,2,1
+25047,3,48500,1,140,Savage Courage Assault Shield,202,105,1,0,3,1
+25048,3,48500,1,140,Savage Courage Assault Shield,202,105,1,0,4,1
+25049,3,49000,1,145,Solitary Assault Shield,202,110,1,0,0,1
+25050,3,49000,1,145,Solitary Assault Shield,202,110,1,0,1,1
+25051,3,49000,1,145,Solitary Assault Shield,202,110,1,0,2,1
+25052,3,49000,1,145,Solitary Assault Shield,202,110,1,0,3,1
+25053,3,49000,1,145,Solitary Assault Shield,202,110,1,0,4,1
+25054,3,49500,1,150,Hero's Assault Shield,202,115,1,0,0,1
+25055,3,49500,1,150,Hero's Assault Shield,202,115,1,0,1,1
+25056,3,49500,1,150,Hero's Assault Shield,202,115,1,0,2,1
+25057,3,49500,1,150,Hero's Assault Shield,202,115,1,0,3,1
+25058,3,49500,1,150,Hero's Assault Shield,202,115,1,0,4,1
+25089,3,48500,1,140,Savage Courage Ranger Rod,205,105,5,0,0,1
+25090,3,48500,1,140,Savage Courage Ranger Rod,205,105,5,0,1,1
+25091,3,48500,1,140,Savage Courage Ranger Rod,205,105,5,0,2,1
+25092,3,48500,1,140,Savage Courage Ranger Rod,205,105,5,0,3,1
+25093,3,48500,1,140,Savage Courage Ranger Rod,205,105,5,0,4,1
+25094,3,49000,1,145,Solitary Ranger's Rod,205,110,5,0,0,1
+25095,3,49000,1,145,Solitary Ranger's Rod,205,110,5,0,1,1
+25096,3,49000,1,145,Solitary Ranger's Rod,205,110,5,0,2,1
+25097,3,49000,1,145,Solitary Ranger's Rod,205,110,5,0,3,1
+25098,3,49000,1,145,Solitary Ranger's Rod,205,110,5,0,4,1
+25099,3,49500,1,150,Hero's Ranger Rod,205,115,5,0,0,1
+25100,3,49500,1,150,Hero's Ranger Rod,205,115,5,0,1,1
+25101,3,49500,1,150,Hero's Ranger Rod,205,115,5,0,2,1
+25102,3,49500,1,150,Hero's Ranger Rod,205,115,5,0,3,1
+25103,3,49500,1,150,Hero's Ranger Rod,205,115,5,0,4,1
+25579,3,50000,1,140,Shield of Guardian,202,1,1,0,4,1
+25582,3,50000,1,140,Torch of Guardian,205,1,5,0,4,1
+25592,3,50000,1,145,Fortress Guard's Fortified Shield,202,1,1,0,4,1
+25595,3,50000,1,145,Fortress Guard's Fortified Lantern,205,1,5,0,4,1
+25605,3,50000,1,150,High Ancient Shield,202,1,1,0,4,1
+25608,3,50000,1,150,High Ancient Torch,205,1,5,0,4,1
 422,3,30,1,1,Horned Helm,303,3,12,0,0,1
 2034,3,30,1,1,Horned Helm,303,3,12,0,1,1
 3057,3,30,1,1,Horned Helm,303,3,12,0,2,1
@@ -11819,11 +11819,11 @@
 3168,3,2820,1,9,Gryphus Helm,303,43,12,0,2,1
 4191,3,2820,1,9,Gryphus Helm,303,43,12,0,3,1
 5214,3,2820,1,9,Gryphus Helm,303,43,12,0,4,1
-534,3,7351,1,3,Faith Head,303,70,12,0,0,1
-2146,3,7351,1,3,Faith Head,303,70,12,0,1,1
-3169,3,7351,1,3,Faith Head,303,70,12,0,2,1
-4192,3,7351,1,3,Faith Head,303,70,12,0,3,1
-5215,3,7351,1,3,Faith Head,303,70,12,0,4,1
+534,3,7351,1,35,Faith Head,303,70,12,0,0,1
+2146,3,7351,1,35,Faith Head,303,70,12,0,1,1
+3169,3,7351,1,35,Faith Head,303,70,12,0,2,1
+4192,3,7351,1,35,Faith Head,303,70,12,0,3,1
+5215,3,7351,1,35,Faith Head,303,70,12,0,4,1
 535,3,3535,1,10,Silver Sallet,303,49,12,0,0,1
 2147,3,3535,1,10,Silver Sallet,303,49,12,0,1,1
 3170,3,3535,1,10,Silver Sallet,303,49,12,0,2,1
@@ -11949,11 +11949,11 @@
 3272,3,2690,1,9,Officer's Cap,303,41,14,0,2,1
 4295,3,2690,1,9,Officer's Cap,303,41,14,0,3,1
 5318,3,2690,1,9,Officer's Cap,303,41,14,0,4,1
-638,3,7351,1,3,Faith Hood,303,70,14,0,0,1
-2250,3,7351,1,3,Faith Hood,303,70,14,0,1,1
-3273,3,7351,1,3,Faith Hood,303,70,14,0,2,1
-4296,3,7351,1,3,Faith Hood,303,70,14,0,3,1
-5319,3,7351,1,3,Faith Hood,303,70,14,0,4,1
+638,3,7351,1,35,Faith Hood,303,70,14,0,0,1
+2250,3,7351,1,35,Faith Hood,303,70,14,0,1,1
+3273,3,7351,1,35,Faith Hood,303,70,14,0,2,1
+4296,3,7351,1,35,Faith Hood,303,70,14,0,3,1
+5319,3,7351,1,35,Faith Hood,303,70,14,0,4,1
 639,3,3385,1,10,Aloni Headgear,303,46,14,0,0,1
 2251,3,3385,1,10,Aloni Headgear,303,46,14,0,1,1
 3274,3,3385,1,10,Aloni Headgear,303,46,14,0,2,1
@@ -11999,11 +11999,11 @@
 3282,3,5760,1,12,Rubedo Mask,303,60,3,0,2,1
 4305,3,5760,1,12,Rubedo Mask,303,60,3,0,3,1
 5328,3,5760,1,12,Rubedo Mask,303,60,3,0,4,1
-648,3,6339,1,4,Empyreal Guard,303,65,14,0,0,1
-2260,3,6339,1,4,Empyreal Guard,303,65,14,0,1,1
-3283,3,6339,1,4,Empyreal Guard,303,65,14,0,2,1
-4306,3,6339,1,4,Empyreal Guard,303,65,14,0,3,1
-5329,3,6339,1,4,Empyreal Guard,303,65,14,0,4,1
+648,3,6339,1,20,Empyreal Guard,303,65,14,0,0,1
+2260,3,6339,1,20,Empyreal Guard,303,65,14,0,1,1
+3283,3,6339,1,20,Empyreal Guard,303,65,14,0,2,1
+4306,3,6339,1,20,Empyreal Guard,303,65,14,0,3,1
+5329,3,6339,1,20,Empyreal Guard,303,65,14,0,4,1
 649,3,5015,1,12,Hanzou Mask,303,58,14,0,0,1
 2261,3,5015,1,12,Hanzou Mask,303,58,14,0,1,1
 3284,3,5015,1,12,Hanzou Mask,303,58,14,0,2,1
@@ -12079,11 +12079,11 @@
 3378,3,2960,1,9,Adept's Hat,303,45,15,0,2,1
 4401,3,2960,1,9,Adept's Hat,303,45,15,0,3,1
 5424,3,2960,1,9,Adept's Hat,303,45,15,0,4,1
-744,3,7351,1,3,Faith Cap,303,70,15,0,0,1
-2356,3,7351,1,3,Faith Cap,303,70,15,0,1,1
-3379,3,7351,1,3,Faith Cap,303,70,15,0,2,1
-4402,3,7351,1,3,Faith Cap,303,70,15,0,3,1
-5425,3,7351,1,3,Faith Cap,303,70,15,0,4,1
+744,3,7351,1,35,Faith Cap,303,70,15,0,0,1
+2356,3,7351,1,35,Faith Cap,303,70,15,0,1,1
+3379,3,7351,1,35,Faith Cap,303,70,15,0,2,1
+4402,3,7351,1,35,Faith Cap,303,70,15,0,3,1
+5425,3,7351,1,35,Faith Cap,303,70,15,0,4,1
 745,3,3535,1,11,Circlet of Divine Sight,303,52,15,0,0,1
 2357,3,3535,1,11,Circlet of Divine Sight,303,52,15,0,1,1
 3380,3,3535,1,11,Circlet of Divine Sight,303,52,15,0,2,1
@@ -12214,11 +12214,11 @@
 3486,3,2960,1,9,Greater Eyes,303,45,17,0,2,1
 4509,3,2960,1,9,Greater Eyes,303,45,17,0,3,1
 5532,3,2960,1,9,Greater Eyes,303,45,17,0,4,1
-852,3,7351,1,3,Genius Helm,303,70,17,0,0,1
-2464,3,7351,1,3,Genius Helm,303,70,17,0,1,1
-3487,3,7351,1,3,Genius Helm,303,70,17,0,2,1
-4510,3,7351,1,3,Genius Helm,303,70,17,0,3,1
-5533,3,7351,1,3,Genius Helm,303,70,17,0,4,1
+852,3,7351,1,35,Genius Helm,303,70,17,0,0,1
+2464,3,7351,1,35,Genius Helm,303,70,17,0,1,1
+3487,3,7351,1,35,Genius Helm,303,70,17,0,2,1
+4510,3,7351,1,35,Genius Helm,303,70,17,0,3,1
+5533,3,7351,1,35,Genius Helm,303,70,17,0,4,1
 853,3,3535,1,12,Maverick Helm,303,56,17,0,0,1
 2465,3,3535,1,12,Maverick Helm,303,56,17,0,1,1
 3488,3,3535,1,12,Maverick Helm,303,56,17,0,2,1
@@ -12269,11 +12269,11 @@
 3497,3,5015,1,12,Oath's Helm,303,58,17,0,2,1
 4520,3,5015,1,12,Oath's Helm,303,58,17,0,3,1
 5543,3,5015,1,12,Oath's Helm,303,58,17,0,4,1
-863,3,6339,1,4,Heavenly Eyes,303,65,17,0,0,1
-2475,3,6339,1,4,Heavenly Eyes,303,65,17,0,1,1
-3498,3,6339,1,4,Heavenly Eyes,303,65,17,0,2,1
-4521,3,6339,1,4,Heavenly Eyes,303,65,17,0,3,1
-5544,3,6339,1,4,Heavenly Eyes,303,65,17,0,4,1
+863,3,6339,1,20,Heavenly Eyes,303,65,17,0,0,1
+2475,3,6339,1,20,Heavenly Eyes,303,65,17,0,1,1
+3498,3,6339,1,20,Heavenly Eyes,303,65,17,0,2,1
+4521,3,6339,1,20,Heavenly Eyes,303,65,17,0,3,1
+5544,3,6339,1,20,Heavenly Eyes,303,65,17,0,4,1
 942,3,40,1,1,Leather Circlet,303,1,0,0,0,1
 2554,3,40,1,1,Leather Circlet,303,1,0,0,1,1
 3577,3,40,1,1,Leather Circlet,303,1,0,0,2,1
@@ -12614,147 +12614,147 @@
 10910,3,5000,1,12,Rathian Helm,303,30,16,3,2,1
 10911,3,5000,1,12,Rathian Helm,303,30,16,3,3,1
 10912,3,5000,1,12,Rathian Helm,303,30,16,3,4,1
-10913,3,5000,1,6,Silver Sol Helm,303,55,13,3,0,1
-10914,3,5000,1,6,Silver Sol Helm,303,55,13,3,1,1
-10915,3,5000,1,6,Silver Sol Helm,303,55,13,3,2,1
-10916,3,5000,1,6,Silver Sol Helm,303,55,13,3,3,1
-10917,3,5000,1,6,Silver Sol Helm,303,55,13,3,4,1
-10918,3,5000,1,6,Gold Luna Helm,303,55,16,3,0,1
-10919,3,5000,1,6,Gold Luna Helm,303,55,16,3,1,1
-10920,3,5000,1,6,Gold Luna Helm,303,55,16,3,2,1
-10921,3,5000,1,6,Gold Luna Helm,303,55,16,3,3,1
-10922,3,5000,1,6,Gold Luna Helm,303,55,16,3,4,1
+10913,3,5000,1,70,Silver Sol Helm,303,55,13,3,0,1
+10914,3,5000,1,70,Silver Sol Helm,303,55,13,3,1,1
+10915,3,5000,1,70,Silver Sol Helm,303,55,13,3,2,1
+10916,3,5000,1,70,Silver Sol Helm,303,55,13,3,3,1
+10917,3,5000,1,70,Silver Sol Helm,303,55,13,3,4,1
+10918,3,5000,1,70,Gold Luna Helm,303,55,16,3,0,1
+10919,3,5000,1,70,Gold Luna Helm,303,55,16,3,1,1
+10920,3,5000,1,70,Gold Luna Helm,303,55,16,3,2,1
+10921,3,5000,1,70,Gold Luna Helm,303,55,16,3,3,1
+10922,3,5000,1,70,Gold Luna Helm,303,55,16,3,4,1
 11749,3,6000,1,1,Invisible Cap,303,1,0,0,0,1
-12536,3,6339,1,4,Damascus Helm,303,65,12,0,0,1
-12537,3,6339,1,4,Damascus Helm,303,65,12,0,1,1
-12538,3,6339,1,4,Damascus Helm,303,65,12,0,2,1
-12539,3,6339,1,4,Damascus Helm,303,65,12,0,3,1
-12540,3,6339,1,4,Damascus Helm,303,65,12,0,4,1
-12541,3,6339,1,9,Immortal's Great Helm,303,65,12,0,0,1
-12542,3,6339,1,9,Immortal's Great Helm,303,65,12,0,1,1
-12543,3,6339,1,9,Immortal's Great Helm,303,65,12,0,2,1
-12544,3,6339,1,9,Immortal's Great Helm,303,65,12,0,3,1
-12545,3,6339,1,9,Immortal's Great Helm,303,65,12,0,4,1
-12546,3,6339,1,14,Enlightenment Knight,303,65,12,0,0,1
-12547,3,6339,1,14,Enlightenment Knight,303,65,12,0,1,1
-12548,3,6339,1,14,Enlightenment Knight,303,65,12,0,2,1
-12549,3,6339,1,14,Enlightenment Knight,303,65,12,0,3,1
-12550,3,6339,1,14,Enlightenment Knight,303,65,12,0,4,1
-12551,3,6735,1,14,Wild Noble,303,67,12,0,0,1
-12552,3,6735,1,14,Wild Noble,303,67,12,0,1,1
-12553,3,6735,1,14,Wild Noble,303,67,12,0,2,1
-12554,3,6735,1,14,Wild Noble,303,67,12,0,3,1
-12555,3,6735,1,14,Wild Noble,303,67,12,0,4,1
-12556,3,7351,1,8,Alloy Helm,303,70,12,0,0,1
-12557,3,7351,1,8,Alloy Helm,303,70,12,0,1,1
-12558,3,7351,1,8,Alloy Helm,303,70,12,0,2,1
-12559,3,7351,1,8,Alloy Helm,303,70,12,0,3,1
-12560,3,7351,1,8,Alloy Helm,303,70,12,0,4,1
-12561,3,7351,1,13,Predator Head,303,70,12,0,0,1
-12562,3,7351,1,13,Predator Head,303,70,12,0,1,1
-12563,3,7351,1,13,Predator Head,303,70,12,0,2,1
-12564,3,7351,1,13,Predator Head,303,70,12,0,3,1
-12565,3,7351,1,13,Predator Head,303,70,12,0,4,1
-12566,3,6339,1,4,Glorious Diadem,303,65,15,0,0,1
-12567,3,6339,1,4,Glorious Diadem,303,65,15,0,1,1
-12568,3,6339,1,4,Glorious Diadem,303,65,15,0,2,1
-12569,3,6339,1,4,Glorious Diadem,303,65,15,0,3,1
-12570,3,6339,1,4,Glorious Diadem,303,65,15,0,4,1
-12571,3,6339,1,9,Forehead Protector of Righteousness,303,65,15,0,0,1
-12572,3,6339,1,9,Forehead Protector of Righteousness,303,65,15,0,1,1
-12573,3,6339,1,9,Forehead Protector of Righteousness,303,65,15,0,2,1
-12574,3,6339,1,9,Forehead Protector of Righteousness,303,65,15,0,3,1
-12575,3,6339,1,9,Forehead Protector of Righteousness,303,65,15,0,4,1
-12576,3,6339,1,14,Bishop Hood,303,65,15,0,0,1
-12577,3,6339,1,14,Bishop Hood,303,65,15,0,1,1
-12578,3,6339,1,14,Bishop Hood,303,65,15,0,2,1
-12579,3,6339,1,14,Bishop Hood,303,65,15,0,3,1
-12580,3,6339,1,14,Bishop Hood,303,65,15,0,4,1
-12581,3,6735,1,14,Coif of Crown,303,67,15,0,0,1
-12582,3,6735,1,14,Coif of Crown,303,67,15,0,1,1
-12583,3,6735,1,14,Coif of Crown,303,67,15,0,2,1
-12584,3,6735,1,14,Coif of Crown,303,67,15,0,3,1
-12585,3,6735,1,14,Coif of Crown,303,67,15,0,4,1
-12586,3,7351,1,8,Libertas Cap,303,70,15,0,0,1
-12587,3,7351,1,8,Libertas Cap,303,70,15,0,1,1
-12588,3,7351,1,8,Libertas Cap,303,70,15,0,2,1
-12589,3,7351,1,8,Libertas Cap,303,70,15,0,3,1
-12590,3,7351,1,8,Libertas Cap,303,70,15,0,4,1
-12591,3,7351,1,13,Carrion Face,303,70,15,0,0,1
-12592,3,7351,1,13,Carrion Face,303,70,15,0,1,1
-12593,3,7351,1,13,Carrion Face,303,70,15,0,2,1
-12594,3,7351,1,13,Carrion Face,303,70,15,0,3,1
-12595,3,7351,1,13,Carrion Face,303,70,15,0,4,1
+12536,3,6339,1,20,Damascus Helm,303,65,12,0,0,1
+12537,3,6339,1,20,Damascus Helm,303,65,12,0,1,1
+12538,3,6339,1,20,Damascus Helm,303,65,12,0,2,1
+12539,3,6339,1,20,Damascus Helm,303,65,12,0,3,1
+12540,3,6339,1,20,Damascus Helm,303,65,12,0,4,1
+12541,3,6339,1,25,Immortal's Great Helm,303,65,12,0,0,1
+12542,3,6339,1,25,Immortal's Great Helm,303,65,12,0,1,1
+12543,3,6339,1,25,Immortal's Great Helm,303,65,12,0,2,1
+12544,3,6339,1,25,Immortal's Great Helm,303,65,12,0,3,1
+12545,3,6339,1,25,Immortal's Great Helm,303,65,12,0,4,1
+12546,3,6339,1,30,Enlightenment Knight,303,65,12,0,0,1
+12547,3,6339,1,30,Enlightenment Knight,303,65,12,0,1,1
+12548,3,6339,1,30,Enlightenment Knight,303,65,12,0,2,1
+12549,3,6339,1,30,Enlightenment Knight,303,65,12,0,3,1
+12550,3,6339,1,30,Enlightenment Knight,303,65,12,0,4,1
+12551,3,6735,1,30,Wild Noble,303,67,12,0,0,1
+12552,3,6735,1,30,Wild Noble,303,67,12,0,1,1
+12553,3,6735,1,30,Wild Noble,303,67,12,0,2,1
+12554,3,6735,1,30,Wild Noble,303,67,12,0,3,1
+12555,3,6735,1,30,Wild Noble,303,67,12,0,4,1
+12556,3,7351,1,40,Alloy Helm,303,70,12,0,0,1
+12557,3,7351,1,40,Alloy Helm,303,70,12,0,1,1
+12558,3,7351,1,40,Alloy Helm,303,70,12,0,2,1
+12559,3,7351,1,40,Alloy Helm,303,70,12,0,3,1
+12560,3,7351,1,40,Alloy Helm,303,70,12,0,4,1
+12561,3,7351,1,45,Predator Head,303,70,12,0,0,1
+12562,3,7351,1,45,Predator Head,303,70,12,0,1,1
+12563,3,7351,1,45,Predator Head,303,70,12,0,2,1
+12564,3,7351,1,45,Predator Head,303,70,12,0,3,1
+12565,3,7351,1,45,Predator Head,303,70,12,0,4,1
+12566,3,6339,1,20,Glorious Diadem,303,65,15,0,0,1
+12567,3,6339,1,20,Glorious Diadem,303,65,15,0,1,1
+12568,3,6339,1,20,Glorious Diadem,303,65,15,0,2,1
+12569,3,6339,1,20,Glorious Diadem,303,65,15,0,3,1
+12570,3,6339,1,20,Glorious Diadem,303,65,15,0,4,1
+12571,3,6339,1,25,Forehead Protector of Righteousness,303,65,15,0,0,1
+12572,3,6339,1,25,Forehead Protector of Righteousness,303,65,15,0,1,1
+12573,3,6339,1,25,Forehead Protector of Righteousness,303,65,15,0,2,1
+12574,3,6339,1,25,Forehead Protector of Righteousness,303,65,15,0,3,1
+12575,3,6339,1,25,Forehead Protector of Righteousness,303,65,15,0,4,1
+12576,3,6339,1,30,Bishop Hood,303,65,15,0,0,1
+12577,3,6339,1,30,Bishop Hood,303,65,15,0,1,1
+12578,3,6339,1,30,Bishop Hood,303,65,15,0,2,1
+12579,3,6339,1,30,Bishop Hood,303,65,15,0,3,1
+12580,3,6339,1,30,Bishop Hood,303,65,15,0,4,1
+12581,3,6735,1,30,Coif of Crown,303,67,15,0,0,1
+12582,3,6735,1,30,Coif of Crown,303,67,15,0,1,1
+12583,3,6735,1,30,Coif of Crown,303,67,15,0,2,1
+12584,3,6735,1,30,Coif of Crown,303,67,15,0,3,1
+12585,3,6735,1,30,Coif of Crown,303,67,15,0,4,1
+12586,3,7351,1,40,Libertas Cap,303,70,15,0,0,1
+12587,3,7351,1,40,Libertas Cap,303,70,15,0,1,1
+12588,3,7351,1,40,Libertas Cap,303,70,15,0,2,1
+12589,3,7351,1,40,Libertas Cap,303,70,15,0,3,1
+12590,3,7351,1,40,Libertas Cap,303,70,15,0,4,1
+12591,3,7351,1,45,Carrion Face,303,70,15,0,0,1
+12592,3,7351,1,45,Carrion Face,303,70,15,0,1,1
+12593,3,7351,1,45,Carrion Face,303,70,15,0,2,1
+12594,3,7351,1,45,Carrion Face,303,70,15,0,3,1
+12595,3,7351,1,45,Carrion Face,303,70,15,0,4,1
 12596,3,5767,1,15,Helm of Gloom,303,62,17,0,0,1
 12597,3,5767,1,15,Helm of Gloom,303,62,17,0,1,1
 12598,3,5767,1,15,Helm of Gloom,303,62,17,0,2,1
 12599,3,5767,1,15,Helm of Gloom,303,62,17,0,3,1
 12600,3,5767,1,15,Helm of Gloom,303,62,17,0,4,1
-12601,3,6339,1,9,Forehead Protector of Wisemen,303,65,17,0,0,1
-12602,3,6339,1,9,Forehead Protector of Wisemen,303,65,17,0,1,1
-12603,3,6339,1,9,Forehead Protector of Wisemen,303,65,17,0,2,1
-12604,3,6339,1,9,Forehead Protector of Wisemen,303,65,17,0,3,1
-12605,3,6339,1,9,Forehead Protector of Wisemen,303,65,17,0,4,1
-12606,3,6339,1,14,Saint's Helm,303,65,17,0,0,1
-12607,3,6339,1,14,Saint's Helm,303,65,17,0,1,1
-12608,3,6339,1,14,Saint's Helm,303,65,17,0,2,1
-12609,3,6339,1,14,Saint's Helm,303,65,17,0,3,1
-12610,3,6339,1,14,Saint's Helm,303,65,17,0,4,1
-12611,3,6735,1,14,Roaming Hat,303,67,17,0,0,1
-12612,3,6735,1,14,Roaming Hat,303,67,17,0,1,1
-12613,3,6735,1,14,Roaming Hat,303,67,17,0,2,1
-12614,3,6735,1,14,Roaming Hat,303,67,17,0,3,1
-12615,3,6735,1,14,Roaming Hat,303,67,17,0,4,1
-12616,3,7351,1,8,Helm of Certainty,303,70,17,0,0,1
-12617,3,7351,1,8,Helm of Certainty,303,70,17,0,1,1
-12618,3,7351,1,8,Helm of Certainty,303,70,17,0,2,1
-12619,3,7351,1,8,Helm of Certainty,303,70,17,0,3,1
-12620,3,7351,1,8,Helm of Certainty,303,70,17,0,4,1
-12621,3,7351,1,13,Scholarly Eye,303,70,17,0,0,1
-12622,3,7351,1,13,Scholarly Eye,303,70,17,0,1,1
-12623,3,7351,1,13,Scholarly Eye,303,70,17,0,2,1
-12624,3,7351,1,13,Scholarly Eye,303,70,17,0,3,1
-12625,3,7351,1,13,Scholarly Eye,303,70,17,0,4,1
+12601,3,6339,1,25,Forehead Protector of Wisemen,303,65,17,0,0,1
+12602,3,6339,1,25,Forehead Protector of Wisemen,303,65,17,0,1,1
+12603,3,6339,1,25,Forehead Protector of Wisemen,303,65,17,0,2,1
+12604,3,6339,1,25,Forehead Protector of Wisemen,303,65,17,0,3,1
+12605,3,6339,1,25,Forehead Protector of Wisemen,303,65,17,0,4,1
+12606,3,6339,1,30,Saint's Helm,303,65,17,0,0,1
+12607,3,6339,1,30,Saint's Helm,303,65,17,0,1,1
+12608,3,6339,1,30,Saint's Helm,303,65,17,0,2,1
+12609,3,6339,1,30,Saint's Helm,303,65,17,0,3,1
+12610,3,6339,1,30,Saint's Helm,303,65,17,0,4,1
+12611,3,6735,1,30,Roaming Hat,303,67,17,0,0,1
+12612,3,6735,1,30,Roaming Hat,303,67,17,0,1,1
+12613,3,6735,1,30,Roaming Hat,303,67,17,0,2,1
+12614,3,6735,1,30,Roaming Hat,303,67,17,0,3,1
+12615,3,6735,1,30,Roaming Hat,303,67,17,0,4,1
+12616,3,7351,1,40,Helm of Certainty,303,70,17,0,0,1
+12617,3,7351,1,40,Helm of Certainty,303,70,17,0,1,1
+12618,3,7351,1,40,Helm of Certainty,303,70,17,0,2,1
+12619,3,7351,1,40,Helm of Certainty,303,70,17,0,3,1
+12620,3,7351,1,40,Helm of Certainty,303,70,17,0,4,1
+12621,3,7351,1,45,Scholarly Eye,303,70,17,0,0,1
+12622,3,7351,1,45,Scholarly Eye,303,70,17,0,1,1
+12623,3,7351,1,45,Scholarly Eye,303,70,17,0,2,1
+12624,3,7351,1,45,Scholarly Eye,303,70,17,0,3,1
+12625,3,7351,1,45,Scholarly Eye,303,70,17,0,4,1
 12626,3,5767,1,15,Fortune Coif,303,62,14,0,0,1
 12627,3,5767,1,15,Fortune Coif,303,62,14,0,1,1
 12628,3,5767,1,15,Fortune Coif,303,62,14,0,2,1
 12629,3,5767,1,15,Fortune Coif,303,62,14,0,3,1
 12630,3,5767,1,15,Fortune Coif,303,62,14,0,4,1
-12631,3,6339,1,9,Masked Gentleman's Hat,303,65,14,0,0,1
-12632,3,6339,1,9,Masked Gentleman's Hat,303,65,14,0,1,1
-12633,3,6339,1,9,Masked Gentleman's Hat,303,65,14,0,2,1
-12634,3,6339,1,9,Masked Gentleman's Hat,303,65,14,0,3,1
-12635,3,6339,1,9,Masked Gentleman's Hat,303,65,14,0,4,1
-12636,3,6339,1,14,Paladin Hood,303,65,14,0,0,1
-12637,3,6339,1,14,Paladin Hood,303,65,14,0,1,1
-12638,3,6339,1,14,Paladin Hood,303,65,14,0,2,1
-12639,3,6339,1,14,Paladin Hood,303,65,14,0,3,1
-12640,3,6339,1,14,Paladin Hood,303,65,14,0,4,1
-12641,3,6735,1,14,Sentinel Beret,303,67,14,0,0,1
-12642,3,6735,1,14,Sentinel Beret,303,67,14,0,1,1
-12643,3,6735,1,14,Sentinel Beret,303,67,14,0,2,1
-12644,3,6735,1,14,Sentinel Beret,303,67,14,0,3,1
-12645,3,6735,1,14,Sentinel Beret,303,67,14,0,4,1
-12646,3,7351,1,8,Aquila Helm,303,70,14,0,0,1
-12647,3,7351,1,8,Aquila Helm,303,70,14,0,1,1
-12648,3,7351,1,8,Aquila Helm,303,70,14,0,2,1
-12649,3,7351,1,8,Aquila Helm,303,70,14,0,3,1
-12650,3,7351,1,8,Aquila Helm,303,70,14,0,4,1
-12651,3,7351,1,13,Hood of Concealment,303,70,14,0,0,1
-12652,3,7351,1,13,Hood of Concealment,303,70,14,0,1,1
-12653,3,7351,1,13,Hood of Concealment,303,70,14,0,2,1
-12654,3,7351,1,13,Hood of Concealment,303,70,14,0,3,1
-12655,3,7351,1,13,Hood of Concealment,303,70,14,0,4,1
+12631,3,6339,1,25,Masked Gentleman's Hat,303,65,14,0,0,1
+12632,3,6339,1,25,Masked Gentleman's Hat,303,65,14,0,1,1
+12633,3,6339,1,25,Masked Gentleman's Hat,303,65,14,0,2,1
+12634,3,6339,1,25,Masked Gentleman's Hat,303,65,14,0,3,1
+12635,3,6339,1,25,Masked Gentleman's Hat,303,65,14,0,4,1
+12636,3,6339,1,30,Paladin Hood,303,65,14,0,0,1
+12637,3,6339,1,30,Paladin Hood,303,65,14,0,1,1
+12638,3,6339,1,30,Paladin Hood,303,65,14,0,2,1
+12639,3,6339,1,30,Paladin Hood,303,65,14,0,3,1
+12640,3,6339,1,30,Paladin Hood,303,65,14,0,4,1
+12641,3,6735,1,30,Sentinel Beret,303,67,14,0,0,1
+12642,3,6735,1,30,Sentinel Beret,303,67,14,0,1,1
+12643,3,6735,1,30,Sentinel Beret,303,67,14,0,2,1
+12644,3,6735,1,30,Sentinel Beret,303,67,14,0,3,1
+12645,3,6735,1,30,Sentinel Beret,303,67,14,0,4,1
+12646,3,7351,1,40,Aquila Helm,303,70,14,0,0,1
+12647,3,7351,1,40,Aquila Helm,303,70,14,0,1,1
+12648,3,7351,1,40,Aquila Helm,303,70,14,0,2,1
+12649,3,7351,1,40,Aquila Helm,303,70,14,0,3,1
+12650,3,7351,1,40,Aquila Helm,303,70,14,0,4,1
+12651,3,7351,1,45,Hood of Concealment,303,70,14,0,0,1
+12652,3,7351,1,45,Hood of Concealment,303,70,14,0,1,1
+12653,3,7351,1,45,Hood of Concealment,303,70,14,0,2,1
+12654,3,7351,1,45,Hood of Concealment,303,70,14,0,3,1
+12655,3,7351,1,45,Hood of Concealment,303,70,14,0,4,1
 13033,3,999,1,12,Mysterious Thief's Mask,303,55,0,0,0,1
 13034,3,999,1,12,Mysterious Thief's Mask,303,55,0,0,1,1
 13035,3,999,1,12,Mysterious Thief's Mask,303,55,0,0,2,1
 13036,3,999,1,12,Mysterious Thief's Mask,303,55,0,0,3,1
 13037,3,999,1,12,Mysterious Thief's Mask,303,55,0,0,4,1
-13038,3,999,1,13,Flying Dragon Circlet,303,72,0,0,0,1
-13039,3,999,1,13,Flying Dragon Circlet,303,72,0,0,1,1
-13040,3,999,1,13,Flying Dragon Circlet,303,72,0,0,2,1
-13041,3,999,1,13,Flying Dragon Circlet,303,72,0,0,3,1
-13042,3,999,1,13,Flying Dragon Circlet,303,72,0,0,4,1
+13038,3,999,1,45,Flying Dragon Circlet,303,72,0,0,0,1
+13039,3,999,1,45,Flying Dragon Circlet,303,72,0,0,1,1
+13040,3,999,1,45,Flying Dragon Circlet,303,72,0,0,2,1
+13041,3,999,1,45,Flying Dragon Circlet,303,72,0,0,3,1
+13042,3,999,1,45,Flying Dragon Circlet,303,72,0,0,4,1
 13493,3,10000,1,10,Eyepatch of the One-eyed Dragon,303,1,0,0,0,1
 13494,3,10000,1,10,Eyepatch of the One-eyed Dragon,303,1,0,0,1,1
 13495,3,10000,1,10,Eyepatch of the One-eyed Dragon,303,1,0,0,2,1
@@ -12763,157 +12763,157 @@
 13831,3,30000,1,10,Victor's Crown (I),303,1,0,0,0,1
 13832,3,20000,1,10,Victor's Crown (II),303,1,0,0,0,1
 13833,3,10000,1,10,Victor's Crown (III),303,1,0,0,0,1
-14837,3,8439,1,2,Executioner's Mask,303,75,12,0,0,1
-14838,3,8439,1,2,Executioner's Mask,303,75,12,0,1,1
-14839,3,8439,1,2,Executioner's Mask,303,75,12,0,2,1
-14840,3,8439,1,2,Executioner's Mask,303,75,12,0,3,1
-14841,3,8439,1,2,Executioner's Mask,303,75,12,0,4,1
-14842,3,8439,1,7,Ancient Beast Armet,303,75,12,0,0,1
-14843,3,8439,1,7,Ancient Beast Armet,303,75,12,0,1,1
-14844,3,8439,1,7,Ancient Beast Armet,303,75,12,0,2,1
-14845,3,8439,1,7,Ancient Beast Armet,303,75,12,0,3,1
-14846,3,8439,1,7,Ancient Beast Armet,303,75,12,0,4,1
-14847,3,8439,1,12,Vicious Skull,303,75,12,0,0,1
-14848,3,8439,1,12,Vicious Skull,303,75,12,0,1,1
-14849,3,8439,1,12,Vicious Skull,303,75,12,0,2,1
-14850,3,8439,1,12,Vicious Skull,303,75,12,0,3,1
-14851,3,8439,1,12,Vicious Skull,303,75,12,0,4,1
-14852,3,8895,1,12,Royal Guardsman's Sallet,303,77,12,0,0,1
-14853,3,8895,1,12,Royal Guardsman's Sallet,303,77,12,0,1,1
-14854,3,8895,1,12,Royal Guardsman's Sallet,303,77,12,0,2,1
-14855,3,8895,1,12,Royal Guardsman's Sallet,303,77,12,0,3,1
-14856,3,8895,1,12,Royal Guardsman's Sallet,303,77,12,0,4,1
-14857,3,9601,1,1,Northern Horn,303,80,12,0,0,1
-14858,3,9601,1,1,Northern Horn,303,80,12,0,1,1
-14859,3,9601,1,1,Northern Horn,303,80,12,0,2,1
-14860,3,9601,1,1,Northern Horn,303,80,12,0,3,1
-14861,3,9601,1,1,Northern Horn,303,80,12,0,4,1
-14862,3,9601,1,6,Knight Helm of Dawn,303,80,12,0,0,1
-14863,3,9601,1,6,Knight Helm of Dawn,303,80,12,0,1,1
-14864,3,9601,1,6,Knight Helm of Dawn,303,80,12,0,2,1
-14865,3,9601,1,6,Knight Helm of Dawn,303,80,12,0,3,1
-14866,3,9601,1,6,Knight Helm of Dawn,303,80,12,0,4,1
-14867,3,9601,1,11,Azure Helm,303,80,12,0,0,1
-14868,3,9601,1,11,Azure Helm,303,80,12,0,1,1
-14869,3,9601,1,11,Azure Helm,303,80,12,0,2,1
-14870,3,9601,1,11,Azure Helm,303,80,12,0,3,1
-14871,3,9601,1,11,Azure Helm,303,80,12,0,4,1
-14872,3,9601,1,11,Finnegan's Mask,303,80,0,3,0,1
-14873,3,9601,1,11,Finnegan's Mask,303,80,0,3,1,1
-14874,3,9601,1,11,Finnegan's Mask,303,80,0,3,2,1
-14875,3,9601,1,11,Finnegan's Mask,303,80,0,3,3,1
-14876,3,9601,1,11,Finnegan's Mask,303,80,0,3,4,1
-14877,3,9601,1,11,Greedy Mask,303,80,0,3,0,1
-14878,3,9601,1,11,Greedy Mask,303,80,0,3,1,1
-14879,3,9601,1,11,Greedy Mask,303,80,0,3,2,1
-14880,3,9601,1,11,Greedy Mask,303,80,0,3,3,1
-14881,3,9601,1,11,Greedy Mask,303,80,0,3,4,1
+14837,3,8439,1,50,Executioner's Mask,303,75,12,0,0,1
+14838,3,8439,1,50,Executioner's Mask,303,75,12,0,1,1
+14839,3,8439,1,50,Executioner's Mask,303,75,12,0,2,1
+14840,3,8439,1,50,Executioner's Mask,303,75,12,0,3,1
+14841,3,8439,1,50,Executioner's Mask,303,75,12,0,4,1
+14842,3,8439,1,55,Ancient Beast Armet,303,75,12,0,0,1
+14843,3,8439,1,55,Ancient Beast Armet,303,75,12,0,1,1
+14844,3,8439,1,55,Ancient Beast Armet,303,75,12,0,2,1
+14845,3,8439,1,55,Ancient Beast Armet,303,75,12,0,3,1
+14846,3,8439,1,55,Ancient Beast Armet,303,75,12,0,4,1
+14847,3,8439,1,60,Vicious Skull,303,75,12,0,0,1
+14848,3,8439,1,60,Vicious Skull,303,75,12,0,1,1
+14849,3,8439,1,60,Vicious Skull,303,75,12,0,2,1
+14850,3,8439,1,60,Vicious Skull,303,75,12,0,3,1
+14851,3,8439,1,60,Vicious Skull,303,75,12,0,4,1
+14852,3,8895,1,60,Royal Guardsman's Sallet,303,77,12,0,0,1
+14853,3,8895,1,60,Royal Guardsman's Sallet,303,77,12,0,1,1
+14854,3,8895,1,60,Royal Guardsman's Sallet,303,77,12,0,2,1
+14855,3,8895,1,60,Royal Guardsman's Sallet,303,77,12,0,3,1
+14856,3,8895,1,60,Royal Guardsman's Sallet,303,77,12,0,4,1
+14857,3,9601,1,65,Northern Horn,303,80,12,0,0,1
+14858,3,9601,1,65,Northern Horn,303,80,12,0,1,1
+14859,3,9601,1,65,Northern Horn,303,80,12,0,2,1
+14860,3,9601,1,65,Northern Horn,303,80,12,0,3,1
+14861,3,9601,1,65,Northern Horn,303,80,12,0,4,1
+14862,3,9601,1,70,Knight Helm of Dawn,303,80,12,0,0,1
+14863,3,9601,1,70,Knight Helm of Dawn,303,80,12,0,1,1
+14864,3,9601,1,70,Knight Helm of Dawn,303,80,12,0,2,1
+14865,3,9601,1,70,Knight Helm of Dawn,303,80,12,0,3,1
+14866,3,9601,1,70,Knight Helm of Dawn,303,80,12,0,4,1
+14867,3,9601,1,75,Azure Helm,303,80,12,0,0,1
+14868,3,9601,1,75,Azure Helm,303,80,12,0,1,1
+14869,3,9601,1,75,Azure Helm,303,80,12,0,2,1
+14870,3,9601,1,75,Azure Helm,303,80,12,0,3,1
+14871,3,9601,1,75,Azure Helm,303,80,12,0,4,1
+14872,3,9601,1,75,Finnegan's Mask,303,80,0,3,0,1
+14873,3,9601,1,75,Finnegan's Mask,303,80,0,3,1,1
+14874,3,9601,1,75,Finnegan's Mask,303,80,0,3,2,1
+14875,3,9601,1,75,Finnegan's Mask,303,80,0,3,3,1
+14876,3,9601,1,75,Finnegan's Mask,303,80,0,3,4,1
+14877,3,9601,1,75,Greedy Mask,303,80,0,3,0,1
+14878,3,9601,1,75,Greedy Mask,303,80,0,3,1,1
+14879,3,9601,1,75,Greedy Mask,303,80,0,3,2,1
+14880,3,9601,1,75,Greedy Mask,303,80,0,3,3,1
+14881,3,9601,1,75,Greedy Mask,303,80,0,3,4,1
 14882,3,10000,1,10,Mask of Beowulf,303,1,0,0,0,1
-14883,3,8439,1,2,Innocent Mitre,303,75,15,0,0,1
-14884,3,8439,1,2,Innocent Mitre,303,75,15,0,1,1
-14885,3,8439,1,2,Innocent Mitre,303,75,15,0,2,1
-14886,3,8439,1,2,Innocent Mitre,303,75,15,0,3,1
-14887,3,8439,1,2,Innocent Mitre,303,75,15,0,4,1
-14888,3,8439,1,7,Crimson Hat,303,75,15,0,0,1
-14889,3,8439,1,7,Crimson Hat,303,75,15,0,1,1
-14890,3,8439,1,7,Crimson Hat,303,75,15,0,2,1
-14891,3,8439,1,7,Crimson Hat,303,75,15,0,3,1
-14892,3,8439,1,7,Crimson Hat,303,75,15,0,4,1
-14893,3,8439,1,12,Mistletoe Circlet,303,75,15,0,0,1
-14894,3,8439,1,12,Mistletoe Circlet,303,75,15,0,1,1
-14895,3,8439,1,12,Mistletoe Circlet,303,75,15,0,2,1
-14896,3,8439,1,12,Mistletoe Circlet,303,75,15,0,3,1
-14897,3,8439,1,12,Mistletoe Circlet,303,75,15,0,4,1
-14898,3,8895,1,12,Medium Head,303,77,15,0,0,1
-14899,3,8895,1,12,Medium Head,303,77,15,0,1,1
-14900,3,8895,1,12,Medium Head,303,77,15,0,2,1
-14901,3,8895,1,12,Medium Head,303,77,15,0,3,1
-14902,3,8895,1,12,Medium Head,303,77,15,0,4,1
-14903,3,9601,1,1,Garrisoner's Helm,303,80,15,0,0,1
-14904,3,9601,1,1,Garrisoner's Helm,303,80,15,0,1,1
-14905,3,9601,1,1,Garrisoner's Helm,303,80,15,0,2,1
-14906,3,9601,1,1,Garrisoner's Helm,303,80,15,0,3,1
-14907,3,9601,1,1,Garrisoner's Helm,303,80,15,0,4,1
-14908,3,9601,1,6,Ginkgo-dyed Mage Hat,303,80,15,0,0,1
-14909,3,9601,1,6,Ginkgo-dyed Mage Hat,303,80,15,0,1,1
-14910,3,9601,1,6,Ginkgo-dyed Mage Hat,303,80,15,0,2,1
-14911,3,9601,1,6,Ginkgo-dyed Mage Hat,303,80,15,0,3,1
-14912,3,9601,1,6,Ginkgo-dyed Mage Hat,303,80,15,0,4,1
-14913,3,9601,1,11,Azure Crown,303,80,15,0,0,1
-14914,3,9601,1,11,Azure Crown,303,80,15,0,1,1
-14915,3,9601,1,11,Azure Crown,303,80,15,0,2,1
-14916,3,9601,1,11,Azure Crown,303,80,15,0,3,1
-14917,3,9601,1,11,Azure Crown,303,80,15,0,4,1
-14918,3,8439,1,2,Continent Helm,303,75,17,0,0,1
-14919,3,8439,1,2,Continent Helm,303,75,17,0,1,1
-14920,3,8439,1,2,Continent Helm,303,75,17,0,2,1
-14921,3,8439,1,2,Continent Helm,303,75,17,0,3,1
-14922,3,8439,1,2,Continent Helm,303,75,17,0,4,1
-14923,3,8439,1,7,Helm of Keen Insight,303,75,17,0,0,1
-14924,3,8439,1,7,Helm of Keen Insight,303,75,17,0,1,1
-14925,3,8439,1,7,Helm of Keen Insight,303,75,17,0,2,1
-14926,3,8439,1,7,Helm of Keen Insight,303,75,17,0,3,1
-14927,3,8439,1,7,Helm of Keen Insight,303,75,17,0,4,1
-14928,3,8439,1,12,Fortress Eye,303,75,17,0,0,1
-14929,3,8439,1,12,Fortress Eye,303,75,17,0,1,1
-14930,3,8439,1,12,Fortress Eye,303,75,17,0,2,1
-14931,3,8439,1,12,Fortress Eye,303,75,17,0,3,1
-14932,3,8439,1,12,Fortress Eye,303,75,17,0,4,1
-14933,3,8895,1,12,Circlet of Benevolence,303,77,17,0,0,1
-14934,3,8895,1,12,Circlet of Benevolence,303,77,17,0,1,1
-14935,3,8895,1,12,Circlet of Benevolence,303,77,17,0,2,1
-14936,3,8895,1,12,Circlet of Benevolence,303,77,17,0,3,1
-14937,3,8895,1,12,Circlet of Benevolence,303,77,17,0,4,1
-14938,3,9601,1,1,Monochrome Mask,303,80,17,0,0,1
-14939,3,9601,1,1,Monochrome Mask,303,80,17,0,1,1
-14940,3,9601,1,1,Monochrome Mask,303,80,17,0,2,1
-14941,3,9601,1,1,Monochrome Mask,303,80,17,0,3,1
-14942,3,9601,1,1,Monochrome Mask,303,80,17,0,4,1
-14943,3,9601,1,6,Dark Red Helm,303,80,17,0,0,1
-14944,3,9601,1,6,Dark Red Helm,303,80,17,0,1,1
-14945,3,9601,1,6,Dark Red Helm,303,80,17,0,2,1
-14946,3,9601,1,6,Dark Red Helm,303,80,17,0,3,1
-14947,3,9601,1,6,Dark Red Helm,303,80,17,0,4,1
-14948,3,9601,1,11,Azure Head,303,80,17,0,0,1
-14949,3,9601,1,11,Azure Head,303,80,17,0,1,1
-14950,3,9601,1,11,Azure Head,303,80,17,0,2,1
-14951,3,9601,1,11,Azure Head,303,80,17,0,3,1
-14952,3,9601,1,11,Azure Head,303,80,17,0,4,1
-14953,3,8439,1,2,Yellow Feathered Cap,303,75,14,0,0,1
-14954,3,8439,1,2,Yellow Feathered Cap,303,75,14,0,1,1
-14955,3,8439,1,2,Yellow Feathered Cap,303,75,14,0,2,1
-14956,3,8439,1,2,Yellow Feathered Cap,303,75,14,0,3,1
-14957,3,8439,1,2,Yellow Feathered Cap,303,75,14,0,4,1
-14958,3,8439,1,7,Ocean's Cap,303,75,14,0,0,1
-14959,3,8439,1,7,Ocean's Cap,303,75,14,0,1,1
-14960,3,8439,1,7,Ocean's Cap,303,75,14,0,2,1
-14961,3,8439,1,7,Ocean's Cap,303,75,14,0,3,1
-14962,3,8439,1,7,Ocean's Cap,303,75,14,0,4,1
-14963,3,8439,1,12,Forest Horn,303,75,14,0,0,1
-14964,3,8439,1,12,Forest Horn,303,75,14,0,1,1
-14965,3,8439,1,12,Forest Horn,303,75,14,0,2,1
-14966,3,8439,1,12,Forest Horn,303,75,14,0,3,1
-14967,3,8439,1,12,Forest Horn,303,75,14,0,4,1
-14968,3,8895,1,12,Black Panther Mask,303,77,14,0,0,1
-14969,3,8895,1,12,Black Panther Mask,303,77,14,0,1,1
-14970,3,8895,1,12,Black Panther Mask,303,77,14,0,2,1
-14971,3,8895,1,12,Black Panther Mask,303,77,14,0,3,1
-14972,3,8895,1,12,Black Panther Mask,303,77,14,0,4,1
-14973,3,9601,1,1,Patrician Beret,303,80,14,0,0,1
-14974,3,9601,1,1,Patrician Beret,303,80,14,0,1,1
-14975,3,9601,1,1,Patrician Beret,303,80,14,0,2,1
-14976,3,9601,1,1,Patrician Beret,303,80,14,0,3,1
-14977,3,9601,1,1,Patrician Beret,303,80,14,0,4,1
-14978,3,9601,1,6,Hood of Evening Mist,303,80,14,0,0,1
-14979,3,9601,1,6,Hood of Evening Mist,303,80,14,0,1,1
-14980,3,9601,1,6,Hood of Evening Mist,303,80,14,0,2,1
-14981,3,9601,1,6,Hood of Evening Mist,303,80,14,0,3,1
-14982,3,9601,1,6,Hood of Evening Mist,303,80,14,0,4,1
-14983,3,9601,1,11,Azure Mask,303,80,14,0,0,1
-14984,3,9601,1,11,Azure Mask,303,80,14,0,1,1
-14985,3,9601,1,11,Azure Mask,303,80,14,0,2,1
-14986,3,9601,1,11,Azure Mask,303,80,14,0,3,1
-14987,3,9601,1,11,Azure Mask,303,80,14,0,4,1
+14883,3,8439,1,50,Innocent Mitre,303,75,15,0,0,1
+14884,3,8439,1,50,Innocent Mitre,303,75,15,0,1,1
+14885,3,8439,1,50,Innocent Mitre,303,75,15,0,2,1
+14886,3,8439,1,50,Innocent Mitre,303,75,15,0,3,1
+14887,3,8439,1,50,Innocent Mitre,303,75,15,0,4,1
+14888,3,8439,1,55,Crimson Hat,303,75,15,0,0,1
+14889,3,8439,1,55,Crimson Hat,303,75,15,0,1,1
+14890,3,8439,1,55,Crimson Hat,303,75,15,0,2,1
+14891,3,8439,1,55,Crimson Hat,303,75,15,0,3,1
+14892,3,8439,1,55,Crimson Hat,303,75,15,0,4,1
+14893,3,8439,1,60,Mistletoe Circlet,303,75,15,0,0,1
+14894,3,8439,1,60,Mistletoe Circlet,303,75,15,0,1,1
+14895,3,8439,1,60,Mistletoe Circlet,303,75,15,0,2,1
+14896,3,8439,1,60,Mistletoe Circlet,303,75,15,0,3,1
+14897,3,8439,1,60,Mistletoe Circlet,303,75,15,0,4,1
+14898,3,8895,1,60,Medium Head,303,77,15,0,0,1
+14899,3,8895,1,60,Medium Head,303,77,15,0,1,1
+14900,3,8895,1,60,Medium Head,303,77,15,0,2,1
+14901,3,8895,1,60,Medium Head,303,77,15,0,3,1
+14902,3,8895,1,60,Medium Head,303,77,15,0,4,1
+14903,3,9601,1,65,Garrisoner's Helm,303,80,15,0,0,1
+14904,3,9601,1,65,Garrisoner's Helm,303,80,15,0,1,1
+14905,3,9601,1,65,Garrisoner's Helm,303,80,15,0,2,1
+14906,3,9601,1,65,Garrisoner's Helm,303,80,15,0,3,1
+14907,3,9601,1,65,Garrisoner's Helm,303,80,15,0,4,1
+14908,3,9601,1,70,Ginkgo-dyed Mage Hat,303,80,15,0,0,1
+14909,3,9601,1,70,Ginkgo-dyed Mage Hat,303,80,15,0,1,1
+14910,3,9601,1,70,Ginkgo-dyed Mage Hat,303,80,15,0,2,1
+14911,3,9601,1,70,Ginkgo-dyed Mage Hat,303,80,15,0,3,1
+14912,3,9601,1,70,Ginkgo-dyed Mage Hat,303,80,15,0,4,1
+14913,3,9601,1,75,Azure Crown,303,80,15,0,0,1
+14914,3,9601,1,75,Azure Crown,303,80,15,0,1,1
+14915,3,9601,1,75,Azure Crown,303,80,15,0,2,1
+14916,3,9601,1,75,Azure Crown,303,80,15,0,3,1
+14917,3,9601,1,75,Azure Crown,303,80,15,0,4,1
+14918,3,8439,1,50,Continent Helm,303,75,17,0,0,1
+14919,3,8439,1,50,Continent Helm,303,75,17,0,1,1
+14920,3,8439,1,50,Continent Helm,303,75,17,0,2,1
+14921,3,8439,1,50,Continent Helm,303,75,17,0,3,1
+14922,3,8439,1,50,Continent Helm,303,75,17,0,4,1
+14923,3,8439,1,55,Helm of Keen Insight,303,75,17,0,0,1
+14924,3,8439,1,55,Helm of Keen Insight,303,75,17,0,1,1
+14925,3,8439,1,55,Helm of Keen Insight,303,75,17,0,2,1
+14926,3,8439,1,55,Helm of Keen Insight,303,75,17,0,3,1
+14927,3,8439,1,55,Helm of Keen Insight,303,75,17,0,4,1
+14928,3,8439,1,60,Fortress Eye,303,75,17,0,0,1
+14929,3,8439,1,60,Fortress Eye,303,75,17,0,1,1
+14930,3,8439,1,60,Fortress Eye,303,75,17,0,2,1
+14931,3,8439,1,60,Fortress Eye,303,75,17,0,3,1
+14932,3,8439,1,60,Fortress Eye,303,75,17,0,4,1
+14933,3,8895,1,60,Circlet of Benevolence,303,77,17,0,0,1
+14934,3,8895,1,60,Circlet of Benevolence,303,77,17,0,1,1
+14935,3,8895,1,60,Circlet of Benevolence,303,77,17,0,2,1
+14936,3,8895,1,60,Circlet of Benevolence,303,77,17,0,3,1
+14937,3,8895,1,60,Circlet of Benevolence,303,77,17,0,4,1
+14938,3,9601,1,65,Monochrome Mask,303,80,17,0,0,1
+14939,3,9601,1,65,Monochrome Mask,303,80,17,0,1,1
+14940,3,9601,1,65,Monochrome Mask,303,80,17,0,2,1
+14941,3,9601,1,65,Monochrome Mask,303,80,17,0,3,1
+14942,3,9601,1,65,Monochrome Mask,303,80,17,0,4,1
+14943,3,9601,1,70,Dark Red Helm,303,80,17,0,0,1
+14944,3,9601,1,70,Dark Red Helm,303,80,17,0,1,1
+14945,3,9601,1,70,Dark Red Helm,303,80,17,0,2,1
+14946,3,9601,1,70,Dark Red Helm,303,80,17,0,3,1
+14947,3,9601,1,70,Dark Red Helm,303,80,17,0,4,1
+14948,3,9601,1,75,Azure Head,303,80,17,0,0,1
+14949,3,9601,1,75,Azure Head,303,80,17,0,1,1
+14950,3,9601,1,75,Azure Head,303,80,17,0,2,1
+14951,3,9601,1,75,Azure Head,303,80,17,0,3,1
+14952,3,9601,1,75,Azure Head,303,80,17,0,4,1
+14953,3,8439,1,50,Yellow Feathered Cap,303,75,14,0,0,1
+14954,3,8439,1,50,Yellow Feathered Cap,303,75,14,0,1,1
+14955,3,8439,1,50,Yellow Feathered Cap,303,75,14,0,2,1
+14956,3,8439,1,50,Yellow Feathered Cap,303,75,14,0,3,1
+14957,3,8439,1,50,Yellow Feathered Cap,303,75,14,0,4,1
+14958,3,8439,1,55,Ocean's Cap,303,75,14,0,0,1
+14959,3,8439,1,55,Ocean's Cap,303,75,14,0,1,1
+14960,3,8439,1,55,Ocean's Cap,303,75,14,0,2,1
+14961,3,8439,1,55,Ocean's Cap,303,75,14,0,3,1
+14962,3,8439,1,55,Ocean's Cap,303,75,14,0,4,1
+14963,3,8439,1,60,Forest Horn,303,75,14,0,0,1
+14964,3,8439,1,60,Forest Horn,303,75,14,0,1,1
+14965,3,8439,1,60,Forest Horn,303,75,14,0,2,1
+14966,3,8439,1,60,Forest Horn,303,75,14,0,3,1
+14967,3,8439,1,60,Forest Horn,303,75,14,0,4,1
+14968,3,8895,1,60,Black Panther Mask,303,77,14,0,0,1
+14969,3,8895,1,60,Black Panther Mask,303,77,14,0,1,1
+14970,3,8895,1,60,Black Panther Mask,303,77,14,0,2,1
+14971,3,8895,1,60,Black Panther Mask,303,77,14,0,3,1
+14972,3,8895,1,60,Black Panther Mask,303,77,14,0,4,1
+14973,3,9601,1,65,Patrician Beret,303,80,14,0,0,1
+14974,3,9601,1,65,Patrician Beret,303,80,14,0,1,1
+14975,3,9601,1,65,Patrician Beret,303,80,14,0,2,1
+14976,3,9601,1,65,Patrician Beret,303,80,14,0,3,1
+14977,3,9601,1,65,Patrician Beret,303,80,14,0,4,1
+14978,3,9601,1,70,Hood of Evening Mist,303,80,14,0,0,1
+14979,3,9601,1,70,Hood of Evening Mist,303,80,14,0,1,1
+14980,3,9601,1,70,Hood of Evening Mist,303,80,14,0,2,1
+14981,3,9601,1,70,Hood of Evening Mist,303,80,14,0,3,1
+14982,3,9601,1,70,Hood of Evening Mist,303,80,14,0,4,1
+14983,3,9601,1,75,Azure Mask,303,80,14,0,0,1
+14984,3,9601,1,75,Azure Mask,303,80,14,0,1,1
+14985,3,9601,1,75,Azure Mask,303,80,14,0,2,1
+14986,3,9601,1,75,Azure Mask,303,80,14,0,3,1
+14987,3,9601,1,75,Azure Mask,303,80,14,0,4,1
 16135,3,2000,1,1,Bunny Ears (Brown),303,1,0,0,0,1
 16136,3,2000,1,1,Bunny Ears (White),303,1,0,0,0,1
 16137,3,2000,1,1,Bunny Ears (Black),303,1,0,0,0,1
@@ -12934,254 +12934,254 @@
 16789,3,100,1,1,Reindeer's Coif,303,1,0,0,4,1
 16795,3,100,1,1,Christmas Cap (White),303,1,0,0,4,1
 16796,3,100,1,1,Reindeer's Coif (White),303,1,0,0,4,1
-17571,3,9910,1,0,Brigand Mask,303,80,12,0,0,1
-17572,3,9910,1,0,Brigand Mask,303,80,12,0,1,1
-17573,3,9910,1,0,Brigand Mask,303,80,12,0,2,1
-17574,3,9910,1,0,Brigand Mask,303,80,12,0,3,1
-17575,3,9910,1,0,Brigand Mask,303,80,12,0,4,1
-17576,3,10624,1,5,Gelmez Armet,303,83,12,0,0,1
-17577,3,10624,1,5,Gelmez Armet,303,83,12,0,1,1
-17578,3,10624,1,5,Gelmez Armet,303,83,12,0,2,1
-17579,3,10624,1,5,Gelmez Armet,303,83,12,0,3,1
-17580,3,10624,1,5,Gelmez Armet,303,83,12,0,4,1
-17581,3,11100,1,10,Acrean Helm,303,85,12,0,0,1
-17582,3,11100,1,10,Acrean Helm,303,85,12,0,1,1
-17583,3,11100,1,10,Acrean Helm,303,85,12,0,2,1
-17584,3,11100,1,10,Acrean Helm,303,85,12,0,3,1
-17585,3,11100,1,10,Acrean Helm,303,85,12,0,4,1
-17586,3,9910,1,0,Modestly Coif,303,80,15,0,0,1
-17587,3,9910,1,0,Modestly Coif,303,80,15,0,1,1
-17588,3,9910,1,0,Modestly Coif,303,80,15,0,2,1
-17589,3,9910,1,0,Modestly Coif,303,80,15,0,3,1
-17590,3,9910,1,0,Modestly Coif,303,80,15,0,4,1
-17591,3,10624,1,5,Duarev Hood,303,83,15,0,0,1
-17592,3,10624,1,5,Duarev Hood,303,83,15,0,1,1
-17593,3,10624,1,5,Duarev Hood,303,83,15,0,2,1
-17594,3,10624,1,5,Duarev Hood,303,83,15,0,3,1
-17595,3,10624,1,5,Duarev Hood,303,83,15,0,4,1
-17596,3,11100,1,10,Acrean Circlet,303,85,15,0,0,1
-17597,3,11100,1,10,Acrean Circlet,303,85,15,0,1,1
-17598,3,11100,1,10,Acrean Circlet,303,85,15,0,2,1
-17599,3,11100,1,10,Acrean Circlet,303,85,15,0,3,1
-17600,3,11100,1,10,Acrean Circlet,303,85,15,0,4,1
-17601,3,9910,1,0,Brass Helm,303,80,17,0,0,1
-17602,3,9910,1,0,Brass Helm,303,80,17,0,1,1
-17603,3,9910,1,0,Brass Helm,303,80,17,0,2,1
-17604,3,9910,1,0,Brass Helm,303,80,17,0,3,1
-17605,3,9910,1,0,Brass Helm,303,80,17,0,4,1
-17606,3,10624,1,5,Sizjak Hat,303,83,17,0,0,1
-17607,3,10624,1,5,Sizjak Hat,303,83,17,0,1,1
-17608,3,10624,1,5,Sizjak Hat,303,83,17,0,2,1
-17609,3,10624,1,5,Sizjak Hat,303,83,17,0,3,1
-17610,3,10624,1,5,Sizjak Hat,303,83,17,0,4,1
-17611,3,11100,1,10,Acrean Turban,303,85,17,0,0,1
-17612,3,11100,1,10,Acrean Turban,303,85,17,0,1,1
-17613,3,11100,1,10,Acrean Turban,303,85,17,0,2,1
-17614,3,11100,1,10,Acrean Turban,303,85,17,0,3,1
-17615,3,11100,1,10,Acrean Turban,303,85,17,0,4,1
-17616,3,9910,1,0,Coif of Warm Winds,303,80,14,0,0,1
-17617,3,9910,1,0,Coif of Warm Winds,303,80,14,0,1,1
-17618,3,9910,1,0,Coif of Warm Winds,303,80,14,0,2,1
-17619,3,9910,1,0,Coif of Warm Winds,303,80,14,0,3,1
-17620,3,9910,1,0,Coif of Warm Winds,303,80,14,0,4,1
-17621,3,10624,1,5,Shahabad Helm,303,83,14,0,0,1
-17622,3,10624,1,5,Shahabad Helm,303,83,14,0,1,1
-17623,3,10624,1,5,Shahabad Helm,303,83,14,0,2,1
-17624,3,10624,1,5,Shahabad Helm,303,83,14,0,3,1
-17625,3,10624,1,5,Shahabad Helm,303,83,14,0,4,1
-17626,3,11100,1,10,Acrean Hat,303,85,14,0,0,1
-17627,3,11100,1,10,Acrean Hat,303,85,14,0,1,1
-17628,3,11100,1,10,Acrean Hat,303,85,14,0,2,1
-17629,3,11100,1,10,Acrean Hat,303,85,14,0,3,1
-17630,3,11100,1,10,Acrean Hat,303,85,14,0,4,1
-18199,3,11100,1,10,Courage Helm,303,85,12,0,0,1
-18200,3,11100,1,10,Courage Helm,303,85,12,0,1,1
-18201,3,11100,1,10,Courage Helm,303,85,12,0,2,1
-18202,3,11100,1,10,Courage Helm,303,85,12,0,3,1
-18203,3,11100,1,10,Courage Helm,303,85,12,0,4,1
-18204,3,11716,1,15,Emine Helm,303,88,12,0,0,1
-18205,3,11716,1,15,Emine Helm,303,88,12,0,1,1
-18206,3,11716,1,15,Emine Helm,303,88,12,0,2,1
-18207,3,11716,1,15,Emine Helm,303,88,12,0,3,1
-18208,3,11716,1,15,Emine Helm,303,88,12,0,4,1
-18209,3,12387,1,4,Dools Armet,303,90,12,0,0,1
-18210,3,12387,1,4,Dools Armet,303,90,12,0,1,1
-18211,3,12387,1,4,Dools Armet,303,90,12,0,2,1
-18212,3,12387,1,4,Dools Armet,303,90,12,0,3,1
-18213,3,12387,1,4,Dools Armet,303,90,12,0,4,1
-18214,3,11100,1,10,Magnus Mitre,303,85,15,0,0,1
-18215,3,11100,1,10,Magnus Mitre,303,85,15,0,1,1
-18216,3,11100,1,10,Magnus Mitre,303,85,15,0,2,1
-18217,3,11100,1,10,Magnus Mitre,303,85,15,0,3,1
-18218,3,11100,1,10,Magnus Mitre,303,85,15,0,4,1
-18219,3,11716,1,15,Forehead Protector of Hope,303,88,15,0,0,1
-18220,3,11716,1,15,Forehead Protector of Hope,303,88,15,0,1,1
-18221,3,11716,1,15,Forehead Protector of Hope,303,88,15,0,2,1
-18222,3,11716,1,15,Forehead Protector of Hope,303,88,15,0,3,1
-18223,3,11716,1,15,Forehead Protector of Hope,303,88,15,0,4,1
-18224,3,12387,1,4,Dools Mask,303,90,15,0,0,1
-18225,3,12387,1,4,Dools Mask,303,90,15,0,1,1
-18226,3,12387,1,4,Dools Mask,303,90,15,0,2,1
-18227,3,12387,1,4,Dools Mask,303,90,15,0,3,1
-18228,3,12387,1,4,Dools Mask,303,90,15,0,4,1
-18229,3,11100,1,10,Kelsus Barbute,303,85,17,0,0,1
-18230,3,11100,1,10,Kelsus Barbute,303,85,17,0,1,1
-18231,3,11100,1,10,Kelsus Barbute,303,85,17,0,2,1
-18232,3,11100,1,10,Kelsus Barbute,303,85,17,0,3,1
-18233,3,11100,1,10,Kelsus Barbute,303,85,17,0,4,1
-18234,3,11716,1,15,Kier Cervelliere,303,88,17,0,0,1
-18235,3,11716,1,15,Kier Cervelliere,303,88,17,0,1,1
-18236,3,11716,1,15,Kier Cervelliere,303,88,17,0,2,1
-18237,3,11716,1,15,Kier Cervelliere,303,88,17,0,3,1
-18238,3,11716,1,15,Kier Cervelliere,303,88,17,0,4,1
-18239,3,12387,1,4,Dools Barbute,303,90,17,0,0,1
-18240,3,12387,1,4,Dools Barbute,303,90,17,0,1,1
-18241,3,12387,1,4,Dools Barbute,303,90,17,0,2,1
-18242,3,12387,1,4,Dools Barbute,303,90,17,0,3,1
-18243,3,12387,1,4,Dools Barbute,303,90,17,0,4,1
-18244,3,11100,1,10,Aura Balaclava,303,85,14,0,0,1
-18245,3,11100,1,10,Aura Balaclava,303,85,14,0,1,1
-18246,3,11100,1,10,Aura Balaclava,303,85,14,0,2,1
-18247,3,11100,1,10,Aura Balaclava,303,85,14,0,3,1
-18248,3,11100,1,10,Aura Balaclava,303,85,14,0,4,1
-18249,3,11716,1,15,Niloufar Hood,303,88,14,0,0,1
-18250,3,11716,1,15,Niloufar Hood,303,88,14,0,1,1
-18251,3,11716,1,15,Niloufar Hood,303,88,14,0,2,1
-18252,3,11716,1,15,Niloufar Hood,303,88,14,0,3,1
-18253,3,11716,1,15,Niloufar Hood,303,88,14,0,4,1
-18254,3,12387,1,4,Dools Sallet,303,90,14,0,0,1
-18255,3,12387,1,4,Dools Sallet,303,90,14,0,1,1
-18256,3,12387,1,4,Dools Sallet,303,90,14,0,2,1
-18257,3,12387,1,4,Dools Sallet,303,90,14,0,3,1
-18258,3,12387,1,4,Dools Sallet,303,90,14,0,4,1
+17571,3,9910,1,80,Brigand Mask,303,80,12,0,0,1
+17572,3,9910,1,80,Brigand Mask,303,80,12,0,1,1
+17573,3,9910,1,80,Brigand Mask,303,80,12,0,2,1
+17574,3,9910,1,80,Brigand Mask,303,80,12,0,3,1
+17575,3,9910,1,80,Brigand Mask,303,80,12,0,4,1
+17576,3,10624,1,85,Gelmez Armet,303,83,12,0,0,1
+17577,3,10624,1,85,Gelmez Armet,303,83,12,0,1,1
+17578,3,10624,1,85,Gelmez Armet,303,83,12,0,2,1
+17579,3,10624,1,85,Gelmez Armet,303,83,12,0,3,1
+17580,3,10624,1,85,Gelmez Armet,303,83,12,0,4,1
+17581,3,11100,1,90,Acrean Helm,303,85,12,0,0,1
+17582,3,11100,1,90,Acrean Helm,303,85,12,0,1,1
+17583,3,11100,1,90,Acrean Helm,303,85,12,0,2,1
+17584,3,11100,1,90,Acrean Helm,303,85,12,0,3,1
+17585,3,11100,1,90,Acrean Helm,303,85,12,0,4,1
+17586,3,9910,1,80,Modestly Coif,303,80,15,0,0,1
+17587,3,9910,1,80,Modestly Coif,303,80,15,0,1,1
+17588,3,9910,1,80,Modestly Coif,303,80,15,0,2,1
+17589,3,9910,1,80,Modestly Coif,303,80,15,0,3,1
+17590,3,9910,1,80,Modestly Coif,303,80,15,0,4,1
+17591,3,10624,1,85,Duarev Hood,303,83,15,0,0,1
+17592,3,10624,1,85,Duarev Hood,303,83,15,0,1,1
+17593,3,10624,1,85,Duarev Hood,303,83,15,0,2,1
+17594,3,10624,1,85,Duarev Hood,303,83,15,0,3,1
+17595,3,10624,1,85,Duarev Hood,303,83,15,0,4,1
+17596,3,11100,1,90,Acrean Circlet,303,85,15,0,0,1
+17597,3,11100,1,90,Acrean Circlet,303,85,15,0,1,1
+17598,3,11100,1,90,Acrean Circlet,303,85,15,0,2,1
+17599,3,11100,1,90,Acrean Circlet,303,85,15,0,3,1
+17600,3,11100,1,90,Acrean Circlet,303,85,15,0,4,1
+17601,3,9910,1,80,Brass Helm,303,80,17,0,0,1
+17602,3,9910,1,80,Brass Helm,303,80,17,0,1,1
+17603,3,9910,1,80,Brass Helm,303,80,17,0,2,1
+17604,3,9910,1,80,Brass Helm,303,80,17,0,3,1
+17605,3,9910,1,80,Brass Helm,303,80,17,0,4,1
+17606,3,10624,1,85,Sizjak Hat,303,83,17,0,0,1
+17607,3,10624,1,85,Sizjak Hat,303,83,17,0,1,1
+17608,3,10624,1,85,Sizjak Hat,303,83,17,0,2,1
+17609,3,10624,1,85,Sizjak Hat,303,83,17,0,3,1
+17610,3,10624,1,85,Sizjak Hat,303,83,17,0,4,1
+17611,3,11100,1,90,Acrean Turban,303,85,17,0,0,1
+17612,3,11100,1,90,Acrean Turban,303,85,17,0,1,1
+17613,3,11100,1,90,Acrean Turban,303,85,17,0,2,1
+17614,3,11100,1,90,Acrean Turban,303,85,17,0,3,1
+17615,3,11100,1,90,Acrean Turban,303,85,17,0,4,1
+17616,3,9910,1,80,Coif of Warm Winds,303,80,14,0,0,1
+17617,3,9910,1,80,Coif of Warm Winds,303,80,14,0,1,1
+17618,3,9910,1,80,Coif of Warm Winds,303,80,14,0,2,1
+17619,3,9910,1,80,Coif of Warm Winds,303,80,14,0,3,1
+17620,3,9910,1,80,Coif of Warm Winds,303,80,14,0,4,1
+17621,3,10624,1,85,Shahabad Helm,303,83,14,0,0,1
+17622,3,10624,1,85,Shahabad Helm,303,83,14,0,1,1
+17623,3,10624,1,85,Shahabad Helm,303,83,14,0,2,1
+17624,3,10624,1,85,Shahabad Helm,303,83,14,0,3,1
+17625,3,10624,1,85,Shahabad Helm,303,83,14,0,4,1
+17626,3,11100,1,90,Acrean Hat,303,85,14,0,0,1
+17627,3,11100,1,90,Acrean Hat,303,85,14,0,1,1
+17628,3,11100,1,90,Acrean Hat,303,85,14,0,2,1
+17629,3,11100,1,90,Acrean Hat,303,85,14,0,3,1
+17630,3,11100,1,90,Acrean Hat,303,85,14,0,4,1
+18199,3,11100,1,90,Courage Helm,303,85,12,0,0,1
+18200,3,11100,1,90,Courage Helm,303,85,12,0,1,1
+18201,3,11100,1,90,Courage Helm,303,85,12,0,2,1
+18202,3,11100,1,90,Courage Helm,303,85,12,0,3,1
+18203,3,11100,1,90,Courage Helm,303,85,12,0,4,1
+18204,3,11716,1,95,Emine Helm,303,88,12,0,0,1
+18205,3,11716,1,95,Emine Helm,303,88,12,0,1,1
+18206,3,11716,1,95,Emine Helm,303,88,12,0,2,1
+18207,3,11716,1,95,Emine Helm,303,88,12,0,3,1
+18208,3,11716,1,95,Emine Helm,303,88,12,0,4,1
+18209,3,12387,1,100,Dools Armet,303,90,12,0,0,1
+18210,3,12387,1,100,Dools Armet,303,90,12,0,1,1
+18211,3,12387,1,100,Dools Armet,303,90,12,0,2,1
+18212,3,12387,1,100,Dools Armet,303,90,12,0,3,1
+18213,3,12387,1,100,Dools Armet,303,90,12,0,4,1
+18214,3,11100,1,90,Magnus Mitre,303,85,15,0,0,1
+18215,3,11100,1,90,Magnus Mitre,303,85,15,0,1,1
+18216,3,11100,1,90,Magnus Mitre,303,85,15,0,2,1
+18217,3,11100,1,90,Magnus Mitre,303,85,15,0,3,1
+18218,3,11100,1,90,Magnus Mitre,303,85,15,0,4,1
+18219,3,11716,1,95,Forehead Protector of Hope,303,88,15,0,0,1
+18220,3,11716,1,95,Forehead Protector of Hope,303,88,15,0,1,1
+18221,3,11716,1,95,Forehead Protector of Hope,303,88,15,0,2,1
+18222,3,11716,1,95,Forehead Protector of Hope,303,88,15,0,3,1
+18223,3,11716,1,95,Forehead Protector of Hope,303,88,15,0,4,1
+18224,3,12387,1,100,Dools Mask,303,90,15,0,0,1
+18225,3,12387,1,100,Dools Mask,303,90,15,0,1,1
+18226,3,12387,1,100,Dools Mask,303,90,15,0,2,1
+18227,3,12387,1,100,Dools Mask,303,90,15,0,3,1
+18228,3,12387,1,100,Dools Mask,303,90,15,0,4,1
+18229,3,11100,1,90,Kelsus Barbute,303,85,17,0,0,1
+18230,3,11100,1,90,Kelsus Barbute,303,85,17,0,1,1
+18231,3,11100,1,90,Kelsus Barbute,303,85,17,0,2,1
+18232,3,11100,1,90,Kelsus Barbute,303,85,17,0,3,1
+18233,3,11100,1,90,Kelsus Barbute,303,85,17,0,4,1
+18234,3,11716,1,95,Kier Cervelliere,303,88,17,0,0,1
+18235,3,11716,1,95,Kier Cervelliere,303,88,17,0,1,1
+18236,3,11716,1,95,Kier Cervelliere,303,88,17,0,2,1
+18237,3,11716,1,95,Kier Cervelliere,303,88,17,0,3,1
+18238,3,11716,1,95,Kier Cervelliere,303,88,17,0,4,1
+18239,3,12387,1,100,Dools Barbute,303,90,17,0,0,1
+18240,3,12387,1,100,Dools Barbute,303,90,17,0,1,1
+18241,3,12387,1,100,Dools Barbute,303,90,17,0,2,1
+18242,3,12387,1,100,Dools Barbute,303,90,17,0,3,1
+18243,3,12387,1,100,Dools Barbute,303,90,17,0,4,1
+18244,3,11100,1,90,Aura Balaclava,303,85,14,0,0,1
+18245,3,11100,1,90,Aura Balaclava,303,85,14,0,1,1
+18246,3,11100,1,90,Aura Balaclava,303,85,14,0,2,1
+18247,3,11100,1,90,Aura Balaclava,303,85,14,0,3,1
+18248,3,11100,1,90,Aura Balaclava,303,85,14,0,4,1
+18249,3,11716,1,95,Niloufar Hood,303,88,14,0,0,1
+18250,3,11716,1,95,Niloufar Hood,303,88,14,0,1,1
+18251,3,11716,1,95,Niloufar Hood,303,88,14,0,2,1
+18252,3,11716,1,95,Niloufar Hood,303,88,14,0,3,1
+18253,3,11716,1,95,Niloufar Hood,303,88,14,0,4,1
+18254,3,12387,1,100,Dools Sallet,303,90,14,0,0,1
+18255,3,12387,1,100,Dools Sallet,303,90,14,0,1,1
+18256,3,12387,1,100,Dools Sallet,303,90,14,0,2,1
+18257,3,12387,1,100,Dools Sallet,303,90,14,0,3,1
+18258,3,12387,1,100,Dools Sallet,303,90,14,0,4,1
 18485,3,100,1,1,Volcanic Sparkle,303,75,0,0,4,1
-19236,3,0,1,10,Helm of the First King,303,80,0,3,0,1
-19237,3,0,1,4,Helm of the First King,303,80,0,3,1,1
-19238,3,0,1,9,Helm of the First King,303,80,0,3,2,1
-19239,3,0,1,14,Helm of the First King,303,80,0,3,3,1
-19240,3,0,1,8,Helm of the First King,303,80,0,3,4,1
+19236,3,0,1,90,Helm of the First King,303,80,0,3,0,1
+19237,3,0,1,100,Helm of the First King,303,80,0,3,1,1
+19238,3,0,1,105,Helm of the First King,303,80,0,3,2,1
+19239,3,0,1,110,Helm of the First King,303,80,0,3,3,1
+19240,3,0,1,120,Helm of the First King,303,80,0,3,4,1
 19500,3,3000,1,10,Magical Night Jack-o'-Helm,303,1,0,0,4,1
-20425,3,12300,1,4,Maddest Head,303,90,12,0,0,1
-20426,3,12300,1,4,Maddest Head,303,90,12,0,1,1
-20427,3,12300,1,4,Maddest Head,303,90,12,0,2,1
-20428,3,12300,1,4,Maddest Head,303,90,12,0,3,1
-20429,3,12300,1,4,Maddest Head,303,90,12,0,4,1
-20430,3,12915,1,9,Corail Helm,303,93,12,0,0,1
-20431,3,12915,1,9,Corail Helm,303,93,12,0,1,1
-20432,3,12915,1,9,Corail Helm,303,93,12,0,2,1
-20433,3,12915,1,9,Corail Helm,303,93,12,0,3,1
-20434,3,12915,1,9,Corail Helm,303,93,12,0,4,1
-20444,3,13530,1,14,Mehizaf Helm,303,95,12,0,0,1
-20445,3,13530,1,14,Mehizaf Helm,303,95,12,0,1,1
-20446,3,13530,1,14,Mehizaf Helm,303,95,12,0,2,1
-20447,3,13530,1,14,Mehizaf Helm,303,95,12,0,3,1
-20448,3,13530,1,14,Mehizaf Helm,303,95,12,0,4,1
-20762,3,13530,1,14,Courage Helm,303,95,12,0,0,1
-20763,3,13530,1,14,Courage Helm,303,95,12,0,1,1
-20764,3,13530,1,14,Courage Helm,303,95,12,0,2,1
-20765,3,13530,1,14,Courage Helm,303,95,12,0,3,1
-20766,3,13530,1,14,Courage Helm,303,95,12,0,4,1
-20767,3,14145,1,3,Confidence Helm,303,98,12,0,0,1
-20768,3,14145,1,3,Confidence Helm,303,98,12,0,1,1
-20769,3,14145,1,3,Confidence Helm,303,98,12,0,2,1
-20770,3,14145,1,3,Confidence Helm,303,98,12,0,3,1
-20771,3,14145,1,3,Confidence Helm,303,98,12,0,4,1
-20772,3,14760,1,8,Ambition Head,303,100,12,0,0,1
-20773,3,14760,1,8,Ambition Head,303,100,12,0,1,1
-20774,3,14760,1,8,Ambition Head,303,100,12,0,2,1
-20775,3,14760,1,8,Ambition Head,303,100,12,0,3,1
-20776,3,14760,1,8,Ambition Head,303,100,12,0,4,1
-20494,3,12300,1,4,Capable Hat,303,90,14,0,0,1
-20495,3,12300,1,4,Capable Hat,303,90,14,0,1,1
-20496,3,12300,1,4,Capable Hat,303,90,14,0,2,1
-20497,3,12300,1,4,Capable Hat,303,90,14,0,3,1
-20498,3,12300,1,4,Capable Hat,303,90,14,0,4,1
-20499,3,12915,1,9,Cuivre Hat,303,93,14,0,0,1
-20500,3,12915,1,9,Cuivre Hat,303,93,14,0,1,1
-20501,3,12915,1,9,Cuivre Hat,303,93,14,0,2,1
-20502,3,12915,1,9,Cuivre Hat,303,93,14,0,3,1
-20503,3,12915,1,9,Cuivre Hat,303,93,14,0,4,1
-20504,3,13530,1,14,Mehizaf Mask,303,95,14,0,0,1
-20505,3,13530,1,14,Mehizaf Mask,303,95,14,0,1,1
-20506,3,13530,1,14,Mehizaf Mask,303,95,14,0,2,1
-20507,3,13530,1,14,Mehizaf Mask,303,95,14,0,3,1
-20508,3,13530,1,14,Mehizaf Mask,303,95,14,0,4,1
-20822,3,13530,1,14,Hardy Mask,303,95,14,0,0,1
-20823,3,13530,1,14,Hardy Mask,303,95,14,0,1,1
-20824,3,13530,1,14,Hardy Mask,303,95,14,0,2,1
-20825,3,13530,1,14,Hardy Mask,303,95,14,0,3,1
-20826,3,13530,1,14,Hardy Mask,303,95,14,0,4,1
-20827,3,14145,1,3,Taciturne Hat,303,98,14,0,0,1
-20828,3,14145,1,3,Taciturne Hat,303,98,14,0,1,1
-20829,3,14145,1,3,Taciturne Hat,303,98,14,0,2,1
-20830,3,14145,1,3,Taciturne Hat,303,98,14,0,3,1
-20831,3,14145,1,3,Taciturne Hat,303,98,14,0,4,1
-20832,3,14760,1,8,Mission Head,303,100,14,0,0,1
-20833,3,14760,1,8,Mission Head,303,100,14,0,1,1
-20834,3,14760,1,8,Mission Head,303,100,14,0,2,1
-20835,3,14760,1,8,Mission Head,303,100,14,0,3,1
-20836,3,14760,1,8,Mission Head,303,100,14,0,4,1
-20554,3,12300,1,4,Round Mirror of Sacrament,303,90,15,0,0,1
-20555,3,12300,1,4,Round Mirror of Sacrament,303,90,15,0,1,1
-20556,3,12300,1,4,Round Mirror of Sacrament,303,90,15,0,2,1
-20557,3,12300,1,4,Round Mirror of Sacrament,303,90,15,0,3,1
-20558,3,12300,1,4,Round Mirror of Sacrament,303,90,15,0,4,1
-20559,3,12915,1,9,June Crown,303,93,15,0,0,1
-20560,3,12915,1,9,June Crown,303,93,15,0,1,1
-20561,3,12915,1,9,June Crown,303,93,15,0,2,1
-20562,3,12915,1,9,June Crown,303,93,15,0,3,1
-20563,3,12915,1,9,June Crown,303,93,15,0,4,1
-20564,3,13530,1,14,Mehizaf Head,303,95,15,0,0,1
-20565,3,13530,1,14,Mehizaf Head,303,95,15,0,1,1
-20566,3,13530,1,14,Mehizaf Head,303,95,15,0,2,1
-20567,3,13530,1,14,Mehizaf Head,303,95,15,0,3,1
-20568,3,13530,1,14,Mehizaf Head,303,95,15,0,4,1
-20882,3,13530,1,14,Miséricorde Hat,303,95,15,0,0,1
-20883,3,13530,1,14,Miséricorde Hat,303,95,15,0,1,1
-20884,3,13530,1,14,Miséricorde Hat,303,95,15,0,2,1
-20885,3,13530,1,14,Miséricorde Hat,303,95,15,0,3,1
-20886,3,13530,1,14,Miséricorde Hat,303,95,15,0,4,1
-20887,3,14145,1,3,Charité Circlet,303,98,15,0,0,1
-20888,3,14145,1,3,Charité Circlet,303,98,15,0,1,1
-20889,3,14145,1,3,Charité Circlet,303,98,15,0,2,1
-20890,3,14145,1,3,Charité Circlet,303,98,15,0,3,1
-20891,3,14145,1,3,Charité Circlet,303,98,15,0,4,1
-20892,3,14760,1,8,Redoutable Head,303,100,15,0,0,1
-20893,3,14760,1,8,Redoutable Head,303,100,15,0,1,1
-20894,3,14760,1,8,Redoutable Head,303,100,15,0,2,1
-20895,3,14760,1,8,Redoutable Head,303,100,15,0,3,1
-20896,3,14760,1,8,Redoutable Head,303,100,15,0,4,1
-20614,3,12300,1,4,Pundit Eye,303,90,17,0,0,1
-20615,3,12300,1,4,Pundit Eye,303,90,17,0,1,1
-20616,3,12300,1,4,Pundit Eye,303,90,17,0,2,1
-20617,3,12300,1,4,Pundit Eye,303,90,17,0,3,1
-20618,3,12300,1,4,Pundit Eye,303,90,17,0,4,1
-20619,3,12915,1,9,Briller Head,303,93,17,0,0,1
-20620,3,12915,1,9,Briller Head,303,93,17,0,1,1
-20621,3,12915,1,9,Briller Head,303,93,17,0,2,1
-20622,3,12915,1,9,Briller Head,303,93,17,0,3,1
-20623,3,12915,1,9,Briller Head,303,93,17,0,4,1
-20624,3,13530,1,14,Mehizaf Crown,303,95,17,0,0,1
-20625,3,13530,1,14,Mehizaf Crown,303,95,17,0,1,1
-20626,3,13530,1,14,Mehizaf Crown,303,95,17,0,2,1
-20627,3,13530,1,14,Mehizaf Crown,303,95,17,0,3,1
-20628,3,13530,1,14,Mehizaf Crown,303,95,17,0,4,1
-20942,3,13530,1,14,Positivité Helm,303,95,17,0,0,1
-20943,3,13530,1,14,Positivité Helm,303,95,17,0,1,1
-20944,3,13530,1,14,Positivité Helm,303,95,17,0,2,1
-20945,3,13530,1,14,Positivité Helm,303,95,17,0,3,1
-20946,3,13530,1,14,Positivité Helm,303,95,17,0,4,1
-20947,3,14145,1,3,Solidarité Turban,303,98,17,0,0,1
-20948,3,14145,1,3,Solidarité Turban,303,98,17,0,1,1
-20949,3,14145,1,3,Solidarité Turban,303,98,17,0,2,1
-20950,3,14145,1,3,Solidarité Turban,303,98,17,0,3,1
-20951,3,14145,1,3,Solidarité Turban,303,98,17,0,4,1
-20952,3,14760,1,8,Ideal Head,303,100,17,0,0,1
-20953,3,14760,1,8,Ideal Head,303,100,17,0,1,1
-20954,3,14760,1,8,Ideal Head,303,100,17,0,2,1
-20955,3,14760,1,8,Ideal Head,303,100,17,0,3,1
-20956,3,14760,1,8,Ideal Head,303,100,17,0,4,1
-20443,3,10000,1,10,Scarlet Dragon Mask,303,1,0,0,0,1
+20425,3,12300,1,100,Maddest Head,303,90,12,0,0,1
+20426,3,12300,1,100,Maddest Head,303,90,12,0,1,1
+20427,3,12300,1,100,Maddest Head,303,90,12,0,2,1
+20428,3,12300,1,100,Maddest Head,303,90,12,0,3,1
+20429,3,12300,1,100,Maddest Head,303,90,12,0,4,1
+20430,3,12915,1,105,Corail Helm,303,93,12,0,0,1
+20431,3,12915,1,105,Corail Helm,303,93,12,0,1,1
+20432,3,12915,1,105,Corail Helm,303,93,12,0,2,1
+20433,3,12915,1,105,Corail Helm,303,93,12,0,3,1
+20434,3,12915,1,105,Corail Helm,303,93,12,0,4,1
+20444,3,13530,1,110,Mehizaf Helm,303,95,12,0,0,1
+20445,3,13530,1,110,Mehizaf Helm,303,95,12,0,1,1
+20446,3,13530,1,110,Mehizaf Helm,303,95,12,0,2,1
+20447,3,13530,1,110,Mehizaf Helm,303,95,12,0,3,1
+20448,3,13530,1,110,Mehizaf Helm,303,95,12,0,4,1
+20762,3,13530,1,110,Courage Helm,303,95,12,0,0,1
+20763,3,13530,1,110,Courage Helm,303,95,12,0,1,1
+20764,3,13530,1,110,Courage Helm,303,95,12,0,2,1
+20765,3,13530,1,110,Courage Helm,303,95,12,0,3,1
+20766,3,13530,1,110,Courage Helm,303,95,12,0,4,1
+20767,3,14145,1,115,Confidence Helm,303,98,12,0,0,1
+20768,3,14145,1,115,Confidence Helm,303,98,12,0,1,1
+20769,3,14145,1,115,Confidence Helm,303,98,12,0,2,1
+20770,3,14145,1,115,Confidence Helm,303,98,12,0,3,1
+20771,3,14145,1,115,Confidence Helm,303,98,12,0,4,1
+20772,3,14760,1,120,Ambition Head,303,100,12,0,0,1
+20773,3,14760,1,120,Ambition Head,303,100,12,0,1,1
+20774,3,14760,1,120,Ambition Head,303,100,12,0,2,1
+20775,3,14760,1,120,Ambition Head,303,100,12,0,3,1
+20776,3,14760,1,120,Ambition Head,303,100,12,0,4,1
+20494,3,12300,1,100,Capable Hat,303,90,14,0,0,1
+20495,3,12300,1,100,Capable Hat,303,90,14,0,1,1
+20496,3,12300,1,100,Capable Hat,303,90,14,0,2,1
+20497,3,12300,1,100,Capable Hat,303,90,14,0,3,1
+20498,3,12300,1,100,Capable Hat,303,90,14,0,4,1
+20499,3,12915,1,105,Cuivre Hat,303,93,14,0,0,1
+20500,3,12915,1,105,Cuivre Hat,303,93,14,0,1,1
+20501,3,12915,1,105,Cuivre Hat,303,93,14,0,2,1
+20502,3,12915,1,105,Cuivre Hat,303,93,14,0,3,1
+20503,3,12915,1,105,Cuivre Hat,303,93,14,0,4,1
+20504,3,13530,1,110,Mehizaf Mask,303,95,14,0,0,1
+20505,3,13530,1,110,Mehizaf Mask,303,95,14,0,1,1
+20506,3,13530,1,110,Mehizaf Mask,303,95,14,0,2,1
+20507,3,13530,1,110,Mehizaf Mask,303,95,14,0,3,1
+20508,3,13530,1,110,Mehizaf Mask,303,95,14,0,4,1
+20822,3,13530,1,110,Hardy Mask,303,95,14,0,0,1
+20823,3,13530,1,110,Hardy Mask,303,95,14,0,1,1
+20824,3,13530,1,110,Hardy Mask,303,95,14,0,2,1
+20825,3,13530,1,110,Hardy Mask,303,95,14,0,3,1
+20826,3,13530,1,110,Hardy Mask,303,95,14,0,4,1
+20827,3,14145,1,115,Taciturne Hat,303,98,14,0,0,1
+20828,3,14145,1,115,Taciturne Hat,303,98,14,0,1,1
+20829,3,14145,1,115,Taciturne Hat,303,98,14,0,2,1
+20830,3,14145,1,115,Taciturne Hat,303,98,14,0,3,1
+20831,3,14145,1,115,Taciturne Hat,303,98,14,0,4,1
+20832,3,14760,1,120,Mission Head,303,100,14,0,0,1
+20833,3,14760,1,120,Mission Head,303,100,14,0,1,1
+20834,3,14760,1,120,Mission Head,303,100,14,0,2,1
+20835,3,14760,1,120,Mission Head,303,100,14,0,3,1
+20836,3,14760,1,120,Mission Head,303,100,14,0,4,1
+20554,3,12300,1,100,Round Mirror of Sacrament,303,90,15,0,0,1
+20555,3,12300,1,100,Round Mirror of Sacrament,303,90,15,0,1,1
+20556,3,12300,1,100,Round Mirror of Sacrament,303,90,15,0,2,1
+20557,3,12300,1,100,Round Mirror of Sacrament,303,90,15,0,3,1
+20558,3,12300,1,100,Round Mirror of Sacrament,303,90,15,0,4,1
+20559,3,12915,1,105,June Crown,303,93,15,0,0,1
+20560,3,12915,1,105,June Crown,303,93,15,0,1,1
+20561,3,12915,1,105,June Crown,303,93,15,0,2,1
+20562,3,12915,1,105,June Crown,303,93,15,0,3,1
+20563,3,12915,1,105,June Crown,303,93,15,0,4,1
+20564,3,13530,1,110,Mehizaf Head,303,95,15,0,0,1
+20565,3,13530,1,110,Mehizaf Head,303,95,15,0,1,1
+20566,3,13530,1,110,Mehizaf Head,303,95,15,0,2,1
+20567,3,13530,1,110,Mehizaf Head,303,95,15,0,3,1
+20568,3,13530,1,110,Mehizaf Head,303,95,15,0,4,1
+20882,3,13530,1,110,Miséricorde Hat,303,95,15,0,0,1
+20883,3,13530,1,110,Miséricorde Hat,303,95,15,0,1,1
+20884,3,13530,1,110,Miséricorde Hat,303,95,15,0,2,1
+20885,3,13530,1,110,Miséricorde Hat,303,95,15,0,3,1
+20886,3,13530,1,110,Miséricorde Hat,303,95,15,0,4,1
+20887,3,14145,1,115,Charité Circlet,303,98,15,0,0,1
+20888,3,14145,1,115,Charité Circlet,303,98,15,0,1,1
+20889,3,14145,1,115,Charité Circlet,303,98,15,0,2,1
+20890,3,14145,1,115,Charité Circlet,303,98,15,0,3,1
+20891,3,14145,1,115,Charité Circlet,303,98,15,0,4,1
+20892,3,14760,1,120,Redoutable Head,303,100,15,0,0,1
+20893,3,14760,1,120,Redoutable Head,303,100,15,0,1,1
+20894,3,14760,1,120,Redoutable Head,303,100,15,0,2,1
+20895,3,14760,1,120,Redoutable Head,303,100,15,0,3,1
+20896,3,14760,1,120,Redoutable Head,303,100,15,0,4,1
+20614,3,12300,1,100,Pundit Eye,303,90,17,0,0,1
+20615,3,12300,1,100,Pundit Eye,303,90,17,0,1,1
+20616,3,12300,1,100,Pundit Eye,303,90,17,0,2,1
+20617,3,12300,1,100,Pundit Eye,303,90,17,0,3,1
+20618,3,12300,1,100,Pundit Eye,303,90,17,0,4,1
+20619,3,12915,1,105,Briller Head,303,93,17,0,0,1
+20620,3,12915,1,105,Briller Head,303,93,17,0,1,1
+20621,3,12915,1,105,Briller Head,303,93,17,0,2,1
+20622,3,12915,1,105,Briller Head,303,93,17,0,3,1
+20623,3,12915,1,105,Briller Head,303,93,17,0,4,1
+20624,3,13530,1,110,Mehizaf Crown,303,95,17,0,0,1
+20625,3,13530,1,110,Mehizaf Crown,303,95,17,0,1,1
+20626,3,13530,1,110,Mehizaf Crown,303,95,17,0,2,1
+20627,3,13530,1,110,Mehizaf Crown,303,95,17,0,3,1
+20628,3,13530,1,110,Mehizaf Crown,303,95,17,0,4,1
+20942,3,13530,1,110,Positivité Helm,303,95,17,0,0,1
+20943,3,13530,1,110,Positivité Helm,303,95,17,0,1,1
+20944,3,13530,1,110,Positivité Helm,303,95,17,0,2,1
+20945,3,13530,1,110,Positivité Helm,303,95,17,0,3,1
+20946,3,13530,1,110,Positivité Helm,303,95,17,0,4,1
+20947,3,14145,1,115,Solidarité Turban,303,98,17,0,0,1
+20948,3,14145,1,115,Solidarité Turban,303,98,17,0,1,1
+20949,3,14145,1,115,Solidarité Turban,303,98,17,0,2,1
+20950,3,14145,1,115,Solidarité Turban,303,98,17,0,3,1
+20951,3,14145,1,115,Solidarité Turban,303,98,17,0,4,1
+20952,3,14760,1,120,Ideal Head,303,100,17,0,0,1
+20953,3,14760,1,120,Ideal Head,303,100,17,0,1,1
+20954,3,14760,1,120,Ideal Head,303,100,17,0,2,1
+20955,3,14760,1,120,Ideal Head,303,100,17,0,3,1
+20956,3,14760,1,120,Ideal Head,303,100,17,0,4,1
+20443,3,10000,1,90,Scarlet Dragon Mask,303,1,0,0,0,1
 20678,3,100,1,1,War God's Headpiece,303,1,0,0,4,1
 21002,3,100,1,1,Refined Circlet,303,1,0,0,4,1
 21007,3,100,1,1,Noble Circlet,303,1,0,0,4,1
@@ -13190,19 +13190,19 @@
 20756,3,10000,1,7,Midsummer Dandy Sunglasses,303,1,0,0,0,1
 20757,3,10000,1,7,Midsummer Modern Sunglasses,303,1,0,0,0,1
 20758,3,10000,1,7,Midsummer Unique Sunglasses,303,1,0,0,0,1
-21294,3,10000,1,12,Maestro Helm,303,1,0,3,4,1
-21296,3,10000,1,15,Virtuoso Helm,303,1,0,3,4,1
+21294,3,10000,1,92,Maestro Helm,303,1,0,3,4,1
+21296,3,10000,1,95,Virtuoso Helm,303,1,0,3,4,1
 21396,3,500,1,12,Cursed Helm,303,1,0,0,0,1
 21400,3,500,1,12,Chaos Mask,303,1,0,0,0,1
-21677,3,10000,1,11,Papillon Ribbon (White),303,1,0,0,4,1
-21678,3,10000,1,11,Papillon Ribbon (Black),303,1,0,0,4,1
-21679,3,10000,1,11,Papillon Ribbon (Peach),303,1,0,0,4,1
-21680,3,10000,1,11,Bunny Ribbon (White),303,1,0,0,4,1
-21681,3,10000,1,11,Bunny Ribbon (Black),303,1,0,0,4,1
-21682,3,10000,1,11,Bunny Ribbon (Peach),303,1,0,0,4,1
-21683,3,10000,1,11,Bear's Cap (White),303,1,0,0,4,1
-21684,3,10000,1,11,Bear's Cap (Black),303,1,0,0,4,1
-21685,3,10000,1,11,Bear's Cap (Brown),303,1,0,0,4,1
+21677,3,10000,1,75,Papillon Ribbon (White),303,1,0,0,4,1
+21678,3,10000,1,75,Papillon Ribbon (Black),303,1,0,0,4,1
+21679,3,10000,1,75,Papillon Ribbon (Peach),303,1,0,0,4,1
+21680,3,10000,1,75,Bunny Ribbon (White),303,1,0,0,4,1
+21681,3,10000,1,75,Bunny Ribbon (Black),303,1,0,0,4,1
+21682,3,10000,1,75,Bunny Ribbon (Peach),303,1,0,0,4,1
+21683,3,10000,1,75,Bear's Cap (White),303,1,0,0,4,1
+21684,3,10000,1,75,Bear's Cap (Black),303,1,0,0,4,1
+21685,3,10000,1,75,Bear's Cap (Brown),303,1,0,0,4,1
 23380,3,0,1,6,Investigator's Spectacles,303,1,0,0,0,1
 23395,3,10000,1,1,Mischievous Black Wolf Mask,303,1,0,0,4,1
 23396,3,10000,1,1,Mischievous White Wolf Mask,303,1,0,0,4,1
@@ -13218,106 +13218,106 @@
 23454,3,100,1,1,Reindeer's Ears (Brown),303,1,0,0,4,1
 23455,3,100,1,1,Reindeer's Ears (White),303,1,0,0,4,1
 23460,3,100,1,1,Christmas Ornament Hat,303,1,0,0,4,1
-24099,3,0,1,2,Spirit's Heavy Armored Helm,303,100,12,0,0,1
-24100,3,0,1,2,Spirit's Heavy Armored Helm,303,100,12,0,1,1
-24101,3,0,1,2,Spirit's Heavy Armored Helm,303,100,12,0,2,1
-24102,3,0,1,2,Spirit's Heavy Armored Helm,303,100,12,0,3,1
-24103,3,0,1,2,Spirit's Heavy Armored Helm,303,100,12,0,4,1
-24104,3,0,1,2,Fire King's Heavy Armored Helm,303,100,12,0,0,1
-24105,3,0,1,2,Fire King's Heavy Armored Helm,303,100,12,0,1,1
-24106,3,0,1,2,Fire King's Heavy Armored Helm,303,100,12,0,2,1
-24107,3,0,1,2,Fire King's Heavy Armored Helm,303,100,12,0,3,1
-24108,3,0,1,2,Fire King's Heavy Armored Helm,303,100,12,0,4,1
-24109,3,0,1,2,White Wings Armored Helm,303,100,12,0,0,1
-24110,3,0,1,2,White Wings Armored Helm,303,100,12,0,1,1
-24111,3,0,1,2,White Wings Armored Helm,303,100,12,0,2,1
-24112,3,0,1,2,White Wings Armored Helm,303,100,12,0,3,1
-24113,3,0,1,2,White Wings Armored Helm,303,100,12,0,4,1
-24114,3,0,1,2,Golden Heavy Helmet,303,100,12,0,0,1
-24115,3,0,1,2,Golden Heavy Helmet,303,100,12,0,1,1
-24116,3,0,1,2,Golden Heavy Helmet,303,100,12,0,2,1
-24117,3,0,1,2,Golden Heavy Helmet,303,100,12,0,3,1
-24118,3,0,1,2,Golden Heavy Helmet,303,100,12,0,4,1
-24119,3,0,1,7,Blackshatter Heavy Duty Helmet,303,100,12,0,0,1
-24120,3,0,1,7,Blackshatter Heavy Duty Helmet,303,100,12,0,1,1
-24121,3,0,1,7,Blackshatter Heavy Duty Helmet,303,100,12,0,2,1
-24122,3,0,1,7,Blackshatter Heavy Duty Helmet,303,100,12,0,3,1
-24123,3,0,1,7,Blackshatter Heavy Duty Helmet,303,100,12,0,4,1
-24199,3,0,1,2,Spirit light Armored Helm,303,100,14,0,0,1
-24200,3,0,1,2,Spirit light Armored Helm,303,100,14,0,1,1
-24201,3,0,1,2,Spirit light Armored Helm,303,100,14,0,2,1
-24202,3,0,1,2,Spirit light Armored Helm,303,100,14,0,3,1
-24203,3,0,1,2,Spirit light Armored Helm,303,100,14,0,4,1
-24204,3,0,1,2,Fire King's Armored Helm,303,100,14,0,0,1
-24205,3,0,1,2,Fire King's Armored Helm,303,100,14,0,1,1
-24206,3,0,1,2,Fire King's Armored Helm,303,100,14,0,2,1
-24207,3,0,1,2,Fire King's Armored Helm,303,100,14,0,3,1
-24208,3,0,1,2,Fire King's Armored Helm,303,100,14,0,4,1
-24209,3,0,1,2,White Wings' Light Armored Helm,303,100,14,0,0,1
-24210,3,0,1,2,White Wings' Light Armored Helm,303,100,14,0,1,1
-24211,3,0,1,2,White Wings' Light Armored Helm,303,100,14,0,2,1
-24212,3,0,1,2,White Wings' Light Armored Helm,303,100,14,0,3,1
-24213,3,0,1,2,White Wings' Light Armored Helm,303,100,14,0,4,1
-24214,3,0,1,2,Golden Light Helmet,303,100,14,0,0,1
-24215,3,0,1,2,Golden Light Helmet,303,100,14,0,1,1
-24216,3,0,1,2,Golden Light Helmet,303,100,14,0,2,1
-24217,3,0,1,2,Golden Light Helmet,303,100,14,0,3,1
-24218,3,0,1,2,Golden Light Helmet,303,100,14,0,4,1
-24219,3,0,1,7,Blackshatter Light Helmet,303,100,14,0,0,1
-24220,3,0,1,7,Blackshatter Light Helmet,303,100,14,0,1,1
-24221,3,0,1,7,Blackshatter Light Helmet,303,100,14,0,2,1
-24222,3,0,1,7,Blackshatter Light Helmet,303,100,14,0,3,1
-24223,3,0,1,7,Blackshatter Light Helmet,303,100,14,0,4,1
-24299,3,0,1,2,Spirit's Magick Helmet,303,100,15,0,0,1
-24300,3,0,1,2,Spirit's Magick Helmet,303,100,15,0,1,1
-24301,3,0,1,2,Spirit's Magick Helmet,303,100,15,0,2,1
-24302,3,0,1,2,Spirit's Magick Helmet,303,100,15,0,3,1
-24303,3,0,1,2,Spirit's Magick Helmet,303,100,15,0,4,1
-24304,3,0,1,2,Fire King's Magick Helmet,303,100,15,0,0,1
-24305,3,0,1,2,Fire King's Magick Helmet,303,100,15,0,1,1
-24306,3,0,1,2,Fire King's Magick Helmet,303,100,15,0,2,1
-24307,3,0,1,2,Fire King's Magick Helmet,303,100,15,0,3,1
-24308,3,0,1,2,Fire King's Magick Helmet,303,100,15,0,4,1
-24309,3,0,1,2,White Wings' Magick Helmet,303,100,15,0,0,1
-24310,3,0,1,2,White Wings' Magick Helmet,303,100,15,0,1,1
-24311,3,0,1,2,White Wings' Magick Helmet,303,100,15,0,2,1
-24312,3,0,1,2,White Wings' Magick Helmet,303,100,15,0,3,1
-24313,3,0,1,2,White Wings' Magick Helmet,303,100,15,0,4,1
-24314,3,0,1,2,Golden Magick Helmet,303,100,15,0,0,1
-24315,3,0,1,2,Golden Magick Helmet,303,100,15,0,1,1
-24316,3,0,1,2,Golden Magick Helmet,303,100,15,0,2,1
-24317,3,0,1,2,Golden Magick Helmet,303,100,15,0,3,1
-24318,3,0,1,2,Golden Magick Helmet,303,100,15,0,4,1
-24319,3,0,1,7,Blackshatter Magic Helm,303,100,15,0,0,1
-24320,3,0,1,7,Blackshatter Magic Helm,303,100,15,0,1,1
-24321,3,0,1,7,Blackshatter Magic Helm,303,100,15,0,2,1
-24322,3,0,1,7,Blackshatter Magic Helm,303,100,15,0,3,1
-24323,3,0,1,7,Blackshatter Magic Helm,303,100,15,0,4,1
-24399,3,0,1,2,Spirit's Magick Combat Helm,303,100,17,0,0,1
-24400,3,0,1,2,Spirit's Magick Combat Helm,303,100,17,0,1,1
-24401,3,0,1,2,Spirit's Magick Combat Helm,303,100,17,0,2,1
-24402,3,0,1,2,Spirit's Magick Combat Helm,303,100,17,0,3,1
-24403,3,0,1,2,Spirit's Magick Combat Helm,303,100,17,0,4,1
-24404,3,0,1,2,Fire King's Magick Combat Helm,303,100,17,0,0,1
-24405,3,0,1,2,Fire King's Magick Combat Helm,303,100,17,0,1,1
-24406,3,0,1,2,Fire King's Magick Combat Helm,303,100,17,0,2,1
-24407,3,0,1,2,Fire King's Magick Combat Helm,303,100,17,0,3,1
-24408,3,0,1,2,Fire King's Magick Combat Helm,303,100,17,0,4,1
-24409,3,0,1,2,White Wings's Combat Helm,303,100,17,0,0,1
-24410,3,0,1,2,White Wings's Combat Helm,303,100,17,0,1,1
-24411,3,0,1,2,White Wings's Combat Helm,303,100,17,0,2,1
-24412,3,0,1,2,White Wings's Combat Helm,303,100,17,0,3,1
-24413,3,0,1,2,White Wings's Combat Helm,303,100,17,0,4,1
-24414,3,0,1,2,Golden Magick Battle Helmet,303,100,17,0,0,1
-24415,3,0,1,2,Golden Magick Battle Helmet,303,100,17,0,1,1
-24416,3,0,1,2,Golden Magick Battle Helmet,303,100,17,0,2,1
-24417,3,0,1,2,Golden Magick Battle Helmet,303,100,17,0,3,1
-24418,3,0,1,2,Golden Magick Battle Helmet,303,100,17,0,4,1
-24419,3,0,1,7,Blackshatter Magic Battle Helmet,303,100,17,0,0,1
-24420,3,0,1,7,Blackshatter Magic Battle Helmet,303,100,17,0,1,1
-24421,3,0,1,7,Blackshatter Magic Battle Helmet,303,100,17,0,2,1
-24422,3,0,1,7,Blackshatter Magic Battle Helmet,303,100,17,0,3,1
-24423,3,0,1,7,Blackshatter Magic Battle Helmet,303,100,17,0,4,1
+24099,3,0,1,130,Spirit's Heavy Armored Helm,303,100,12,0,0,1
+24100,3,0,1,130,Spirit's Heavy Armored Helm,303,100,12,0,1,1
+24101,3,0,1,130,Spirit's Heavy Armored Helm,303,100,12,0,2,1
+24102,3,0,1,130,Spirit's Heavy Armored Helm,303,100,12,0,3,1
+24103,3,0,1,130,Spirit's Heavy Armored Helm,303,100,12,0,4,1
+24104,3,0,1,130,Fire King's Heavy Armored Helm,303,100,12,0,0,1
+24105,3,0,1,130,Fire King's Heavy Armored Helm,303,100,12,0,1,1
+24106,3,0,1,130,Fire King's Heavy Armored Helm,303,100,12,0,2,1
+24107,3,0,1,130,Fire King's Heavy Armored Helm,303,100,12,0,3,1
+24108,3,0,1,130,Fire King's Heavy Armored Helm,303,100,12,0,4,1
+24109,3,0,1,130,White Wings Armored Helm,303,100,12,0,0,1
+24110,3,0,1,130,White Wings Armored Helm,303,100,12,0,1,1
+24111,3,0,1,130,White Wings Armored Helm,303,100,12,0,2,1
+24112,3,0,1,130,White Wings Armored Helm,303,100,12,0,3,1
+24113,3,0,1,130,White Wings Armored Helm,303,100,12,0,4,1
+24114,3,0,1,130,Golden Heavy Helmet,303,100,12,0,0,1
+24115,3,0,1,130,Golden Heavy Helmet,303,100,12,0,1,1
+24116,3,0,1,130,Golden Heavy Helmet,303,100,12,0,2,1
+24117,3,0,1,130,Golden Heavy Helmet,303,100,12,0,3,1
+24118,3,0,1,130,Golden Heavy Helmet,303,100,12,0,4,1
+24119,3,0,1,135,Blackshatter Heavy Duty Helmet,303,100,12,0,0,1
+24120,3,0,1,135,Blackshatter Heavy Duty Helmet,303,100,12,0,1,1
+24121,3,0,1,135,Blackshatter Heavy Duty Helmet,303,100,12,0,2,1
+24122,3,0,1,135,Blackshatter Heavy Duty Helmet,303,100,12,0,3,1
+24123,3,0,1,135,Blackshatter Heavy Duty Helmet,303,100,12,0,4,1
+24199,3,0,1,130,Spirit light Armored Helm,303,100,14,0,0,1
+24200,3,0,1,130,Spirit light Armored Helm,303,100,14,0,1,1
+24201,3,0,1,130,Spirit light Armored Helm,303,100,14,0,2,1
+24202,3,0,1,130,Spirit light Armored Helm,303,100,14,0,3,1
+24203,3,0,1,130,Spirit light Armored Helm,303,100,14,0,4,1
+24204,3,0,1,130,Fire King's Armored Helm,303,100,14,0,0,1
+24205,3,0,1,130,Fire King's Armored Helm,303,100,14,0,1,1
+24206,3,0,1,130,Fire King's Armored Helm,303,100,14,0,2,1
+24207,3,0,1,130,Fire King's Armored Helm,303,100,14,0,3,1
+24208,3,0,1,130,Fire King's Armored Helm,303,100,14,0,4,1
+24209,3,0,1,130,White Wings' Light Armored Helm,303,100,14,0,0,1
+24210,3,0,1,130,White Wings' Light Armored Helm,303,100,14,0,1,1
+24211,3,0,1,130,White Wings' Light Armored Helm,303,100,14,0,2,1
+24212,3,0,1,130,White Wings' Light Armored Helm,303,100,14,0,3,1
+24213,3,0,1,130,White Wings' Light Armored Helm,303,100,14,0,4,1
+24214,3,0,1,130,Golden Light Helmet,303,100,14,0,0,1
+24215,3,0,1,130,Golden Light Helmet,303,100,14,0,1,1
+24216,3,0,1,130,Golden Light Helmet,303,100,14,0,2,1
+24217,3,0,1,130,Golden Light Helmet,303,100,14,0,3,1
+24218,3,0,1,130,Golden Light Helmet,303,100,14,0,4,1
+24219,3,0,1,135,Blackshatter Light Helmet,303,100,14,0,0,1
+24220,3,0,1,135,Blackshatter Light Helmet,303,100,14,0,1,1
+24221,3,0,1,135,Blackshatter Light Helmet,303,100,14,0,2,1
+24222,3,0,1,135,Blackshatter Light Helmet,303,100,14,0,3,1
+24223,3,0,1,135,Blackshatter Light Helmet,303,100,14,0,4,1
+24299,3,0,1,130,Spirit's Magick Helmet,303,100,15,0,0,1
+24300,3,0,1,130,Spirit's Magick Helmet,303,100,15,0,1,1
+24301,3,0,1,130,Spirit's Magick Helmet,303,100,15,0,2,1
+24302,3,0,1,130,Spirit's Magick Helmet,303,100,15,0,3,1
+24303,3,0,1,130,Spirit's Magick Helmet,303,100,15,0,4,1
+24304,3,0,1,130,Fire King's Magick Helmet,303,100,15,0,0,1
+24305,3,0,1,130,Fire King's Magick Helmet,303,100,15,0,1,1
+24306,3,0,1,130,Fire King's Magick Helmet,303,100,15,0,2,1
+24307,3,0,1,130,Fire King's Magick Helmet,303,100,15,0,3,1
+24308,3,0,1,130,Fire King's Magick Helmet,303,100,15,0,4,1
+24309,3,0,1,130,White Wings' Magick Helmet,303,100,15,0,0,1
+24310,3,0,1,130,White Wings' Magick Helmet,303,100,15,0,1,1
+24311,3,0,1,130,White Wings' Magick Helmet,303,100,15,0,2,1
+24312,3,0,1,130,White Wings' Magick Helmet,303,100,15,0,3,1
+24313,3,0,1,130,White Wings' Magick Helmet,303,100,15,0,4,1
+24314,3,0,1,130,Golden Magick Helmet,303,100,15,0,0,1
+24315,3,0,1,130,Golden Magick Helmet,303,100,15,0,1,1
+24316,3,0,1,130,Golden Magick Helmet,303,100,15,0,2,1
+24317,3,0,1,130,Golden Magick Helmet,303,100,15,0,3,1
+24318,3,0,1,130,Golden Magick Helmet,303,100,15,0,4,1
+24319,3,0,1,135,Blackshatter Magic Helm,303,100,15,0,0,1
+24320,3,0,1,135,Blackshatter Magic Helm,303,100,15,0,1,1
+24321,3,0,1,135,Blackshatter Magic Helm,303,100,15,0,2,1
+24322,3,0,1,135,Blackshatter Magic Helm,303,100,15,0,3,1
+24323,3,0,1,135,Blackshatter Magic Helm,303,100,15,0,4,1
+24399,3,0,1,130,Spirit's Magick Combat Helm,303,100,17,0,0,1
+24400,3,0,1,130,Spirit's Magick Combat Helm,303,100,17,0,1,1
+24401,3,0,1,130,Spirit's Magick Combat Helm,303,100,17,0,2,1
+24402,3,0,1,130,Spirit's Magick Combat Helm,303,100,17,0,3,1
+24403,3,0,1,130,Spirit's Magick Combat Helm,303,100,17,0,4,1
+24404,3,0,1,130,Fire King's Magick Combat Helm,303,100,17,0,0,1
+24405,3,0,1,130,Fire King's Magick Combat Helm,303,100,17,0,1,1
+24406,3,0,1,130,Fire King's Magick Combat Helm,303,100,17,0,2,1
+24407,3,0,1,130,Fire King's Magick Combat Helm,303,100,17,0,3,1
+24408,3,0,1,130,Fire King's Magick Combat Helm,303,100,17,0,4,1
+24409,3,0,1,130,White Wings's Combat Helm,303,100,17,0,0,1
+24410,3,0,1,130,White Wings's Combat Helm,303,100,17,0,1,1
+24411,3,0,1,130,White Wings's Combat Helm,303,100,17,0,2,1
+24412,3,0,1,130,White Wings's Combat Helm,303,100,17,0,3,1
+24413,3,0,1,130,White Wings's Combat Helm,303,100,17,0,4,1
+24414,3,0,1,130,Golden Magick Battle Helmet,303,100,17,0,0,1
+24415,3,0,1,130,Golden Magick Battle Helmet,303,100,17,0,1,1
+24416,3,0,1,130,Golden Magick Battle Helmet,303,100,17,0,2,1
+24417,3,0,1,130,Golden Magick Battle Helmet,303,100,17,0,3,1
+24418,3,0,1,130,Golden Magick Battle Helmet,303,100,17,0,4,1
+24419,3,0,1,135,Blackshatter Magic Battle Helmet,303,100,17,0,0,1
+24420,3,0,1,135,Blackshatter Magic Battle Helmet,303,100,17,0,1,1
+24421,3,0,1,135,Blackshatter Magic Battle Helmet,303,100,17,0,2,1
+24422,3,0,1,135,Blackshatter Magic Battle Helmet,303,100,17,0,3,1
+24423,3,0,1,135,Blackshatter Magic Battle Helmet,303,100,17,0,4,1
 24601,3,0,1,12,Pleiades Helm,303,1,0,0,4,1
 24605,3,0,1,12,Valkyrian Helm,303,1,0,0,4,1
 24890,3,10000,1,1,Southern Country Straw Hat (Red),303,1,0,0,0,1
@@ -13331,70 +13331,70 @@
 24924,3,10000,1,1,Bear's Cap (Deep Red),303,1,0,0,0,1
 24934,3,10000,1,1,God of War's helmet,303,1,0,0,4,1
 24938,3,10000,1,1,Spriggan Mask,303,1,0,0,4,1
-25019,3,10000,1,8,Golden Circlet,303,1,0,0,0,1
+25019,3,10000,1,120,Golden Circlet,303,1,0,0,0,1
 25224,3,10000,1,1,Holy Seal's Generous Helm,303,1,0,0,4,1
 25228,3,15000,1,1,Tricksters' Generous Helm,303,1,0,0,4,1
 25232,3,15000,1,1,Hero's Generous Helm,303,1,0,0,4,1
-25236,3,15000,1,12,Savage Courage Assault Skull,303,105,12,0,0,1
-25237,3,15000,1,12,Savage Courage Assault Skull,303,105,12,0,1,1
-25238,3,15000,1,12,Savage Courage Assault Skull,303,105,12,0,2,1
-25239,3,15000,1,12,Savage Courage Assault Skull,303,105,12,0,3,1
-25240,3,15000,1,12,Savage Courage Assault Skull,303,105,12,0,4,1
-25256,3,15000,1,1,Solitary Assault Helm,303,110,12,0,0,1
-25257,3,15000,1,1,Solitary Assault Helm,303,110,12,0,1,1
-25258,3,15000,1,1,Solitary Assault Helm,303,110,12,0,2,1
-25259,3,15000,1,1,Solitary Assault Helm,303,110,12,0,3,1
-25260,3,15000,1,1,Solitary Assault Helm,303,110,12,0,4,1
-25276,3,15000,1,6,Hero's Assault Head,303,115,12,0,0,1
-25277,3,15000,1,6,Hero's Assault Head,303,115,12,0,1,1
-25278,3,15000,1,6,Hero's Assault Head,303,115,12,0,2,1
-25279,3,15000,1,6,Hero's Assault Head,303,115,12,0,3,1
-25280,3,15000,1,6,Hero's Assault Head,303,115,12,0,4,1
-25296,3,15000,1,12,Savage Courage Snipe Mask,303,105,14,0,0,1
-25297,3,15000,1,12,Savage Courage Snipe Mask,303,105,14,0,1,1
-25298,3,15000,1,12,Savage Courage Snipe Mask,303,105,14,0,2,1
-25299,3,15000,1,12,Savage Courage Snipe Mask,303,105,14,0,3,1
-25300,3,15000,1,12,Savage Courage Snipe Mask,303,105,14,0,4,1
-25316,3,15000,1,1,Solitary's Snipe Hat,303,110,14,0,0,1
-25317,3,15000,1,1,Solitary's Snipe Hat,303,110,14,0,1,1
-25318,3,15000,1,1,Solitary's Snipe Hat,303,110,14,0,2,1
-25319,3,15000,1,1,Solitary's Snipe Hat,303,110,14,0,3,1
-25320,3,15000,1,1,Solitary's Snipe Hat,303,110,14,0,4,1
-25336,3,15000,1,6,Hero's Snipe Hood,303,115,14,0,0,1
-25337,3,15000,1,6,Hero's Snipe Hood,303,115,14,0,1,1
-25338,3,15000,1,6,Hero's Snipe Hood,303,115,14,0,2,1
-25339,3,15000,1,6,Hero's Snipe Hood,303,115,14,0,3,1
-25340,3,15000,1,6,Hero's Snipe Hood,303,115,14,0,4,1
-25356,3,15000,1,12,Savage Courage Magic Mask,303,105,15,0,0,1
-25357,3,15000,1,12,Savage Courage Magic Mask,303,105,15,0,1,1
-25358,3,15000,1,12,Savage Courage Magic Mask,303,105,15,0,2,1
-25359,3,15000,1,12,Savage Courage Magic Mask,303,105,15,0,3,1
-25360,3,15000,1,12,Savage Courage Magic Mask,303,105,15,0,4,1
-25376,3,15000,1,1,Solitary Magic Head,303,110,15,0,0,1
-25377,3,15000,1,1,Solitary Magic Head,303,110,15,0,1,1
-25378,3,15000,1,1,Solitary Magic Head,303,110,15,0,2,1
-25379,3,15000,1,1,Solitary Magic Head,303,110,15,0,3,1
-25380,3,15000,1,1,Solitary Magic Head,303,110,15,0,4,1
-25396,3,15000,1,6,Hero's Magic Mask,303,115,15,0,0,1
-25397,3,15000,1,6,Hero's Magic Mask,303,115,15,0,1,1
-25398,3,15000,1,6,Hero's Magic Mask,303,115,15,0,2,1
-25399,3,15000,1,6,Hero's Magic Mask,303,115,15,0,3,1
-25400,3,15000,1,6,Hero's Magic Mask,303,115,15,0,4,1
-25416,3,15000,1,12,Savage Courage Ranger Turban,303,105,17,0,0,1
-25417,3,15000,1,12,Savage Courage Ranger Turban,303,105,17,0,1,1
-25418,3,15000,1,12,Savage Courage Ranger Turban,303,105,17,0,2,1
-25419,3,15000,1,12,Savage Courage Ranger Turban,303,105,17,0,3,1
-25420,3,15000,1,12,Savage Courage Ranger Turban,303,105,17,0,4,1
-25436,3,15000,1,1,Solitary Ranger's Head,303,110,17,0,0,1
-25437,3,15000,1,1,Solitary Ranger's Head,303,110,17,0,1,1
-25438,3,15000,1,1,Solitary Ranger's Head,303,110,17,0,2,1
-25439,3,15000,1,1,Solitary Ranger's Head,303,110,17,0,3,1
-25440,3,15000,1,1,Solitary Ranger's Head,303,110,17,0,4,1
-25456,3,15000,1,6,Hero's Ranger Mask,303,115,17,0,0,1
-25457,3,15000,1,6,Hero's Ranger Mask,303,115,17,0,1,1
-25458,3,15000,1,6,Hero's Ranger Mask,303,115,17,0,2,1
-25459,3,15000,1,6,Hero's Ranger Mask,303,115,17,0,3,1
-25460,3,15000,1,6,Hero's Ranger Mask,303,115,17,0,4,1
+25236,3,15000,1,140,Savage Courage Assault Skull,303,105,12,0,0,1
+25237,3,15000,1,140,Savage Courage Assault Skull,303,105,12,0,1,1
+25238,3,15000,1,140,Savage Courage Assault Skull,303,105,12,0,2,1
+25239,3,15000,1,140,Savage Courage Assault Skull,303,105,12,0,3,1
+25240,3,15000,1,140,Savage Courage Assault Skull,303,105,12,0,4,1
+25256,3,15000,1,145,Solitary Assault Helm,303,110,12,0,0,1
+25257,3,15000,1,145,Solitary Assault Helm,303,110,12,0,1,1
+25258,3,15000,1,145,Solitary Assault Helm,303,110,12,0,2,1
+25259,3,15000,1,145,Solitary Assault Helm,303,110,12,0,3,1
+25260,3,15000,1,145,Solitary Assault Helm,303,110,12,0,4,1
+25276,3,15000,1,150,Hero's Assault Head,303,115,12,0,0,1
+25277,3,15000,1,150,Hero's Assault Head,303,115,12,0,1,1
+25278,3,15000,1,150,Hero's Assault Head,303,115,12,0,2,1
+25279,3,15000,1,150,Hero's Assault Head,303,115,12,0,3,1
+25280,3,15000,1,150,Hero's Assault Head,303,115,12,0,4,1
+25296,3,15000,1,140,Savage Courage Snipe Mask,303,105,14,0,0,1
+25297,3,15000,1,140,Savage Courage Snipe Mask,303,105,14,0,1,1
+25298,3,15000,1,140,Savage Courage Snipe Mask,303,105,14,0,2,1
+25299,3,15000,1,140,Savage Courage Snipe Mask,303,105,14,0,3,1
+25300,3,15000,1,140,Savage Courage Snipe Mask,303,105,14,0,4,1
+25316,3,15000,1,145,Solitary's Snipe Hat,303,110,14,0,0,1
+25317,3,15000,1,145,Solitary's Snipe Hat,303,110,14,0,1,1
+25318,3,15000,1,145,Solitary's Snipe Hat,303,110,14,0,2,1
+25319,3,15000,1,145,Solitary's Snipe Hat,303,110,14,0,3,1
+25320,3,15000,1,145,Solitary's Snipe Hat,303,110,14,0,4,1
+25336,3,15000,1,150,Hero's Snipe Hood,303,115,14,0,0,1
+25337,3,15000,1,150,Hero's Snipe Hood,303,115,14,0,1,1
+25338,3,15000,1,150,Hero's Snipe Hood,303,115,14,0,2,1
+25339,3,15000,1,150,Hero's Snipe Hood,303,115,14,0,3,1
+25340,3,15000,1,150,Hero's Snipe Hood,303,115,14,0,4,1
+25356,3,15000,1,140,Savage Courage Magic Mask,303,105,15,0,0,1
+25357,3,15000,1,140,Savage Courage Magic Mask,303,105,15,0,1,1
+25358,3,15000,1,140,Savage Courage Magic Mask,303,105,15,0,2,1
+25359,3,15000,1,140,Savage Courage Magic Mask,303,105,15,0,3,1
+25360,3,15000,1,140,Savage Courage Magic Mask,303,105,15,0,4,1
+25376,3,15000,1,145,Solitary Magic Head,303,110,15,0,0,1
+25377,3,15000,1,145,Solitary Magic Head,303,110,15,0,1,1
+25378,3,15000,1,145,Solitary Magic Head,303,110,15,0,2,1
+25379,3,15000,1,145,Solitary Magic Head,303,110,15,0,3,1
+25380,3,15000,1,145,Solitary Magic Head,303,110,15,0,4,1
+25396,3,15000,1,150,Hero's Magic Mask,303,115,15,0,0,1
+25397,3,15000,1,150,Hero's Magic Mask,303,115,15,0,1,1
+25398,3,15000,1,150,Hero's Magic Mask,303,115,15,0,2,1
+25399,3,15000,1,150,Hero's Magic Mask,303,115,15,0,3,1
+25400,3,15000,1,150,Hero's Magic Mask,303,115,15,0,4,1
+25416,3,15000,1,140,Savage Courage Ranger Turban,303,105,17,0,0,1
+25417,3,15000,1,140,Savage Courage Ranger Turban,303,105,17,0,1,1
+25418,3,15000,1,140,Savage Courage Ranger Turban,303,105,17,0,2,1
+25419,3,15000,1,140,Savage Courage Ranger Turban,303,105,17,0,3,1
+25420,3,15000,1,140,Savage Courage Ranger Turban,303,105,17,0,4,1
+25436,3,15000,1,145,Solitary Ranger's Head,303,110,17,0,0,1
+25437,3,15000,1,145,Solitary Ranger's Head,303,110,17,0,1,1
+25438,3,15000,1,145,Solitary Ranger's Head,303,110,17,0,2,1
+25439,3,15000,1,145,Solitary Ranger's Head,303,110,17,0,3,1
+25440,3,15000,1,145,Solitary Ranger's Head,303,110,17,0,4,1
+25456,3,15000,1,150,Hero's Ranger Mask,303,115,17,0,0,1
+25457,3,15000,1,150,Hero's Ranger Mask,303,115,17,0,1,1
+25458,3,15000,1,150,Hero's Ranger Mask,303,115,17,0,2,1
+25459,3,15000,1,150,Hero's Ranger Mask,303,115,17,0,3,1
+25460,3,15000,1,150,Hero's Ranger Mask,303,115,17,0,4,1
 25530,3,10000,1,1,Holy Seal's Trust Hood,303,1,0,0,4,1
 25534,3,10000,1,1,Holy Seal's Bliss Hood,303,1,0,0,4,1
 25538,3,10000,1,1,Holy Seal's Grandiose Helm,303,1,0,0,4,1
@@ -13569,11 +13569,11 @@
 3194,3,5180,1,9,Dawn Plate,304,45,12,1,2,1
 4217,3,5180,1,9,Dawn Plate,304,45,12,1,3,1
 5240,3,5180,1,9,Dawn Plate,304,45,12,1,4,1
-560,3,12865,1,3,Faith Armor,304,70,12,1,0,1
-2172,3,12865,1,3,Faith Armor,304,70,12,1,1,1
-3195,3,12865,1,3,Faith Armor,304,70,12,1,2,1
-4218,3,12865,1,3,Faith Armor,304,70,12,1,3,1
-5241,3,12865,1,3,Faith Armor,304,70,12,1,4,1
+560,3,12865,1,35,Faith Armor,304,70,12,1,0,1
+2172,3,12865,1,35,Faith Armor,304,70,12,1,1,1
+3195,3,12865,1,35,Faith Armor,304,70,12,1,2,1
+4218,3,12865,1,35,Faith Armor,304,70,12,1,3,1
+5241,3,12865,1,35,Faith Armor,304,70,12,1,4,1
 561,3,6185,1,10,Silver Cuirass,304,49,12,1,0,1
 2173,3,6185,1,10,Silver Cuirass,304,49,12,1,1,1
 3196,3,6185,1,10,Silver Cuirass,304,49,12,1,2,1
@@ -13699,11 +13699,11 @@
 3298,3,5180,1,9,Hard Skin Armor,304,45,14,1,2,1
 4321,3,5180,1,9,Hard Skin Armor,304,45,14,1,3,1
 5344,3,5180,1,9,Hard Skin Armor,304,45,14,1,4,1
-664,3,12865,1,3,Faith Jacket,304,70,14,1,0,1
-2276,3,12865,1,3,Faith Jacket,304,70,14,1,1,1
-3299,3,12865,1,3,Faith Jacket,304,70,14,1,2,1
-4322,3,12865,1,3,Faith Jacket,304,70,14,1,3,1
-5345,3,12865,1,3,Faith Jacket,304,70,14,1,4,1
+664,3,12865,1,35,Faith Jacket,304,70,14,1,0,1
+2276,3,12865,1,35,Faith Jacket,304,70,14,1,1,1
+3299,3,12865,1,35,Faith Jacket,304,70,14,1,2,1
+4322,3,12865,1,35,Faith Jacket,304,70,14,1,3,1
+5345,3,12865,1,35,Faith Jacket,304,70,14,1,4,1
 665,3,5925,1,10,Spirit Guard,304,46,14,1,0,1
 2277,3,5925,1,10,Spirit Guard,304,46,14,1,1,1
 3300,3,5925,1,10,Spirit Guard,304,46,14,1,2,1
@@ -13749,11 +13749,11 @@
 3308,3,10080,1,12,Rubedo Jacket,304,60,3,1,2,1
 4331,3,10080,1,12,Rubedo Jacket,304,60,3,1,3,1
 5354,3,10080,1,12,Rubedo Jacket,304,60,3,1,4,1
-674,3,11093,1,4,Supernal Jacket,304,65,14,1,0,1
-2286,3,11093,1,4,Supernal Jacket,304,65,14,1,1,1
-3309,3,11093,1,4,Supernal Jacket,304,65,14,1,2,1
-4332,3,11093,1,4,Supernal Jacket,304,65,14,1,3,1
-5355,3,11093,1,4,Supernal Jacket,304,65,14,1,4,1
+674,3,11093,1,20,Supernal Jacket,304,65,14,1,0,1
+2286,3,11093,1,20,Supernal Jacket,304,65,14,1,1,1
+3309,3,11093,1,20,Supernal Jacket,304,65,14,1,2,1
+4332,3,11093,1,20,Supernal Jacket,304,65,14,1,3,1
+5355,3,11093,1,20,Supernal Jacket,304,65,14,1,4,1
 675,3,8780,1,12,Lord of Strider,304,58,14,1,0,1
 2287,3,8780,1,12,Lord of Strider,304,58,14,1,1,1
 3310,3,8780,1,12,Lord of Strider,304,58,14,1,2,1
@@ -13829,11 +13829,11 @@
 3405,3,5180,1,9,Adept's Robe,304,45,15,1,2,1
 4428,3,5180,1,9,Adept's Robe,304,45,15,1,3,1
 5451,3,5180,1,9,Adept's Robe,304,45,15,1,4,1
-771,3,12865,1,3,Faith Robe,304,70,15,1,0,1
-2383,3,12865,1,3,Faith Robe,304,70,15,1,1,1
-3406,3,12865,1,3,Faith Robe,304,70,15,1,2,1
-4429,3,12865,1,3,Faith Robe,304,70,15,1,3,1
-5452,3,12865,1,3,Faith Robe,304,70,15,1,4,1
+771,3,12865,1,35,Faith Robe,304,70,15,1,0,1
+2383,3,12865,1,35,Faith Robe,304,70,15,1,1,1
+3406,3,12865,1,35,Faith Robe,304,70,15,1,2,1
+4429,3,12865,1,35,Faith Robe,304,70,15,1,3,1
+5452,3,12865,1,35,Faith Robe,304,70,15,1,4,1
 772,3,6185,1,11,Delusions Robe,304,52,15,1,0,1
 2384,3,6185,1,11,Delusions Robe,304,52,15,1,1,1
 3407,3,6185,1,11,Delusions Robe,304,52,15,1,2,1
@@ -13964,11 +13964,11 @@
 3512,3,5180,1,9,Enforcer's Coat,304,45,17,1,2,1
 4535,3,5180,1,9,Enforcer's Coat,304,45,17,1,3,1
 5558,3,5180,1,9,Enforcer's Coat,304,45,17,1,4,1
-878,3,12865,1,3,Genius Coat,304,70,17,1,0,1
-2490,3,12865,1,3,Genius Coat,304,70,17,1,1,1
-3513,3,12865,1,3,Genius Coat,304,70,17,1,2,1
-4536,3,12865,1,3,Genius Coat,304,70,17,1,3,1
-5559,3,12865,1,3,Genius Coat,304,70,17,1,4,1
+878,3,12865,1,35,Genius Coat,304,70,17,1,0,1
+2490,3,12865,1,35,Genius Coat,304,70,17,1,1,1
+3513,3,12865,1,35,Genius Coat,304,70,17,1,2,1
+4536,3,12865,1,35,Genius Coat,304,70,17,1,3,1
+5559,3,12865,1,35,Genius Coat,304,70,17,1,4,1
 879,3,6185,1,12,Maverick Coat,304,56,17,1,0,1
 2491,3,6185,1,12,Maverick Coat,304,56,17,1,1,1
 3514,3,6185,1,12,Maverick Coat,304,56,17,1,2,1
@@ -14019,11 +14019,11 @@
 3523,3,8780,1,12,Coat of the Covenant,304,58,17,1,2,1
 4546,3,8780,1,12,Coat of the Covenant,304,58,17,1,3,1
 5569,3,8780,1,12,Coat of the Covenant,304,58,17,1,4,1
-889,3,11093,1,4,Heavenly Coat,304,65,17,1,0,1
-2501,3,11093,1,4,Heavenly Coat,304,65,17,1,1,1
-3524,3,11093,1,4,Heavenly Coat,304,65,17,1,2,1
-4547,3,11093,1,4,Heavenly Coat,304,65,17,1,3,1
-5570,3,11093,1,4,Heavenly Coat,304,65,17,1,4,1
+889,3,11093,1,20,Heavenly Coat,304,65,17,1,0,1
+2501,3,11093,1,20,Heavenly Coat,304,65,17,1,1,1
+3524,3,11093,1,20,Heavenly Coat,304,65,17,1,2,1
+4547,3,11093,1,20,Heavenly Coat,304,65,17,1,3,1
+5570,3,11093,1,20,Heavenly Coat,304,65,17,1,4,1
 953,3,250,1,4,Raider's Vest,304,16,0,1,0,1
 2565,3,250,1,4,Raider's Vest,304,16,0,1,1,1
 3588,3,250,1,4,Raider's Vest,304,16,0,1,2,1
@@ -14258,8 +14258,8 @@
 10428,3,4000,1,12,Enforcer's Sacred Armor (Crimson),304,1,0,4,2,1
 10429,3,4000,1,12,Enforcer's Sacred Armor (Crimson),304,1,0,4,3,1
 10430,3,4000,1,12,Enforcer's Sacred Armor (Crimson),304,1,0,4,4,1
-10435,3,5000,1,9,Enforcer's Sacred Armor (Moonflower),304,55,0,4,4,1
-10440,3,5000,1,8,Enforcer's Sacred Armor (Dark Night),304,60,0,4,4,1
+10435,3,5000,1,25,Enforcer's Sacred Armor (Moonflower),304,55,0,4,4,1
+10440,3,5000,1,40,Enforcer's Sacred Armor (Dark Night),304,60,0,4,4,1
 10923,3,5000,1,12,Rathalos Mail,304,30,13,4,0,1
 10924,3,5000,1,12,Rathalos Mail,304,30,13,4,1,1
 10925,3,5000,1,12,Rathalos Mail,304,30,13,4,2,1
@@ -14270,682 +14270,682 @@
 10930,3,5000,1,12,Rathian Mail,304,30,16,4,2,1
 10931,3,5000,1,12,Rathian Mail,304,30,16,4,3,1
 10932,3,5000,1,12,Rathian Mail,304,30,16,4,4,1
-10933,3,5000,1,7,Silver Sol Mail,304,55,13,4,0,1
-10934,3,5000,1,7,Silver Sol Mail,304,55,13,4,1,1
-10935,3,5000,1,7,Silver Sol Mail,304,55,13,4,2,1
-10936,3,5000,1,7,Silver Sol Mail,304,55,13,4,3,1
-10937,3,5000,1,7,Silver Sol Mail,304,55,13,4,4,1
-10938,3,5000,1,7,Gold Luna Mail,304,55,16,4,0,1
-10939,3,5000,1,7,Gold Luna Mail,304,55,16,4,1,1
-10940,3,5000,1,7,Gold Luna Mail,304,55,16,4,2,1
-10941,3,5000,1,7,Gold Luna Mail,304,55,16,4,3,1
-10942,3,5000,1,7,Gold Luna Mail,304,55,16,4,4,1
+10933,3,5000,1,55,Silver Sol Mail,304,55,13,4,0,1
+10934,3,5000,1,55,Silver Sol Mail,304,55,13,4,1,1
+10935,3,5000,1,55,Silver Sol Mail,304,55,13,4,2,1
+10936,3,5000,1,55,Silver Sol Mail,304,55,13,4,3,1
+10937,3,5000,1,55,Silver Sol Mail,304,55,13,4,4,1
+10938,3,5000,1,55,Gold Luna Mail,304,55,16,4,0,1
+10939,3,5000,1,55,Gold Luna Mail,304,55,16,4,1,1
+10940,3,5000,1,55,Gold Luna Mail,304,55,16,4,2,1
+10941,3,5000,1,55,Gold Luna Mail,304,55,16,4,3,1
+10942,3,5000,1,55,Gold Luna Mail,304,55,16,4,4,1
 11750,3,6000,1,1,Invisible Coat,304,1,0,0,0,1
-12656,3,11093,1,4,Damascus Plate,304,65,12,1,0,1
-12657,3,11093,1,4,Damascus Plate,304,65,12,1,1,1
-12658,3,11093,1,4,Damascus Plate,304,65,12,1,2,1
-12659,3,11093,1,4,Damascus Plate,304,65,12,1,3,1
-12660,3,11093,1,4,Damascus Plate,304,65,12,1,4,1
-12661,3,11093,1,9,Immortal's Surcoat,304,65,12,1,0,1
-12662,3,11093,1,9,Immortal's Surcoat,304,65,12,1,1,1
-12663,3,11093,1,9,Immortal's Surcoat,304,65,12,1,2,1
-12664,3,11093,1,9,Immortal's Surcoat,304,65,12,1,3,1
-12665,3,11093,1,9,Immortal's Surcoat,304,65,12,1,4,1
-12666,3,11093,1,14,Enlightenment Armor,304,65,12,1,0,1
-12667,3,11093,1,14,Enlightenment Armor,304,65,12,1,1,1
-12668,3,11093,1,14,Enlightenment Armor,304,65,12,1,2,1
-12669,3,11093,1,14,Enlightenment Armor,304,65,12,1,3,1
-12670,3,11093,1,14,Enlightenment Armor,304,65,12,1,4,1
-12671,3,11786,1,14,Wild Plate,304,67,12,1,0,1
-12672,3,11786,1,14,Wild Plate,304,67,12,1,1,1
-12673,3,11786,1,14,Wild Plate,304,67,12,1,2,1
-12674,3,11786,1,14,Wild Plate,304,67,12,1,3,1
-12675,3,11786,1,14,Wild Plate,304,67,12,1,4,1
-12676,3,12865,1,8,Alloy Armor,304,70,12,1,0,1
-12677,3,12865,1,8,Alloy Armor,304,70,12,1,1,1
-12678,3,12865,1,8,Alloy Armor,304,70,12,1,2,1
-12679,3,12865,1,8,Alloy Armor,304,70,12,1,3,1
-12680,3,12865,1,8,Alloy Armor,304,70,12,1,4,1
-12681,3,12865,1,13,Predator Armor,304,70,12,1,0,1
-12682,3,12865,1,13,Predator Armor,304,70,12,1,1,1
-12683,3,12865,1,13,Predator Armor,304,70,12,1,2,1
-12684,3,12865,1,13,Predator Armor,304,70,12,1,3,1
-12685,3,12865,1,13,Predator Armor,304,70,12,1,4,1
-12686,3,11093,1,4,Stream Robe,304,65,15,1,0,1
-12687,3,11093,1,4,Stream Robe,304,65,15,1,1,1
-12688,3,11093,1,4,Stream Robe,304,65,15,1,2,1
-12689,3,11093,1,4,Stream Robe,304,65,15,1,3,1
-12690,3,11093,1,4,Stream Robe,304,65,15,1,4,1
-12691,3,11093,1,9,Jacket of Integrity,304,65,15,1,0,1
-12692,3,11093,1,9,Jacket of Integrity,304,65,15,1,1,1
-12693,3,11093,1,9,Jacket of Integrity,304,65,15,1,2,1
-12694,3,11093,1,9,Jacket of Integrity,304,65,15,1,3,1
-12695,3,11093,1,9,Jacket of Integrity,304,65,15,1,4,1
-12696,3,11093,1,14,Bishop Robe,304,65,15,1,0,1
-12697,3,11093,1,14,Bishop Robe,304,65,15,1,1,1
-12698,3,11093,1,14,Bishop Robe,304,65,15,1,2,1
-12699,3,11093,1,14,Bishop Robe,304,65,15,1,3,1
-12700,3,11093,1,14,Bishop Robe,304,65,15,1,4,1
-12701,3,11786,1,14,Morality Robe,304,67,15,1,0,1
-12702,3,11786,1,14,Morality Robe,304,67,15,1,1,1
-12703,3,11786,1,14,Morality Robe,304,67,15,1,2,1
-12704,3,11786,1,14,Morality Robe,304,67,15,1,3,1
-12705,3,11786,1,14,Morality Robe,304,67,15,1,4,1
-12706,3,12865,1,8,Libertas Robe,304,70,15,1,0,1
-12707,3,12865,1,8,Libertas Robe,304,70,15,1,1,1
-12708,3,12865,1,8,Libertas Robe,304,70,15,1,2,1
-12709,3,12865,1,8,Libertas Robe,304,70,15,1,3,1
-12710,3,12865,1,8,Libertas Robe,304,70,15,1,4,1
-12711,3,12865,1,13,Carrion Breastplate,304,70,15,1,0,1
-12712,3,12865,1,13,Carrion Breastplate,304,70,15,1,1,1
-12713,3,12865,1,13,Carrion Breastplate,304,70,15,1,2,1
-12714,3,12865,1,13,Carrion Breastplate,304,70,15,1,3,1
-12715,3,12865,1,13,Carrion Breastplate,304,70,15,1,4,1
+12656,3,11093,1,20,Damascus Plate,304,65,12,1,0,1
+12657,3,11093,1,20,Damascus Plate,304,65,12,1,1,1
+12658,3,11093,1,20,Damascus Plate,304,65,12,1,2,1
+12659,3,11093,1,20,Damascus Plate,304,65,12,1,3,1
+12660,3,11093,1,20,Damascus Plate,304,65,12,1,4,1
+12661,3,11093,1,25,Immortal's Surcoat,304,65,12,1,0,1
+12662,3,11093,1,25,Immortal's Surcoat,304,65,12,1,1,1
+12663,3,11093,1,25,Immortal's Surcoat,304,65,12,1,2,1
+12664,3,11093,1,25,Immortal's Surcoat,304,65,12,1,3,1
+12665,3,11093,1,25,Immortal's Surcoat,304,65,12,1,4,1
+12666,3,11093,1,30,Enlightenment Armor,304,65,12,1,0,1
+12667,3,11093,1,30,Enlightenment Armor,304,65,12,1,1,1
+12668,3,11093,1,30,Enlightenment Armor,304,65,12,1,2,1
+12669,3,11093,1,30,Enlightenment Armor,304,65,12,1,3,1
+12670,3,11093,1,30,Enlightenment Armor,304,65,12,1,4,1
+12671,3,11786,1,30,Wild Plate,304,67,12,1,0,1
+12672,3,11786,1,30,Wild Plate,304,67,12,1,1,1
+12673,3,11786,1,30,Wild Plate,304,67,12,1,2,1
+12674,3,11786,1,30,Wild Plate,304,67,12,1,3,1
+12675,3,11786,1,30,Wild Plate,304,67,12,1,4,1
+12676,3,12865,1,40,Alloy Armor,304,70,12,1,0,1
+12677,3,12865,1,40,Alloy Armor,304,70,12,1,1,1
+12678,3,12865,1,40,Alloy Armor,304,70,12,1,2,1
+12679,3,12865,1,40,Alloy Armor,304,70,12,1,3,1
+12680,3,12865,1,40,Alloy Armor,304,70,12,1,4,1
+12681,3,12865,1,45,Predator Armor,304,70,12,1,0,1
+12682,3,12865,1,45,Predator Armor,304,70,12,1,1,1
+12683,3,12865,1,45,Predator Armor,304,70,12,1,2,1
+12684,3,12865,1,45,Predator Armor,304,70,12,1,3,1
+12685,3,12865,1,45,Predator Armor,304,70,12,1,4,1
+12686,3,11093,1,20,Stream Robe,304,65,15,1,0,1
+12687,3,11093,1,20,Stream Robe,304,65,15,1,1,1
+12688,3,11093,1,20,Stream Robe,304,65,15,1,2,1
+12689,3,11093,1,20,Stream Robe,304,65,15,1,3,1
+12690,3,11093,1,20,Stream Robe,304,65,15,1,4,1
+12691,3,11093,1,25,Jacket of Integrity,304,65,15,1,0,1
+12692,3,11093,1,25,Jacket of Integrity,304,65,15,1,1,1
+12693,3,11093,1,25,Jacket of Integrity,304,65,15,1,2,1
+12694,3,11093,1,25,Jacket of Integrity,304,65,15,1,3,1
+12695,3,11093,1,25,Jacket of Integrity,304,65,15,1,4,1
+12696,3,11093,1,30,Bishop Robe,304,65,15,1,0,1
+12697,3,11093,1,30,Bishop Robe,304,65,15,1,1,1
+12698,3,11093,1,30,Bishop Robe,304,65,15,1,2,1
+12699,3,11093,1,30,Bishop Robe,304,65,15,1,3,1
+12700,3,11093,1,30,Bishop Robe,304,65,15,1,4,1
+12701,3,11786,1,30,Morality Robe,304,67,15,1,0,1
+12702,3,11786,1,30,Morality Robe,304,67,15,1,1,1
+12703,3,11786,1,30,Morality Robe,304,67,15,1,2,1
+12704,3,11786,1,30,Morality Robe,304,67,15,1,3,1
+12705,3,11786,1,30,Morality Robe,304,67,15,1,4,1
+12706,3,12865,1,40,Libertas Robe,304,70,15,1,0,1
+12707,3,12865,1,40,Libertas Robe,304,70,15,1,1,1
+12708,3,12865,1,40,Libertas Robe,304,70,15,1,2,1
+12709,3,12865,1,40,Libertas Robe,304,70,15,1,3,1
+12710,3,12865,1,40,Libertas Robe,304,70,15,1,4,1
+12711,3,12865,1,45,Carrion Breastplate,304,70,15,1,0,1
+12712,3,12865,1,45,Carrion Breastplate,304,70,15,1,1,1
+12713,3,12865,1,45,Carrion Breastplate,304,70,15,1,2,1
+12714,3,12865,1,45,Carrion Breastplate,304,70,15,1,3,1
+12715,3,12865,1,45,Carrion Breastplate,304,70,15,1,4,1
 12716,3,10093,1,15,Coat of Gloom,304,62,17,1,0,1
 12717,3,10093,1,15,Coat of Gloom,304,62,17,1,1,1
 12718,3,10093,1,15,Coat of Gloom,304,62,17,1,2,1
 12719,3,10093,1,15,Coat of Gloom,304,62,17,1,3,1
 12720,3,10093,1,15,Coat of Gloom,304,62,17,1,4,1
-12721,3,11093,1,9,Robe of Wisemen,304,65,17,1,0,1
-12722,3,11093,1,9,Robe of Wisemen,304,65,17,1,1,1
-12723,3,11093,1,9,Robe of Wisemen,304,65,17,1,2,1
-12724,3,11093,1,9,Robe of Wisemen,304,65,17,1,3,1
-12725,3,11093,1,9,Robe of Wisemen,304,65,17,1,4,1
-12726,3,11093,1,14,Saint's Apron,304,65,17,1,0,1
-12727,3,11093,1,14,Saint's Apron,304,65,17,1,1,1
-12728,3,11093,1,14,Saint's Apron,304,65,17,1,2,1
-12729,3,11093,1,14,Saint's Apron,304,65,17,1,3,1
-12730,3,11093,1,14,Saint's Apron,304,65,17,1,4,1
-12731,3,11786,1,14,Roaming Coat,304,67,17,1,0,1
-12732,3,11786,1,14,Roaming Coat,304,67,17,1,1,1
-12733,3,11786,1,14,Roaming Coat,304,67,17,1,2,1
-12734,3,11786,1,14,Roaming Coat,304,67,17,1,3,1
-12735,3,11786,1,14,Roaming Coat,304,67,17,1,4,1
-12736,3,12865,1,8,Coat of Certainty,304,70,17,1,0,1
-12737,3,12865,1,8,Coat of Certainty,304,70,17,1,1,1
-12738,3,12865,1,8,Coat of Certainty,304,70,17,1,2,1
-12739,3,12865,1,8,Coat of Certainty,304,70,17,1,3,1
-12740,3,12865,1,8,Coat of Certainty,304,70,17,1,4,1
-12741,3,12865,1,13,Scholarly Coat,304,70,17,1,0,1
-12742,3,12865,1,13,Scholarly Coat,304,70,17,1,1,1
-12743,3,12865,1,13,Scholarly Coat,304,70,17,1,2,1
-12744,3,12865,1,13,Scholarly Coat,304,70,17,1,3,1
-12745,3,12865,1,13,Scholarly Coat,304,70,17,1,4,1
+12721,3,11093,1,25,Robe of Wisemen,304,65,17,1,0,1
+12722,3,11093,1,25,Robe of Wisemen,304,65,17,1,1,1
+12723,3,11093,1,25,Robe of Wisemen,304,65,17,1,2,1
+12724,3,11093,1,25,Robe of Wisemen,304,65,17,1,3,1
+12725,3,11093,1,25,Robe of Wisemen,304,65,17,1,4,1
+12726,3,11093,1,30,Saint's Apron,304,65,17,1,0,1
+12727,3,11093,1,30,Saint's Apron,304,65,17,1,1,1
+12728,3,11093,1,30,Saint's Apron,304,65,17,1,2,1
+12729,3,11093,1,30,Saint's Apron,304,65,17,1,3,1
+12730,3,11093,1,30,Saint's Apron,304,65,17,1,4,1
+12731,3,11786,1,30,Roaming Coat,304,67,17,1,0,1
+12732,3,11786,1,30,Roaming Coat,304,67,17,1,1,1
+12733,3,11786,1,30,Roaming Coat,304,67,17,1,2,1
+12734,3,11786,1,30,Roaming Coat,304,67,17,1,3,1
+12735,3,11786,1,30,Roaming Coat,304,67,17,1,4,1
+12736,3,12865,1,40,Coat of Certainty,304,70,17,1,0,1
+12737,3,12865,1,40,Coat of Certainty,304,70,17,1,1,1
+12738,3,12865,1,40,Coat of Certainty,304,70,17,1,2,1
+12739,3,12865,1,40,Coat of Certainty,304,70,17,1,3,1
+12740,3,12865,1,40,Coat of Certainty,304,70,17,1,4,1
+12741,3,12865,1,45,Scholarly Coat,304,70,17,1,0,1
+12742,3,12865,1,45,Scholarly Coat,304,70,17,1,1,1
+12743,3,12865,1,45,Scholarly Coat,304,70,17,1,2,1
+12744,3,12865,1,45,Scholarly Coat,304,70,17,1,3,1
+12745,3,12865,1,45,Scholarly Coat,304,70,17,1,4,1
 12746,3,10093,1,15,Rover Jacket,304,62,14,1,0,1
 12747,3,10093,1,15,Rover Jacket,304,62,14,1,1,1
 12748,3,10093,1,15,Rover Jacket,304,62,14,1,2,1
 12749,3,10093,1,15,Rover Jacket,304,62,14,1,3,1
 12750,3,10093,1,15,Rover Jacket,304,62,14,1,4,1
-12751,3,11093,1,9,Eagle Jacket,304,65,14,1,0,1
-12752,3,11093,1,9,Eagle Jacket,304,65,14,1,1,1
-12753,3,11093,1,9,Eagle Jacket,304,65,14,1,2,1
-12754,3,11093,1,9,Eagle Jacket,304,65,14,1,3,1
-12755,3,11093,1,9,Eagle Jacket,304,65,14,1,4,1
-12756,3,11093,1,14,Paladin Coat,304,65,14,1,0,1
-12757,3,11093,1,14,Paladin Coat,304,65,14,1,1,1
-12758,3,11093,1,14,Paladin Coat,304,65,14,1,2,1
-12759,3,11093,1,14,Paladin Coat,304,65,14,1,3,1
-12760,3,11093,1,14,Paladin Coat,304,65,14,1,4,1
-12761,3,11786,1,14,Sentinel Jacket,304,67,14,1,0,1
-12762,3,11786,1,14,Sentinel Jacket,304,67,14,1,1,1
-12763,3,11786,1,14,Sentinel Jacket,304,67,14,1,2,1
-12764,3,11786,1,14,Sentinel Jacket,304,67,14,1,3,1
-12765,3,11786,1,14,Sentinel Jacket,304,67,14,1,4,1
-12766,3,12865,1,8,Aquila Armor,304,70,14,1,0,1
-12767,3,12865,1,8,Aquila Armor,304,70,14,1,1,1
-12768,3,12865,1,8,Aquila Armor,304,70,14,1,2,1
-12769,3,12865,1,8,Aquila Armor,304,70,14,1,3,1
-12770,3,12865,1,8,Aquila Armor,304,70,14,1,4,1
-12771,3,12865,1,13,Garb of Concealment,304,70,14,1,0,1
-12772,3,12865,1,13,Garb of Concealment,304,70,14,1,1,1
-12773,3,12865,1,13,Garb of Concealment,304,70,14,1,2,1
-12774,3,12865,1,13,Garb of Concealment,304,70,14,1,3,1
-12775,3,12865,1,13,Garb of Concealment,304,70,14,1,4,1
+12751,3,11093,1,25,Eagle Jacket,304,65,14,1,0,1
+12752,3,11093,1,25,Eagle Jacket,304,65,14,1,1,1
+12753,3,11093,1,25,Eagle Jacket,304,65,14,1,2,1
+12754,3,11093,1,25,Eagle Jacket,304,65,14,1,3,1
+12755,3,11093,1,25,Eagle Jacket,304,65,14,1,4,1
+12756,3,11093,1,30,Paladin Coat,304,65,14,1,0,1
+12757,3,11093,1,30,Paladin Coat,304,65,14,1,1,1
+12758,3,11093,1,30,Paladin Coat,304,65,14,1,2,1
+12759,3,11093,1,30,Paladin Coat,304,65,14,1,3,1
+12760,3,11093,1,30,Paladin Coat,304,65,14,1,4,1
+12761,3,11786,1,30,Sentinel Jacket,304,67,14,1,0,1
+12762,3,11786,1,30,Sentinel Jacket,304,67,14,1,1,1
+12763,3,11786,1,30,Sentinel Jacket,304,67,14,1,2,1
+12764,3,11786,1,30,Sentinel Jacket,304,67,14,1,3,1
+12765,3,11786,1,30,Sentinel Jacket,304,67,14,1,4,1
+12766,3,12865,1,40,Aquila Armor,304,70,14,1,0,1
+12767,3,12865,1,40,Aquila Armor,304,70,14,1,1,1
+12768,3,12865,1,40,Aquila Armor,304,70,14,1,2,1
+12769,3,12865,1,40,Aquila Armor,304,70,14,1,3,1
+12770,3,12865,1,40,Aquila Armor,304,70,14,1,4,1
+12771,3,12865,1,45,Garb of Concealment,304,70,14,1,0,1
+12772,3,12865,1,45,Garb of Concealment,304,70,14,1,1,1
+12773,3,12865,1,45,Garb of Concealment,304,70,14,1,2,1
+12774,3,12865,1,45,Garb of Concealment,304,70,14,1,3,1
+12775,3,12865,1,45,Garb of Concealment,304,70,14,1,4,1
 13043,3,999,1,12,Sunny Pareo,304,55,0,1,0,1
 13044,3,999,1,12,Sunny Pareo,304,55,0,1,1,1
 13045,3,999,1,12,Sunny Pareo,304,55,0,1,2,1
 13046,3,999,1,12,Sunny Pareo,304,55,0,1,3,1
 13047,3,999,1,12,Sunny Pareo,304,55,0,1,4,1
-13048,3,999,1,13,Red Dragon Scale Coat,304,72,0,1,0,1
-13049,3,999,1,13,Red Dragon Scale Coat,304,72,0,1,1,1
-13050,3,999,1,13,Red Dragon Scale Coat,304,72,0,1,2,1
-13051,3,999,1,13,Red Dragon Scale Coat,304,72,0,1,3,1
-13052,3,999,1,13,Red Dragon Scale Coat,304,72,0,1,4,1
+13048,3,999,1,45,Red Dragon Scale Coat,304,72,0,1,0,1
+13049,3,999,1,45,Red Dragon Scale Coat,304,72,0,1,1,1
+13050,3,999,1,45,Red Dragon Scale Coat,304,72,0,1,2,1
+13051,3,999,1,45,Red Dragon Scale Coat,304,72,0,1,3,1
+13052,3,999,1,45,Red Dragon Scale Coat,304,72,0,1,4,1
 13595,3,17500,1,11,Marquis Armor,304,1,0,4,0,1
 13596,3,17500,1,11,Marquis Armor,304,1,0,4,1,1
 13597,3,17500,1,11,Marquis Armor,304,1,0,4,2,1
 13598,3,17500,1,11,Marquis Armor,304,1,0,4,3,1
 13599,3,17500,1,11,Marquis Armor,304,1,0,4,4,1
-14988,3,16802,1,11,Finnegan's Breastplate,304,80,0,4,0,1
-14989,3,16802,1,11,Finnegan's Breastplate,304,80,0,4,1,1
-14990,3,16802,1,11,Finnegan's Breastplate,304,80,0,4,2,1
-14991,3,16802,1,11,Finnegan's Breastplate,304,80,0,4,3,1
-14992,3,16802,1,11,Finnegan's Breastplate,304,80,0,4,4,1
-14993,3,16802,1,11,Greedy Breastplate,304,80,0,4,0,1
-14994,3,16802,1,11,Greedy Breastplate,304,80,0,4,1,1
-14995,3,16802,1,11,Greedy Breastplate,304,80,0,4,2,1
-14996,3,16802,1,11,Greedy Breastplate,304,80,0,4,3,1
-14997,3,16802,1,11,Greedy Breastplate,304,80,0,4,4,1
-14998,3,5000,1,7,Duke Armor (Dark Night),304,70,0,4,4,1
-15003,3,5000,1,6,Duke Armor (Moonflower),304,75,0,4,4,1
-15008,3,14768,1,2,Executioner's Belt,304,75,12,1,0,1
-15009,3,14768,1,2,Executioner's Belt,304,75,12,1,1,1
-15010,3,14768,1,2,Executioner's Belt,304,75,12,1,2,1
-15011,3,14768,1,2,Executioner's Belt,304,75,12,1,3,1
-15012,3,14768,1,2,Executioner's Belt,304,75,12,1,4,1
-15013,3,14768,1,7,Ancient Beast Half Plate,304,75,12,1,0,1
-15014,3,14768,1,7,Ancient Beast Half Plate,304,75,12,1,1,1
-15015,3,14768,1,7,Ancient Beast Half Plate,304,75,12,1,2,1
-15016,3,14768,1,7,Ancient Beast Half Plate,304,75,12,1,3,1
-15017,3,14768,1,7,Ancient Beast Half Plate,304,75,12,1,4,1
-15018,3,14768,1,12,Mail of Genocide,304,75,12,1,0,1
-15019,3,14768,1,12,Mail of Genocide,304,75,12,1,1,1
-15020,3,14768,1,12,Mail of Genocide,304,75,12,1,2,1
-15021,3,14768,1,12,Mail of Genocide,304,75,12,1,3,1
-15022,3,14768,1,12,Mail of Genocide,304,75,12,1,4,1
-15023,3,15566,1,12,Royal Guardsman's Surcoat,304,77,12,1,0,1
-15024,3,15566,1,12,Royal Guardsman's Surcoat,304,77,12,1,1,1
-15025,3,15566,1,12,Royal Guardsman's Surcoat,304,77,12,1,2,1
-15026,3,15566,1,12,Royal Guardsman's Surcoat,304,77,12,1,3,1
-15027,3,15566,1,12,Royal Guardsman's Surcoat,304,77,12,1,4,1
-15028,3,16802,1,1,Northern Arrêt,304,80,12,1,0,1
-15029,3,16802,1,1,Northern Arrêt,304,80,12,1,1,1
-15030,3,16802,1,1,Northern Arrêt,304,80,12,1,2,1
-15031,3,16802,1,1,Northern Arrêt,304,80,12,1,3,1
-15032,3,16802,1,1,Northern Arrêt,304,80,12,1,4,1
-15033,3,16802,1,6,Knight Armor of Dawn,304,80,12,1,0,1
-15034,3,16802,1,6,Knight Armor of Dawn,304,80,12,1,1,1
-15035,3,16802,1,6,Knight Armor of Dawn,304,80,12,1,2,1
-15036,3,16802,1,6,Knight Armor of Dawn,304,80,12,1,3,1
-15037,3,16802,1,6,Knight Armor of Dawn,304,80,12,1,4,1
-15038,3,16802,1,11,Azure Mail,304,80,12,1,0,1
-15039,3,16802,1,11,Azure Mail,304,80,12,1,1,1
-15040,3,16802,1,11,Azure Mail,304,80,12,1,2,1
-15041,3,16802,1,11,Azure Mail,304,80,12,1,3,1
-15042,3,16802,1,11,Azure Mail,304,80,12,1,4,1
-15063,3,14768,1,2,Innocent Vestment,304,75,15,1,0,1
-15064,3,14768,1,2,Innocent Vestment,304,75,15,1,1,1
-15065,3,14768,1,2,Innocent Vestment,304,75,15,1,2,1
-15066,3,14768,1,2,Innocent Vestment,304,75,15,1,3,1
-15067,3,14768,1,2,Innocent Vestment,304,75,15,1,4,1
-15068,3,14768,1,7,Crimson Robe,304,75,15,1,0,1
-15069,3,14768,1,7,Crimson Robe,304,75,15,1,1,1
-15070,3,14768,1,7,Crimson Robe,304,75,15,1,2,1
-15071,3,14768,1,7,Crimson Robe,304,75,15,1,3,1
-15072,3,14768,1,7,Crimson Robe,304,75,15,1,4,1
-15073,3,14768,1,12,Enhanced Jacket,304,75,15,1,0,1
-15074,3,14768,1,12,Enhanced Jacket,304,75,15,1,1,1
-15075,3,14768,1,12,Enhanced Jacket,304,75,15,1,2,1
-15076,3,14768,1,12,Enhanced Jacket,304,75,15,1,3,1
-15077,3,14768,1,12,Enhanced Jacket,304,75,15,1,4,1
-15043,3,15566,1,12,Medium Robe,304,77,15,1,0,1
-15044,3,15566,1,12,Medium Robe,304,77,15,1,1,1
-15045,3,15566,1,12,Medium Robe,304,77,15,1,2,1
-15046,3,15566,1,12,Medium Robe,304,77,15,1,3,1
-15047,3,15566,1,12,Medium Robe,304,77,15,1,4,1
-15048,3,16802,1,1,Garrisoner's Coat,304,80,15,1,0,1
-15049,3,16802,1,1,Garrisoner's Coat,304,80,15,1,1,1
-15050,3,16802,1,1,Garrisoner's Coat,304,80,15,1,2,1
-15051,3,16802,1,1,Garrisoner's Coat,304,80,15,1,3,1
-15052,3,16802,1,1,Garrisoner's Coat,304,80,15,1,4,1
-15053,3,16802,1,6,Ginkgo-dyed Robe,304,80,15,1,0,1
-15054,3,16802,1,6,Ginkgo-dyed Robe,304,80,15,1,1,1
-15055,3,16802,1,6,Ginkgo-dyed Robe,304,80,15,1,2,1
-15056,3,16802,1,6,Ginkgo-dyed Robe,304,80,15,1,3,1
-15057,3,16802,1,6,Ginkgo-dyed Robe,304,80,15,1,4,1
-15058,3,16802,1,11,Azure Robe,304,80,15,1,0,1
-15059,3,16802,1,11,Azure Robe,304,80,15,1,1,1
-15060,3,16802,1,11,Azure Robe,304,80,15,1,2,1
-15061,3,16802,1,11,Azure Robe,304,80,15,1,3,1
-15062,3,16802,1,11,Azure Robe,304,80,15,1,4,1
-15078,3,14768,1,2,Continent Jacket,304,75,17,1,0,1
-15079,3,14768,1,2,Continent Jacket,304,75,17,1,1,1
-15080,3,14768,1,2,Continent Jacket,304,75,17,1,2,1
-15081,3,14768,1,2,Continent Jacket,304,75,17,1,3,1
-15082,3,14768,1,2,Continent Jacket,304,75,17,1,4,1
-15083,3,14768,1,7,Coat of Keen Insight,304,75,17,1,0,1
-15084,3,14768,1,7,Coat of Keen Insight,304,75,17,1,1,1
-15085,3,14768,1,7,Coat of Keen Insight,304,75,17,1,2,1
-15086,3,14768,1,7,Coat of Keen Insight,304,75,17,1,3,1
-15087,3,14768,1,7,Coat of Keen Insight,304,75,17,1,4,1
-15088,3,14768,1,12,Fortress Plate,304,75,17,1,0,1
-15089,3,14768,1,12,Fortress Plate,304,75,17,1,1,1
-15090,3,14768,1,12,Fortress Plate,304,75,17,1,2,1
-15091,3,14768,1,12,Fortress Plate,304,75,17,1,3,1
-15092,3,14768,1,12,Fortress Plate,304,75,17,1,4,1
-15093,3,15566,1,12,Jacket of Benevolence,304,77,17,1,0,1
-15094,3,15566,1,12,Jacket of Benevolence,304,77,17,1,1,1
-15095,3,15566,1,12,Jacket of Benevolence,304,77,17,1,2,1
-15096,3,15566,1,12,Jacket of Benevolence,304,77,17,1,3,1
-15097,3,15566,1,12,Jacket of Benevolence,304,77,17,1,4,1
-15098,3,16802,1,1,Monochrome Robe,304,80,17,1,0,1
-15099,3,16802,1,1,Monochrome Robe,304,80,17,1,1,1
-15100,3,16802,1,1,Monochrome Robe,304,80,17,1,2,1
-15101,3,16802,1,1,Monochrome Robe,304,80,17,1,3,1
-15102,3,16802,1,1,Monochrome Robe,304,80,17,1,4,1
-15103,3,16802,1,6,Dark Red Haubergeon,304,80,17,1,0,1
-15104,3,16802,1,6,Dark Red Haubergeon,304,80,17,1,1,1
-15105,3,16802,1,6,Dark Red Haubergeon,304,80,17,1,2,1
-15106,3,16802,1,6,Dark Red Haubergeon,304,80,17,1,3,1
-15107,3,16802,1,6,Dark Red Haubergeon,304,80,17,1,4,1
-15108,3,16802,1,11,Azure Preventer,304,80,17,1,0,1
-15109,3,16802,1,11,Azure Preventer,304,80,17,1,1,1
-15110,3,16802,1,11,Azure Preventer,304,80,17,1,2,1
-15111,3,16802,1,11,Azure Preventer,304,80,17,1,3,1
-15112,3,16802,1,11,Azure Preventer,304,80,17,1,4,1
-15113,3,14768,1,2,Mountaineer Chest,304,75,14,1,0,1
-15114,3,14768,1,2,Mountaineer Chest,304,75,14,1,1,1
-15115,3,14768,1,2,Mountaineer Chest,304,75,14,1,2,1
-15116,3,14768,1,2,Mountaineer Chest,304,75,14,1,3,1
-15117,3,14768,1,2,Mountaineer Chest,304,75,14,1,4,1
-15118,3,14768,1,7,Ocean's Jacket,304,75,14,1,0,1
-15119,3,14768,1,7,Ocean's Jacket,304,75,14,1,1,1
-15120,3,14768,1,7,Ocean's Jacket,304,75,14,1,2,1
-15121,3,14768,1,7,Ocean's Jacket,304,75,14,1,3,1
-15122,3,14768,1,7,Ocean's Jacket,304,75,14,1,4,1
-15123,3,14768,1,12,Forest Clothes,304,75,14,1,0,1
-15124,3,14768,1,12,Forest Clothes,304,75,14,1,1,1
-15125,3,14768,1,12,Forest Clothes,304,75,14,1,2,1
-15126,3,14768,1,12,Forest Clothes,304,75,14,1,3,1
-15127,3,14768,1,12,Forest Clothes,304,75,14,1,4,1
-15128,3,15566,1,12,Black Panther Padding,304,77,14,1,0,1
-15129,3,15566,1,12,Black Panther Padding,304,77,14,1,1,1
-15130,3,15566,1,12,Black Panther Padding,304,77,14,1,2,1
-15131,3,15566,1,12,Black Panther Padding,304,77,14,1,3,1
-15132,3,15566,1,12,Black Panther Padding,304,77,14,1,4,1
-15133,3,16802,1,1,Patrician Jacket,304,80,14,1,0,1
-15134,3,16802,1,1,Patrician Jacket,304,80,14,1,1,1
-15135,3,16802,1,1,Patrician Jacket,304,80,14,1,2,1
-15136,3,16802,1,1,Patrician Jacket,304,80,14,1,3,1
-15137,3,16802,1,1,Patrician Jacket,304,80,14,1,4,1
-15138,3,16802,1,6,Attire of Evening Mist,304,80,14,1,0,1
-15139,3,16802,1,6,Attire of Evening Mist,304,80,14,1,1,1
-15140,3,16802,1,6,Attire of Evening Mist,304,80,14,1,2,1
-15141,3,16802,1,6,Attire of Evening Mist,304,80,14,1,3,1
-15142,3,16802,1,6,Attire of Evening Mist,304,80,14,1,4,1
-15143,3,16802,1,11,Azure Jacket,304,80,14,1,0,1
-15144,3,16802,1,11,Azure Jacket,304,80,14,1,1,1
-15145,3,16802,1,11,Azure Jacket,304,80,14,1,2,1
-15146,3,16802,1,11,Azure Jacket,304,80,14,1,3,1
-15147,3,16802,1,11,Azure Jacket,304,80,14,1,4,1
+14988,3,16802,1,75,Finnegan's Breastplate,304,80,0,4,0,1
+14989,3,16802,1,75,Finnegan's Breastplate,304,80,0,4,1,1
+14990,3,16802,1,75,Finnegan's Breastplate,304,80,0,4,2,1
+14991,3,16802,1,75,Finnegan's Breastplate,304,80,0,4,3,1
+14992,3,16802,1,75,Finnegan's Breastplate,304,80,0,4,4,1
+14993,3,16802,1,75,Greedy Breastplate,304,80,0,4,0,1
+14994,3,16802,1,75,Greedy Breastplate,304,80,0,4,1,1
+14995,3,16802,1,75,Greedy Breastplate,304,80,0,4,2,1
+14996,3,16802,1,75,Greedy Breastplate,304,80,0,4,3,1
+14997,3,16802,1,75,Greedy Breastplate,304,80,0,4,4,1
+14998,3,5000,1,55,Duke Armor (Dark Night),304,70,0,4,4,1
+15003,3,5000,1,70,Duke Armor (Moonflower),304,75,0,4,4,1
+15008,3,14768,1,50,Executioner's Belt,304,75,12,1,0,1
+15009,3,14768,1,50,Executioner's Belt,304,75,12,1,1,1
+15010,3,14768,1,50,Executioner's Belt,304,75,12,1,2,1
+15011,3,14768,1,50,Executioner's Belt,304,75,12,1,3,1
+15012,3,14768,1,50,Executioner's Belt,304,75,12,1,4,1
+15013,3,14768,1,55,Ancient Beast Half Plate,304,75,12,1,0,1
+15014,3,14768,1,55,Ancient Beast Half Plate,304,75,12,1,1,1
+15015,3,14768,1,55,Ancient Beast Half Plate,304,75,12,1,2,1
+15016,3,14768,1,55,Ancient Beast Half Plate,304,75,12,1,3,1
+15017,3,14768,1,55,Ancient Beast Half Plate,304,75,12,1,4,1
+15018,3,14768,1,60,Mail of Genocide,304,75,12,1,0,1
+15019,3,14768,1,60,Mail of Genocide,304,75,12,1,1,1
+15020,3,14768,1,60,Mail of Genocide,304,75,12,1,2,1
+15021,3,14768,1,60,Mail of Genocide,304,75,12,1,3,1
+15022,3,14768,1,60,Mail of Genocide,304,75,12,1,4,1
+15023,3,15566,1,60,Royal Guardsman's Surcoat,304,77,12,1,0,1
+15024,3,15566,1,60,Royal Guardsman's Surcoat,304,77,12,1,1,1
+15025,3,15566,1,60,Royal Guardsman's Surcoat,304,77,12,1,2,1
+15026,3,15566,1,60,Royal Guardsman's Surcoat,304,77,12,1,3,1
+15027,3,15566,1,60,Royal Guardsman's Surcoat,304,77,12,1,4,1
+15028,3,16802,1,65,Northern Arrêt,304,80,12,1,0,1
+15029,3,16802,1,65,Northern Arrêt,304,80,12,1,1,1
+15030,3,16802,1,65,Northern Arrêt,304,80,12,1,2,1
+15031,3,16802,1,65,Northern Arrêt,304,80,12,1,3,1
+15032,3,16802,1,65,Northern Arrêt,304,80,12,1,4,1
+15033,3,16802,1,70,Knight Armor of Dawn,304,80,12,1,0,1
+15034,3,16802,1,70,Knight Armor of Dawn,304,80,12,1,1,1
+15035,3,16802,1,70,Knight Armor of Dawn,304,80,12,1,2,1
+15036,3,16802,1,70,Knight Armor of Dawn,304,80,12,1,3,1
+15037,3,16802,1,70,Knight Armor of Dawn,304,80,12,1,4,1
+15038,3,16802,1,75,Azure Mail,304,80,12,1,0,1
+15039,3,16802,1,75,Azure Mail,304,80,12,1,1,1
+15040,3,16802,1,75,Azure Mail,304,80,12,1,2,1
+15041,3,16802,1,75,Azure Mail,304,80,12,1,3,1
+15042,3,16802,1,75,Azure Mail,304,80,12,1,4,1
+15063,3,14768,1,50,Innocent Vestment,304,75,15,1,0,1
+15064,3,14768,1,50,Innocent Vestment,304,75,15,1,1,1
+15065,3,14768,1,50,Innocent Vestment,304,75,15,1,2,1
+15066,3,14768,1,50,Innocent Vestment,304,75,15,1,3,1
+15067,3,14768,1,50,Innocent Vestment,304,75,15,1,4,1
+15068,3,14768,1,55,Crimson Robe,304,75,15,1,0,1
+15069,3,14768,1,55,Crimson Robe,304,75,15,1,1,1
+15070,3,14768,1,55,Crimson Robe,304,75,15,1,2,1
+15071,3,14768,1,55,Crimson Robe,304,75,15,1,3,1
+15072,3,14768,1,55,Crimson Robe,304,75,15,1,4,1
+15073,3,14768,1,60,Enhanced Jacket,304,75,15,1,0,1
+15074,3,14768,1,60,Enhanced Jacket,304,75,15,1,1,1
+15075,3,14768,1,60,Enhanced Jacket,304,75,15,1,2,1
+15076,3,14768,1,60,Enhanced Jacket,304,75,15,1,3,1
+15077,3,14768,1,60,Enhanced Jacket,304,75,15,1,4,1
+15043,3,15566,1,60,Medium Robe,304,77,15,1,0,1
+15044,3,15566,1,60,Medium Robe,304,77,15,1,1,1
+15045,3,15566,1,60,Medium Robe,304,77,15,1,2,1
+15046,3,15566,1,60,Medium Robe,304,77,15,1,3,1
+15047,3,15566,1,60,Medium Robe,304,77,15,1,4,1
+15048,3,16802,1,65,Garrisoner's Coat,304,80,15,1,0,1
+15049,3,16802,1,65,Garrisoner's Coat,304,80,15,1,1,1
+15050,3,16802,1,65,Garrisoner's Coat,304,80,15,1,2,1
+15051,3,16802,1,65,Garrisoner's Coat,304,80,15,1,3,1
+15052,3,16802,1,65,Garrisoner's Coat,304,80,15,1,4,1
+15053,3,16802,1,70,Ginkgo-dyed Robe,304,80,15,1,0,1
+15054,3,16802,1,70,Ginkgo-dyed Robe,304,80,15,1,1,1
+15055,3,16802,1,70,Ginkgo-dyed Robe,304,80,15,1,2,1
+15056,3,16802,1,70,Ginkgo-dyed Robe,304,80,15,1,3,1
+15057,3,16802,1,70,Ginkgo-dyed Robe,304,80,15,1,4,1
+15058,3,16802,1,75,Azure Robe,304,80,15,1,0,1
+15059,3,16802,1,75,Azure Robe,304,80,15,1,1,1
+15060,3,16802,1,75,Azure Robe,304,80,15,1,2,1
+15061,3,16802,1,75,Azure Robe,304,80,15,1,3,1
+15062,3,16802,1,75,Azure Robe,304,80,15,1,4,1
+15078,3,14768,1,50,Continent Jacket,304,75,17,1,0,1
+15079,3,14768,1,50,Continent Jacket,304,75,17,1,1,1
+15080,3,14768,1,50,Continent Jacket,304,75,17,1,2,1
+15081,3,14768,1,50,Continent Jacket,304,75,17,1,3,1
+15082,3,14768,1,50,Continent Jacket,304,75,17,1,4,1
+15083,3,14768,1,55,Coat of Keen Insight,304,75,17,1,0,1
+15084,3,14768,1,55,Coat of Keen Insight,304,75,17,1,1,1
+15085,3,14768,1,55,Coat of Keen Insight,304,75,17,1,2,1
+15086,3,14768,1,55,Coat of Keen Insight,304,75,17,1,3,1
+15087,3,14768,1,55,Coat of Keen Insight,304,75,17,1,4,1
+15088,3,14768,1,60,Fortress Plate,304,75,17,1,0,1
+15089,3,14768,1,60,Fortress Plate,304,75,17,1,1,1
+15090,3,14768,1,60,Fortress Plate,304,75,17,1,2,1
+15091,3,14768,1,60,Fortress Plate,304,75,17,1,3,1
+15092,3,14768,1,60,Fortress Plate,304,75,17,1,4,1
+15093,3,15566,1,60,Jacket of Benevolence,304,77,17,1,0,1
+15094,3,15566,1,60,Jacket of Benevolence,304,77,17,1,1,1
+15095,3,15566,1,60,Jacket of Benevolence,304,77,17,1,2,1
+15096,3,15566,1,60,Jacket of Benevolence,304,77,17,1,3,1
+15097,3,15566,1,60,Jacket of Benevolence,304,77,17,1,4,1
+15098,3,16802,1,65,Monochrome Robe,304,80,17,1,0,1
+15099,3,16802,1,65,Monochrome Robe,304,80,17,1,1,1
+15100,3,16802,1,65,Monochrome Robe,304,80,17,1,2,1
+15101,3,16802,1,65,Monochrome Robe,304,80,17,1,3,1
+15102,3,16802,1,65,Monochrome Robe,304,80,17,1,4,1
+15103,3,16802,1,70,Dark Red Haubergeon,304,80,17,1,0,1
+15104,3,16802,1,70,Dark Red Haubergeon,304,80,17,1,1,1
+15105,3,16802,1,70,Dark Red Haubergeon,304,80,17,1,2,1
+15106,3,16802,1,70,Dark Red Haubergeon,304,80,17,1,3,1
+15107,3,16802,1,70,Dark Red Haubergeon,304,80,17,1,4,1
+15108,3,16802,1,75,Azure Preventer,304,80,17,1,0,1
+15109,3,16802,1,75,Azure Preventer,304,80,17,1,1,1
+15110,3,16802,1,75,Azure Preventer,304,80,17,1,2,1
+15111,3,16802,1,75,Azure Preventer,304,80,17,1,3,1
+15112,3,16802,1,75,Azure Preventer,304,80,17,1,4,1
+15113,3,14768,1,50,Mountaineer Chest,304,75,14,1,0,1
+15114,3,14768,1,50,Mountaineer Chest,304,75,14,1,1,1
+15115,3,14768,1,50,Mountaineer Chest,304,75,14,1,2,1
+15116,3,14768,1,50,Mountaineer Chest,304,75,14,1,3,1
+15117,3,14768,1,50,Mountaineer Chest,304,75,14,1,4,1
+15118,3,14768,1,55,Ocean's Jacket,304,75,14,1,0,1
+15119,3,14768,1,55,Ocean's Jacket,304,75,14,1,1,1
+15120,3,14768,1,55,Ocean's Jacket,304,75,14,1,2,1
+15121,3,14768,1,55,Ocean's Jacket,304,75,14,1,3,1
+15122,3,14768,1,55,Ocean's Jacket,304,75,14,1,4,1
+15123,3,14768,1,60,Forest Clothes,304,75,14,1,0,1
+15124,3,14768,1,60,Forest Clothes,304,75,14,1,1,1
+15125,3,14768,1,60,Forest Clothes,304,75,14,1,2,1
+15126,3,14768,1,60,Forest Clothes,304,75,14,1,3,1
+15127,3,14768,1,60,Forest Clothes,304,75,14,1,4,1
+15128,3,15566,1,60,Black Panther Padding,304,77,14,1,0,1
+15129,3,15566,1,60,Black Panther Padding,304,77,14,1,1,1
+15130,3,15566,1,60,Black Panther Padding,304,77,14,1,2,1
+15131,3,15566,1,60,Black Panther Padding,304,77,14,1,3,1
+15132,3,15566,1,60,Black Panther Padding,304,77,14,1,4,1
+15133,3,16802,1,65,Patrician Jacket,304,80,14,1,0,1
+15134,3,16802,1,65,Patrician Jacket,304,80,14,1,1,1
+15135,3,16802,1,65,Patrician Jacket,304,80,14,1,2,1
+15136,3,16802,1,65,Patrician Jacket,304,80,14,1,3,1
+15137,3,16802,1,65,Patrician Jacket,304,80,14,1,4,1
+15138,3,16802,1,70,Attire of Evening Mist,304,80,14,1,0,1
+15139,3,16802,1,70,Attire of Evening Mist,304,80,14,1,1,1
+15140,3,16802,1,70,Attire of Evening Mist,304,80,14,1,2,1
+15141,3,16802,1,70,Attire of Evening Mist,304,80,14,1,3,1
+15142,3,16802,1,70,Attire of Evening Mist,304,80,14,1,4,1
+15143,3,16802,1,75,Azure Jacket,304,80,14,1,0,1
+15144,3,16802,1,75,Azure Jacket,304,80,14,1,1,1
+15145,3,16802,1,75,Azure Jacket,304,80,14,1,2,1
+15146,3,16802,1,75,Azure Jacket,304,80,14,1,3,1
+15147,3,16802,1,75,Azure Jacket,304,80,14,1,4,1
 16487,3,100,1,1,Dragon Breastplate (Decoration),304,1,0,0,4,1
 16488,3,100,1,1,Wyrm's Idea (Decoration),304,1,0,0,4,1
 16489,3,100,1,1,Ddraig Goch Pectus (Decoration),304,1,0,0,4,1
 16490,3,100,1,1,Drachenschuppe (Decoration),304,1,0,0,4,1
-17631,3,16847,1,0,Brigand Armor,304,80,12,1,0,1
-17632,3,16847,1,0,Brigand Armor,304,80,12,1,1,1
-17633,3,16847,1,0,Brigand Armor,304,80,12,1,2,1
-17634,3,16847,1,0,Brigand Armor,304,80,12,1,3,1
-17635,3,16847,1,0,Brigand Armor,304,80,12,1,4,1
-17636,3,18060,1,5,Gelmez Armor,304,83,12,1,0,1
-17637,3,18060,1,5,Gelmez Armor,304,83,12,1,1,1
-17638,3,18060,1,5,Gelmez Armor,304,83,12,1,2,1
-17639,3,18060,1,5,Gelmez Armor,304,83,12,1,3,1
-17640,3,18060,1,5,Gelmez Armor,304,83,12,1,4,1
-17641,3,18869,1,10,Acrean Mail,304,85,12,1,0,1
-17642,3,18869,1,10,Acrean Mail,304,85,12,1,1,1
-17643,3,18869,1,10,Acrean Mail,304,85,12,1,2,1
-17644,3,18869,1,10,Acrean Mail,304,85,12,1,3,1
-17645,3,18869,1,10,Acrean Mail,304,85,12,1,4,1
-17646,3,16847,1,0,Modestly Robe,304,80,15,1,0,1
-17647,3,16847,1,0,Modestly Robe,304,80,15,1,1,1
-17648,3,16847,1,0,Modestly Robe,304,80,15,1,2,1
-17649,3,16847,1,0,Modestly Robe,304,80,15,1,3,1
-17650,3,16847,1,0,Modestly Robe,304,80,15,1,4,1
-17651,3,18060,1,5,Duarev Robe,304,83,15,1,0,1
-17652,3,18060,1,5,Duarev Robe,304,83,15,1,1,1
-17653,3,18060,1,5,Duarev Robe,304,83,15,1,2,1
-17654,3,18060,1,5,Duarev Robe,304,83,15,1,3,1
-17655,3,18060,1,5,Duarev Robe,304,83,15,1,4,1
-17656,3,18869,1,10,Acrean Coat,304,85,15,1,0,1
-17657,3,18869,1,10,Acrean Coat,304,85,15,1,1,1
-17658,3,18869,1,10,Acrean Coat,304,85,15,1,2,1
-17659,3,18869,1,10,Acrean Coat,304,85,15,1,3,1
-17660,3,18869,1,10,Acrean Coat,304,85,15,1,4,1
-17661,3,16847,1,0,Brass Plate,304,80,17,1,0,1
-17662,3,16847,1,0,Brass Plate,304,80,17,1,1,1
-17663,3,16847,1,0,Brass Plate,304,80,17,1,2,1
-17664,3,16847,1,0,Brass Plate,304,80,17,1,3,1
-17665,3,16847,1,0,Brass Plate,304,80,17,1,4,1
-17666,3,18060,1,5,Sizjak Coat,304,83,17,1,0,1
-17667,3,18060,1,5,Sizjak Coat,304,83,17,1,1,1
-17668,3,18060,1,5,Sizjak Coat,304,83,17,1,2,1
-17669,3,18060,1,5,Sizjak Coat,304,83,17,1,3,1
-17670,3,18060,1,5,Sizjak Coat,304,83,17,1,4,1
-17671,3,18869,1,10,Acrean Armor,304,85,17,1,0,1
-17672,3,18869,1,10,Acrean Armor,304,85,17,1,1,1
-17673,3,18869,1,10,Acrean Armor,304,85,17,1,2,1
-17674,3,18869,1,10,Acrean Armor,304,85,17,1,3,1
-17675,3,18869,1,10,Acrean Armor,304,85,17,1,4,1
-17676,3,16847,1,0,Breastplate of Warm Winds,304,80,14,1,0,1
-17677,3,16847,1,0,Breastplate of Warm Winds,304,80,14,1,1,1
-17678,3,16847,1,0,Breastplate of Warm Winds,304,80,14,1,2,1
-17679,3,16847,1,0,Breastplate of Warm Winds,304,80,14,1,3,1
-17680,3,16847,1,0,Breastplate of Warm Winds,304,80,14,1,4,1
-17681,3,18060,1,5,Shahabad Jacket,304,83,14,1,0,1
-17682,3,18060,1,5,Shahabad Jacket,304,83,14,1,1,1
-17683,3,18060,1,5,Shahabad Jacket,304,83,14,1,2,1
-17684,3,18060,1,5,Shahabad Jacket,304,83,14,1,3,1
-17685,3,18060,1,5,Shahabad Jacket,304,83,14,1,4,1
-17686,3,18869,1,10,Acrean Padding,304,85,14,1,0,1
-17687,3,18869,1,10,Acrean Padding,304,85,14,1,1,1
-17688,3,18869,1,10,Acrean Padding,304,85,14,1,2,1
-17689,3,18869,1,10,Acrean Padding,304,85,14,1,3,1
-17690,3,18869,1,10,Acrean Padding,304,85,14,1,4,1
+17631,3,16847,1,80,Brigand Armor,304,80,12,1,0,1
+17632,3,16847,1,80,Brigand Armor,304,80,12,1,1,1
+17633,3,16847,1,80,Brigand Armor,304,80,12,1,2,1
+17634,3,16847,1,80,Brigand Armor,304,80,12,1,3,1
+17635,3,16847,1,80,Brigand Armor,304,80,12,1,4,1
+17636,3,18060,1,85,Gelmez Armor,304,83,12,1,0,1
+17637,3,18060,1,85,Gelmez Armor,304,83,12,1,1,1
+17638,3,18060,1,85,Gelmez Armor,304,83,12,1,2,1
+17639,3,18060,1,85,Gelmez Armor,304,83,12,1,3,1
+17640,3,18060,1,85,Gelmez Armor,304,83,12,1,4,1
+17641,3,18869,1,90,Acrean Mail,304,85,12,1,0,1
+17642,3,18869,1,90,Acrean Mail,304,85,12,1,1,1
+17643,3,18869,1,90,Acrean Mail,304,85,12,1,2,1
+17644,3,18869,1,90,Acrean Mail,304,85,12,1,3,1
+17645,3,18869,1,90,Acrean Mail,304,85,12,1,4,1
+17646,3,16847,1,80,Modestly Robe,304,80,15,1,0,1
+17647,3,16847,1,80,Modestly Robe,304,80,15,1,1,1
+17648,3,16847,1,80,Modestly Robe,304,80,15,1,2,1
+17649,3,16847,1,80,Modestly Robe,304,80,15,1,3,1
+17650,3,16847,1,80,Modestly Robe,304,80,15,1,4,1
+17651,3,18060,1,85,Duarev Robe,304,83,15,1,0,1
+17652,3,18060,1,85,Duarev Robe,304,83,15,1,1,1
+17653,3,18060,1,85,Duarev Robe,304,83,15,1,2,1
+17654,3,18060,1,85,Duarev Robe,304,83,15,1,3,1
+17655,3,18060,1,85,Duarev Robe,304,83,15,1,4,1
+17656,3,18869,1,90,Acrean Coat,304,85,15,1,0,1
+17657,3,18869,1,90,Acrean Coat,304,85,15,1,1,1
+17658,3,18869,1,90,Acrean Coat,304,85,15,1,2,1
+17659,3,18869,1,90,Acrean Coat,304,85,15,1,3,1
+17660,3,18869,1,90,Acrean Coat,304,85,15,1,4,1
+17661,3,16847,1,80,Brass Plate,304,80,17,1,0,1
+17662,3,16847,1,80,Brass Plate,304,80,17,1,1,1
+17663,3,16847,1,80,Brass Plate,304,80,17,1,2,1
+17664,3,16847,1,80,Brass Plate,304,80,17,1,3,1
+17665,3,16847,1,80,Brass Plate,304,80,17,1,4,1
+17666,3,18060,1,85,Sizjak Coat,304,83,17,1,0,1
+17667,3,18060,1,85,Sizjak Coat,304,83,17,1,1,1
+17668,3,18060,1,85,Sizjak Coat,304,83,17,1,2,1
+17669,3,18060,1,85,Sizjak Coat,304,83,17,1,3,1
+17670,3,18060,1,85,Sizjak Coat,304,83,17,1,4,1
+17671,3,18869,1,90,Acrean Armor,304,85,17,1,0,1
+17672,3,18869,1,90,Acrean Armor,304,85,17,1,1,1
+17673,3,18869,1,90,Acrean Armor,304,85,17,1,2,1
+17674,3,18869,1,90,Acrean Armor,304,85,17,1,3,1
+17675,3,18869,1,90,Acrean Armor,304,85,17,1,4,1
+17676,3,16847,1,80,Breastplate of Warm Winds,304,80,14,1,0,1
+17677,3,16847,1,80,Breastplate of Warm Winds,304,80,14,1,1,1
+17678,3,16847,1,80,Breastplate of Warm Winds,304,80,14,1,2,1
+17679,3,16847,1,80,Breastplate of Warm Winds,304,80,14,1,3,1
+17680,3,16847,1,80,Breastplate of Warm Winds,304,80,14,1,4,1
+17681,3,18060,1,85,Shahabad Jacket,304,83,14,1,0,1
+17682,3,18060,1,85,Shahabad Jacket,304,83,14,1,1,1
+17683,3,18060,1,85,Shahabad Jacket,304,83,14,1,2,1
+17684,3,18060,1,85,Shahabad Jacket,304,83,14,1,3,1
+17685,3,18060,1,85,Shahabad Jacket,304,83,14,1,4,1
+17686,3,18869,1,90,Acrean Padding,304,85,14,1,0,1
+17687,3,18869,1,90,Acrean Padding,304,85,14,1,1,1
+17688,3,18869,1,90,Acrean Padding,304,85,14,1,2,1
+17689,3,18869,1,90,Acrean Padding,304,85,14,1,3,1
+17690,3,18869,1,90,Acrean Padding,304,85,14,1,4,1
 17956,3,30000,1,10,Champion Belt of Glory (I),304,1,0,1,0,1
 17957,3,20000,1,10,Champion Belt of Glory (II),304,1,0,1,0,1
 17958,3,10000,1,10,Champion Belt of Glory (III),304,1,0,1,0,1
-18259,3,18869,1,10,Courage Padding,304,85,12,1,0,1
-18260,3,18869,1,10,Courage Padding,304,85,12,1,1,1
-18261,3,18869,1,10,Courage Padding,304,85,12,1,2,1
-18262,3,18869,1,10,Courage Padding,304,85,12,1,3,1
-18263,3,18869,1,10,Courage Padding,304,85,12,1,4,1
-18264,3,19917,1,15,Emine Plate,304,88,12,1,0,1
-18265,3,19917,1,15,Emine Plate,304,88,12,1,1,1
-18266,3,19917,1,15,Emine Plate,304,88,12,1,2,1
-18267,3,19917,1,15,Emine Plate,304,88,12,1,3,1
-18268,3,19917,1,15,Emine Plate,304,88,12,1,4,1
-18269,3,20965,1,4,Dools Armor,304,90,12,1,0,1
-18270,3,20965,1,4,Dools Armor,304,90,12,1,1,1
-18271,3,20965,1,4,Dools Armor,304,90,12,1,2,1
-18272,3,20965,1,4,Dools Armor,304,90,12,1,3,1
-18273,3,20965,1,4,Dools Armor,304,90,12,1,4,1
-18274,3,18869,1,10,Magnus Robe,304,85,15,1,0,1
-18275,3,18869,1,10,Magnus Robe,304,85,15,1,1,1
-18276,3,18869,1,10,Magnus Robe,304,85,15,1,2,1
-18277,3,18869,1,10,Magnus Robe,304,85,15,1,3,1
-18278,3,18869,1,10,Magnus Robe,304,85,15,1,4,1
-18279,3,19917,1,15,Banded Coat of Hope,304,88,15,1,0,1
-18280,3,19917,1,15,Banded Coat of Hope,304,88,15,1,1,1
-18281,3,19917,1,15,Banded Coat of Hope,304,88,15,1,2,1
-18282,3,19917,1,15,Banded Coat of Hope,304,88,15,1,3,1
-18283,3,19917,1,15,Banded Coat of Hope,304,88,15,1,4,1
-18284,3,20965,1,4,Dools Robe,304,90,15,1,0,1
-18285,3,20965,1,4,Dools Robe,304,90,15,1,1,1
-18286,3,20965,1,4,Dools Robe,304,90,15,1,2,1
-18287,3,20965,1,4,Dools Robe,304,90,15,1,3,1
-18288,3,20965,1,4,Dools Robe,304,90,15,1,4,1
-18289,3,18869,1,10,Kelsus Lamellar,304,85,17,1,0,1
-18290,3,18869,1,10,Kelsus Lamellar,304,85,17,1,1,1
-18291,3,18869,1,10,Kelsus Lamellar,304,85,17,1,2,1
-18292,3,18869,1,10,Kelsus Lamellar,304,85,17,1,3,1
-18293,3,18869,1,10,Kelsus Lamellar,304,85,17,1,4,1
-18294,3,19917,1,15,Kier Jacket,304,88,17,1,0,1
-18295,3,19917,1,15,Kier Jacket,304,88,17,1,1,1
-18296,3,19917,1,15,Kier Jacket,304,88,17,1,2,1
-18297,3,19917,1,15,Kier Jacket,304,88,17,1,3,1
-18298,3,19917,1,15,Kier Jacket,304,88,17,1,4,1
-18299,3,20965,1,4,Dools Coat,304,90,17,1,0,1
-18300,3,20965,1,4,Dools Coat,304,90,17,1,1,1
-18301,3,20965,1,4,Dools Coat,304,90,17,1,2,1
-18302,3,20965,1,4,Dools Coat,304,90,17,1,3,1
-18303,3,20965,1,4,Dools Coat,304,90,17,1,4,1
-18304,3,18869,1,10,Aura Jacket,304,85,14,1,0,1
-18305,3,18869,1,10,Aura Jacket,304,85,14,1,1,1
-18306,3,18869,1,10,Aura Jacket,304,85,14,1,2,1
-18307,3,18869,1,10,Aura Jacket,304,85,14,1,3,1
-18308,3,18869,1,10,Aura Jacket,304,85,14,1,4,1
-18309,3,19917,1,15,Niloufar Padding,304,88,14,1,0,1
-18310,3,19917,1,15,Niloufar Padding,304,88,14,1,1,1
-18311,3,19917,1,15,Niloufar Padding,304,88,14,1,2,1
-18312,3,19917,1,15,Niloufar Padding,304,88,14,1,3,1
-18313,3,19917,1,15,Niloufar Padding,304,88,14,1,4,1
-18314,3,20965,1,4,Dools Vest,304,90,14,1,0,1
-18315,3,20965,1,4,Dools Vest,304,90,14,1,1,1
-18316,3,20965,1,4,Dools Vest,304,90,14,1,2,1
-18317,3,20965,1,4,Dools Vest,304,90,14,1,3,1
-18318,3,20965,1,4,Dools Vest,304,90,14,1,4,1
+18259,3,18869,1,90,Courage Padding,304,85,12,1,0,1
+18260,3,18869,1,90,Courage Padding,304,85,12,1,1,1
+18261,3,18869,1,90,Courage Padding,304,85,12,1,2,1
+18262,3,18869,1,90,Courage Padding,304,85,12,1,3,1
+18263,3,18869,1,90,Courage Padding,304,85,12,1,4,1
+18264,3,19917,1,95,Emine Plate,304,88,12,1,0,1
+18265,3,19917,1,95,Emine Plate,304,88,12,1,1,1
+18266,3,19917,1,95,Emine Plate,304,88,12,1,2,1
+18267,3,19917,1,95,Emine Plate,304,88,12,1,3,1
+18268,3,19917,1,95,Emine Plate,304,88,12,1,4,1
+18269,3,20965,1,100,Dools Armor,304,90,12,1,0,1
+18270,3,20965,1,100,Dools Armor,304,90,12,1,1,1
+18271,3,20965,1,100,Dools Armor,304,90,12,1,2,1
+18272,3,20965,1,100,Dools Armor,304,90,12,1,3,1
+18273,3,20965,1,100,Dools Armor,304,90,12,1,4,1
+18274,3,18869,1,90,Magnus Robe,304,85,15,1,0,1
+18275,3,18869,1,90,Magnus Robe,304,85,15,1,1,1
+18276,3,18869,1,90,Magnus Robe,304,85,15,1,2,1
+18277,3,18869,1,90,Magnus Robe,304,85,15,1,3,1
+18278,3,18869,1,90,Magnus Robe,304,85,15,1,4,1
+18279,3,19917,1,95,Banded Coat of Hope,304,88,15,1,0,1
+18280,3,19917,1,95,Banded Coat of Hope,304,88,15,1,1,1
+18281,3,19917,1,95,Banded Coat of Hope,304,88,15,1,2,1
+18282,3,19917,1,95,Banded Coat of Hope,304,88,15,1,3,1
+18283,3,19917,1,95,Banded Coat of Hope,304,88,15,1,4,1
+18284,3,20965,1,100,Dools Robe,304,90,15,1,0,1
+18285,3,20965,1,100,Dools Robe,304,90,15,1,1,1
+18286,3,20965,1,100,Dools Robe,304,90,15,1,2,1
+18287,3,20965,1,100,Dools Robe,304,90,15,1,3,1
+18288,3,20965,1,100,Dools Robe,304,90,15,1,4,1
+18289,3,18869,1,90,Kelsus Lamellar,304,85,17,1,0,1
+18290,3,18869,1,90,Kelsus Lamellar,304,85,17,1,1,1
+18291,3,18869,1,90,Kelsus Lamellar,304,85,17,1,2,1
+18292,3,18869,1,90,Kelsus Lamellar,304,85,17,1,3,1
+18293,3,18869,1,90,Kelsus Lamellar,304,85,17,1,4,1
+18294,3,19917,1,95,Kier Jacket,304,88,17,1,0,1
+18295,3,19917,1,95,Kier Jacket,304,88,17,1,1,1
+18296,3,19917,1,95,Kier Jacket,304,88,17,1,2,1
+18297,3,19917,1,95,Kier Jacket,304,88,17,1,3,1
+18298,3,19917,1,95,Kier Jacket,304,88,17,1,4,1
+18299,3,20965,1,100,Dools Coat,304,90,17,1,0,1
+18300,3,20965,1,100,Dools Coat,304,90,17,1,1,1
+18301,3,20965,1,100,Dools Coat,304,90,17,1,2,1
+18302,3,20965,1,100,Dools Coat,304,90,17,1,3,1
+18303,3,20965,1,100,Dools Coat,304,90,17,1,4,1
+18304,3,18869,1,90,Aura Jacket,304,85,14,1,0,1
+18305,3,18869,1,90,Aura Jacket,304,85,14,1,1,1
+18306,3,18869,1,90,Aura Jacket,304,85,14,1,2,1
+18307,3,18869,1,90,Aura Jacket,304,85,14,1,3,1
+18308,3,18869,1,90,Aura Jacket,304,85,14,1,4,1
+18309,3,19917,1,95,Niloufar Padding,304,88,14,1,0,1
+18310,3,19917,1,95,Niloufar Padding,304,88,14,1,1,1
+18311,3,19917,1,95,Niloufar Padding,304,88,14,1,2,1
+18312,3,19917,1,95,Niloufar Padding,304,88,14,1,3,1
+18313,3,19917,1,95,Niloufar Padding,304,88,14,1,4,1
+18314,3,20965,1,100,Dools Vest,304,90,14,1,0,1
+18315,3,20965,1,100,Dools Vest,304,90,14,1,1,1
+18316,3,20965,1,100,Dools Vest,304,90,14,1,2,1
+18317,3,20965,1,100,Dools Vest,304,90,14,1,3,1
+18318,3,20965,1,100,Dools Vest,304,90,14,1,4,1
 18490,3,100,1,1,Volcanic Color,304,75,0,0,4,1
-18579,3,20000,1,13,Black Venom Armor,304,1,0,4,0,1
-18580,3,20000,1,2,Black Venom Armor,304,1,0,4,1,1
-18581,3,20000,1,7,Black Venom Armor,304,1,0,4,2,1
-18582,3,20000,1,12,Black Venom Armor,304,1,0,4,3,1
-18583,3,20000,1,6,Black Venom Armor,304,1,0,4,4,1
-19241,3,0,1,10,Torso of the First King,304,80,0,4,0,1
-19242,3,0,1,4,Torso of the First King,304,80,0,4,1,1
-19243,3,0,1,9,Torso of the First King,304,80,0,4,2,1
-19244,3,0,1,14,Torso of the First King,304,80,0,4,3,1
-19245,3,0,1,8,Torso of the First King,304,80,0,4,4,1
-19454,3,10000,1,0,Boundless Tempest Armor,304,1,0,4,4,1
-19459,3,10000,1,3,Boundless Tempest Padding,304,1,0,4,4,1
-20449,3,20900,1,4,Maddest Armor,304,90,12,1,0,1
-20450,3,20900,1,4,Maddest Armor,304,90,12,1,1,1
-20451,3,20900,1,4,Maddest Armor,304,90,12,1,2,1
-20452,3,20900,1,4,Maddest Armor,304,90,12,1,3,1
-20453,3,20900,1,4,Maddest Armor,304,90,12,1,4,1
-20454,3,21945,1,9,Corail Mail,304,93,12,1,0,1
-20455,3,21945,1,9,Corail Mail,304,93,12,1,1,1
-20456,3,21945,1,9,Corail Mail,304,93,12,1,2,1
-20457,3,21945,1,9,Corail Mail,304,93,12,1,3,1
-20458,3,21945,1,9,Corail Mail,304,93,12,1,4,1
-20459,3,22990,1,14,Mehizaf Armor,304,95,12,1,0,1
-20460,3,22990,1,14,Mehizaf Armor,304,95,12,1,1,1
-20461,3,22990,1,14,Mehizaf Armor,304,95,12,1,2,1
-20462,3,22990,1,14,Mehizaf Armor,304,95,12,1,3,1
-20463,3,22990,1,14,Mehizaf Armor,304,95,12,1,4,1
-20777,3,22990,1,14,Courage Armor,304,95,12,1,0,1
-20778,3,22990,1,14,Courage Armor,304,95,12,1,1,1
-20779,3,22990,1,14,Courage Armor,304,95,12,1,2,1
-20780,3,22990,1,14,Courage Armor,304,95,12,1,3,1
-20781,3,22990,1,14,Courage Armor,304,95,12,1,4,1
-20782,3,24035,1,3,Confidence Mail,304,98,12,1,0,1
-20783,3,24035,1,3,Confidence Mail,304,98,12,1,1,1
-20784,3,24035,1,3,Confidence Mail,304,98,12,1,2,1
-20785,3,24035,1,3,Confidence Mail,304,98,12,1,3,1
-20786,3,24035,1,3,Confidence Mail,304,98,12,1,4,1
-20787,3,25080,1,8,Ambition Armor,304,100,12,1,0,1
-20788,3,25080,1,8,Ambition Armor,304,100,12,1,1,1
-20789,3,25080,1,8,Ambition Armor,304,100,12,1,2,1
-20790,3,25080,1,8,Ambition Armor,304,100,12,1,3,1
-20791,3,25080,1,8,Ambition Armor,304,100,12,1,4,1
-20509,3,20900,1,4,Capable Padding,304,90,14,1,0,1
-20510,3,20900,1,4,Capable Padding,304,90,14,1,1,1
-20511,3,20900,1,4,Capable Padding,304,90,14,1,2,1
-20512,3,20900,1,4,Capable Padding,304,90,14,1,3,1
-20513,3,20900,1,4,Capable Padding,304,90,14,1,4,1
-20514,3,21945,1,9,Cuivre Jacket,304,93,14,1,0,1
-20515,3,21945,1,9,Cuivre Jacket,304,93,14,1,1,1
-20516,3,21945,1,9,Cuivre Jacket,304,93,14,1,2,1
-20517,3,21945,1,9,Cuivre Jacket,304,93,14,1,3,1
-20518,3,21945,1,9,Cuivre Jacket,304,93,14,1,4,1
-20519,3,22990,1,14,Mehizaf Cross,304,95,14,1,0,1
-20520,3,22990,1,14,Mehizaf Cross,304,95,14,1,1,1
-20521,3,22990,1,14,Mehizaf Cross,304,95,14,1,2,1
-20522,3,22990,1,14,Mehizaf Cross,304,95,14,1,3,1
-20523,3,22990,1,14,Mehizaf Cross,304,95,14,1,4,1
-20837,3,22990,1,14,Hardy Padding,304,95,14,1,0,1
-20838,3,22990,1,14,Hardy Padding,304,95,14,1,1,1
-20839,3,22990,1,14,Hardy Padding,304,95,14,1,2,1
-20840,3,22990,1,14,Hardy Padding,304,95,14,1,3,1
-20841,3,22990,1,14,Hardy Padding,304,95,14,1,4,1
-20842,3,24035,1,3,Taciturne Padding,304,98,14,1,0,1
-20843,3,24035,1,3,Taciturne Padding,304,98,14,1,1,1
-20844,3,24035,1,3,Taciturne Padding,304,98,14,1,2,1
-20845,3,24035,1,3,Taciturne Padding,304,98,14,1,3,1
-20846,3,24035,1,3,Taciturne Padding,304,98,14,1,4,1
-20847,3,25080,1,8,Mission Padding,304,100,14,1,0,1
-20848,3,25080,1,8,Mission Padding,304,100,14,1,1,1
-20849,3,25080,1,8,Mission Padding,304,100,14,1,2,1
-20850,3,25080,1,8,Mission Padding,304,100,14,1,3,1
-20851,3,25080,1,8,Mission Padding,304,100,14,1,4,1
-20569,3,20900,1,4,Robe of Sacrament,304,90,15,1,0,1
-20570,3,20900,1,4,Robe of Sacrament,304,90,15,1,1,1
-20571,3,20900,1,4,Robe of Sacrament,304,90,15,1,2,1
-20572,3,20900,1,4,Robe of Sacrament,304,90,15,1,3,1
-20573,3,20900,1,4,Robe of Sacrament,304,90,15,1,4,1
-20574,3,21945,1,9,June Robe,304,93,15,1,0,1
-20575,3,21945,1,9,June Robe,304,93,15,1,1,1
-20576,3,21945,1,9,June Robe,304,93,15,1,2,1
-20577,3,21945,1,9,June Robe,304,93,15,1,3,1
-20578,3,21945,1,9,June Robe,304,93,15,1,4,1
-20579,3,22990,1,14,Mehizaf Robe,304,95,15,1,0,1
-20580,3,22990,1,14,Mehizaf Robe,304,95,15,1,1,1
-20581,3,22990,1,14,Mehizaf Robe,304,95,15,1,2,1
-20582,3,22990,1,14,Mehizaf Robe,304,95,15,1,3,1
-20583,3,22990,1,14,Mehizaf Robe,304,95,15,1,4,1
-20897,3,22990,1,14,Miséricorde Robe,304,95,15,1,0,1
-20898,3,22990,1,14,Miséricorde Robe,304,95,15,1,1,1
-20899,3,22990,1,14,Miséricorde Robe,304,95,15,1,2,1
-20900,3,22990,1,14,Miséricorde Robe,304,95,15,1,3,1
-20901,3,22990,1,14,Miséricorde Robe,304,95,15,1,4,1
-20902,3,24035,1,3,Charité Coat,304,98,15,1,0,1
-20903,3,24035,1,3,Charité Coat,304,98,15,1,1,1
-20904,3,24035,1,3,Charité Coat,304,98,15,1,2,1
-20905,3,24035,1,3,Charité Coat,304,98,15,1,3,1
-20906,3,24035,1,3,Charité Coat,304,98,15,1,4,1
-20907,3,25080,1,8,Redoutable Robe,304,100,15,1,0,1
-20908,3,25080,1,8,Redoutable Robe,304,100,15,1,1,1
-20909,3,25080,1,8,Redoutable Robe,304,100,15,1,2,1
-20910,3,25080,1,8,Redoutable Robe,304,100,15,1,3,1
-20911,3,25080,1,8,Redoutable Robe,304,100,15,1,4,1
-20629,3,20900,1,4,Pundit Coat,304,90,17,1,0,1
-20630,3,20900,1,4,Pundit Coat,304,90,17,1,1,1
-20631,3,20900,1,4,Pundit Coat,304,90,17,1,2,1
-20632,3,20900,1,4,Pundit Coat,304,90,17,1,3,1
-20633,3,20900,1,4,Pundit Coat,304,90,17,1,4,1
-20634,3,21945,1,9,Briller Jacket,304,93,17,1,0,1
-20635,3,21945,1,9,Briller Jacket,304,93,17,1,1,1
-20636,3,21945,1,9,Briller Jacket,304,93,17,1,2,1
-20637,3,21945,1,9,Briller Jacket,304,93,17,1,3,1
-20638,3,21945,1,9,Briller Jacket,304,93,17,1,4,1
-20639,3,22990,1,14,Mehizaf Coat,304,95,17,1,0,1
-20640,3,22990,1,14,Mehizaf Coat,304,95,17,1,1,1
-20641,3,22990,1,14,Mehizaf Coat,304,95,17,1,2,1
-20642,3,22990,1,14,Mehizaf Coat,304,95,17,1,3,1
-20643,3,22990,1,14,Mehizaf Coat,304,95,17,1,4,1
-20957,3,22990,1,14,Positivité Robe,304,95,17,1,0,1
-20958,3,22990,1,14,Positivité Robe,304,95,17,1,1,1
-20959,3,22990,1,14,Positivité Robe,304,95,17,1,2,1
-20960,3,22990,1,14,Positivité Robe,304,95,17,1,3,1
-20961,3,22990,1,14,Positivité Robe,304,95,17,1,4,1
-20962,3,24035,1,3,Solidarité Armor,304,98,17,1,0,1
-20963,3,24035,1,3,Solidarité Armor,304,98,17,1,1,1
-20964,3,24035,1,3,Solidarité Armor,304,98,17,1,2,1
-20965,3,24035,1,3,Solidarité Armor,304,98,17,1,3,1
-20966,3,24035,1,3,Solidarité Armor,304,98,17,1,4,1
-20967,3,25080,1,8,Ideal Jacket,304,100,17,1,0,1
-20968,3,25080,1,8,Ideal Jacket,304,100,17,1,1,1
-20969,3,25080,1,8,Ideal Jacket,304,100,17,1,2,1
-20970,3,25080,1,8,Ideal Jacket,304,100,17,1,3,1
-20971,3,25080,1,8,Ideal Jacket,304,100,17,1,4,1
+18579,3,20000,1,45,Black Venom Armor,304,1,0,4,0,1
+18580,3,20000,1,50,Black Venom Armor,304,1,0,4,1,1
+18581,3,20000,1,55,Black Venom Armor,304,1,0,4,2,1
+18582,3,20000,1,60,Black Venom Armor,304,1,0,4,3,1
+18583,3,20000,1,70,Black Venom Armor,304,1,0,4,4,1
+19241,3,0,1,90,Torso of the First King,304,80,0,4,0,1
+19242,3,0,1,100,Torso of the First King,304,80,0,4,1,1
+19243,3,0,1,105,Torso of the First King,304,80,0,4,2,1
+19244,3,0,1,110,Torso of the First King,304,80,0,4,3,1
+19245,3,0,1,120,Torso of the First King,304,80,0,4,4,1
+19454,3,10000,1,80,Boundless Tempest Armor,304,1,0,4,4,1
+19459,3,10000,1,83,Boundless Tempest Padding,304,1,0,4,4,1
+20449,3,20900,1,100,Maddest Armor,304,90,12,1,0,1
+20450,3,20900,1,100,Maddest Armor,304,90,12,1,1,1
+20451,3,20900,1,100,Maddest Armor,304,90,12,1,2,1
+20452,3,20900,1,100,Maddest Armor,304,90,12,1,3,1
+20453,3,20900,1,100,Maddest Armor,304,90,12,1,4,1
+20454,3,21945,1,105,Corail Mail,304,93,12,1,0,1
+20455,3,21945,1,105,Corail Mail,304,93,12,1,1,1
+20456,3,21945,1,105,Corail Mail,304,93,12,1,2,1
+20457,3,21945,1,105,Corail Mail,304,93,12,1,3,1
+20458,3,21945,1,105,Corail Mail,304,93,12,1,4,1
+20459,3,22990,1,110,Mehizaf Armor,304,95,12,1,0,1
+20460,3,22990,1,110,Mehizaf Armor,304,95,12,1,1,1
+20461,3,22990,1,110,Mehizaf Armor,304,95,12,1,2,1
+20462,3,22990,1,110,Mehizaf Armor,304,95,12,1,3,1
+20463,3,22990,1,110,Mehizaf Armor,304,95,12,1,4,1
+20777,3,22990,1,110,Courage Armor,304,95,12,1,0,1
+20778,3,22990,1,110,Courage Armor,304,95,12,1,1,1
+20779,3,22990,1,110,Courage Armor,304,95,12,1,2,1
+20780,3,22990,1,110,Courage Armor,304,95,12,1,3,1
+20781,3,22990,1,110,Courage Armor,304,95,12,1,4,1
+20782,3,24035,1,115,Confidence Mail,304,98,12,1,0,1
+20783,3,24035,1,115,Confidence Mail,304,98,12,1,1,1
+20784,3,24035,1,115,Confidence Mail,304,98,12,1,2,1
+20785,3,24035,1,115,Confidence Mail,304,98,12,1,3,1
+20786,3,24035,1,115,Confidence Mail,304,98,12,1,4,1
+20787,3,25080,1,120,Ambition Armor,304,100,12,1,0,1
+20788,3,25080,1,120,Ambition Armor,304,100,12,1,1,1
+20789,3,25080,1,120,Ambition Armor,304,100,12,1,2,1
+20790,3,25080,1,120,Ambition Armor,304,100,12,1,3,1
+20791,3,25080,1,120,Ambition Armor,304,100,12,1,4,1
+20509,3,20900,1,100,Capable Padding,304,90,14,1,0,1
+20510,3,20900,1,100,Capable Padding,304,90,14,1,1,1
+20511,3,20900,1,100,Capable Padding,304,90,14,1,2,1
+20512,3,20900,1,100,Capable Padding,304,90,14,1,3,1
+20513,3,20900,1,100,Capable Padding,304,90,14,1,4,1
+20514,3,21945,1,105,Cuivre Jacket,304,93,14,1,0,1
+20515,3,21945,1,105,Cuivre Jacket,304,93,14,1,1,1
+20516,3,21945,1,105,Cuivre Jacket,304,93,14,1,2,1
+20517,3,21945,1,105,Cuivre Jacket,304,93,14,1,3,1
+20518,3,21945,1,105,Cuivre Jacket,304,93,14,1,4,1
+20519,3,22990,1,110,Mehizaf Cross,304,95,14,1,0,1
+20520,3,22990,1,110,Mehizaf Cross,304,95,14,1,1,1
+20521,3,22990,1,110,Mehizaf Cross,304,95,14,1,2,1
+20522,3,22990,1,110,Mehizaf Cross,304,95,14,1,3,1
+20523,3,22990,1,110,Mehizaf Cross,304,95,14,1,4,1
+20837,3,22990,1,110,Hardy Padding,304,95,14,1,0,1
+20838,3,22990,1,110,Hardy Padding,304,95,14,1,1,1
+20839,3,22990,1,110,Hardy Padding,304,95,14,1,2,1
+20840,3,22990,1,110,Hardy Padding,304,95,14,1,3,1
+20841,3,22990,1,110,Hardy Padding,304,95,14,1,4,1
+20842,3,24035,1,115,Taciturne Padding,304,98,14,1,0,1
+20843,3,24035,1,115,Taciturne Padding,304,98,14,1,1,1
+20844,3,24035,1,115,Taciturne Padding,304,98,14,1,2,1
+20845,3,24035,1,115,Taciturne Padding,304,98,14,1,3,1
+20846,3,24035,1,115,Taciturne Padding,304,98,14,1,4,1
+20847,3,25080,1,120,Mission Padding,304,100,14,1,0,1
+20848,3,25080,1,120,Mission Padding,304,100,14,1,1,1
+20849,3,25080,1,120,Mission Padding,304,100,14,1,2,1
+20850,3,25080,1,120,Mission Padding,304,100,14,1,3,1
+20851,3,25080,1,120,Mission Padding,304,100,14,1,4,1
+20569,3,20900,1,100,Robe of Sacrament,304,90,15,1,0,1
+20570,3,20900,1,100,Robe of Sacrament,304,90,15,1,1,1
+20571,3,20900,1,100,Robe of Sacrament,304,90,15,1,2,1
+20572,3,20900,1,100,Robe of Sacrament,304,90,15,1,3,1
+20573,3,20900,1,100,Robe of Sacrament,304,90,15,1,4,1
+20574,3,21945,1,105,June Robe,304,93,15,1,0,1
+20575,3,21945,1,105,June Robe,304,93,15,1,1,1
+20576,3,21945,1,105,June Robe,304,93,15,1,2,1
+20577,3,21945,1,105,June Robe,304,93,15,1,3,1
+20578,3,21945,1,105,June Robe,304,93,15,1,4,1
+20579,3,22990,1,110,Mehizaf Robe,304,95,15,1,0,1
+20580,3,22990,1,110,Mehizaf Robe,304,95,15,1,1,1
+20581,3,22990,1,110,Mehizaf Robe,304,95,15,1,2,1
+20582,3,22990,1,110,Mehizaf Robe,304,95,15,1,3,1
+20583,3,22990,1,110,Mehizaf Robe,304,95,15,1,4,1
+20897,3,22990,1,110,Miséricorde Robe,304,95,15,1,0,1
+20898,3,22990,1,110,Miséricorde Robe,304,95,15,1,1,1
+20899,3,22990,1,110,Miséricorde Robe,304,95,15,1,2,1
+20900,3,22990,1,110,Miséricorde Robe,304,95,15,1,3,1
+20901,3,22990,1,110,Miséricorde Robe,304,95,15,1,4,1
+20902,3,24035,1,115,Charité Coat,304,98,15,1,0,1
+20903,3,24035,1,115,Charité Coat,304,98,15,1,1,1
+20904,3,24035,1,115,Charité Coat,304,98,15,1,2,1
+20905,3,24035,1,115,Charité Coat,304,98,15,1,3,1
+20906,3,24035,1,115,Charité Coat,304,98,15,1,4,1
+20907,3,25080,1,120,Redoutable Robe,304,100,15,1,0,1
+20908,3,25080,1,120,Redoutable Robe,304,100,15,1,1,1
+20909,3,25080,1,120,Redoutable Robe,304,100,15,1,2,1
+20910,3,25080,1,120,Redoutable Robe,304,100,15,1,3,1
+20911,3,25080,1,120,Redoutable Robe,304,100,15,1,4,1
+20629,3,20900,1,100,Pundit Coat,304,90,17,1,0,1
+20630,3,20900,1,100,Pundit Coat,304,90,17,1,1,1
+20631,3,20900,1,100,Pundit Coat,304,90,17,1,2,1
+20632,3,20900,1,100,Pundit Coat,304,90,17,1,3,1
+20633,3,20900,1,100,Pundit Coat,304,90,17,1,4,1
+20634,3,21945,1,105,Briller Jacket,304,93,17,1,0,1
+20635,3,21945,1,105,Briller Jacket,304,93,17,1,1,1
+20636,3,21945,1,105,Briller Jacket,304,93,17,1,2,1
+20637,3,21945,1,105,Briller Jacket,304,93,17,1,3,1
+20638,3,21945,1,105,Briller Jacket,304,93,17,1,4,1
+20639,3,22990,1,110,Mehizaf Coat,304,95,17,1,0,1
+20640,3,22990,1,110,Mehizaf Coat,304,95,17,1,1,1
+20641,3,22990,1,110,Mehizaf Coat,304,95,17,1,2,1
+20642,3,22990,1,110,Mehizaf Coat,304,95,17,1,3,1
+20643,3,22990,1,110,Mehizaf Coat,304,95,17,1,4,1
+20957,3,22990,1,110,Positivité Robe,304,95,17,1,0,1
+20958,3,22990,1,110,Positivité Robe,304,95,17,1,1,1
+20959,3,22990,1,110,Positivité Robe,304,95,17,1,2,1
+20960,3,22990,1,110,Positivité Robe,304,95,17,1,3,1
+20961,3,22990,1,110,Positivité Robe,304,95,17,1,4,1
+20962,3,24035,1,115,Solidarité Armor,304,98,17,1,0,1
+20963,3,24035,1,115,Solidarité Armor,304,98,17,1,1,1
+20964,3,24035,1,115,Solidarité Armor,304,98,17,1,2,1
+20965,3,24035,1,115,Solidarité Armor,304,98,17,1,3,1
+20966,3,24035,1,115,Solidarité Armor,304,98,17,1,4,1
+20967,3,25080,1,120,Ideal Jacket,304,100,17,1,0,1
+20968,3,25080,1,120,Ideal Jacket,304,100,17,1,1,1
+20969,3,25080,1,120,Ideal Jacket,304,100,17,1,2,1
+20970,3,25080,1,120,Ideal Jacket,304,100,17,1,3,1
+20971,3,25080,1,120,Ideal Jacket,304,100,17,1,4,1
 20684,3,100,1,1,War God's Torso,304,1,0,0,4,1
 21012,3,100,1,1,Refined Bijoux,304,1,0,0,4,1
 21017,3,100,1,1,Noble Bijoux,304,1,0,0,4,1
-21112,3,50000,1,12,Maestro Armor,304,1,0,4,4,1
-20748,3,50000,1,10,Crimson Leather Coat,304,90,0,4,4,1
-21095,3,50000,1,4,White Smoke Leather Coat,304,95,0,4,4,1
-21161,3,50000,1,15,Virtuoso Armor,304,1,0,4,4,1
-21170,3,50000,1,12,Lord Knight Leather Coat,304,90,0,4,4,1
-21178,3,50000,1,6,Selenite Leather Coat,304,95,0,4,4,1
+21112,3,50000,1,92,Maestro Armor,304,1,0,4,4,1
+20748,3,50000,1,106,Crimson Leather Coat,304,90,0,4,4,1
+21095,3,50000,1,116,White Smoke Leather Coat,304,95,0,4,4,1
+21161,3,50000,1,95,Virtuoso Armor,304,1,0,4,4,1
+21170,3,50000,1,108,Lord Knight Leather Coat,304,90,0,4,4,1
+21178,3,50000,1,118,Selenite Leather Coat,304,95,0,4,4,1
 21397,3,500,1,12,Cursed Armor,304,1,0,1,0,1
 21401,3,500,1,12,Chaos Robe,304,1,0,1,0,1
 23422,3,10000,1,1,Angel's Feather Corset (White),304,1,0,0,4,1
 23423,3,10000,1,1,Angel's Feather Corset (Black),304,1,0,0,4,1
 23452,3,100,1,1,Santa's Robe Coat (Red),304,1,0,1,4,1
 23453,3,100,1,1,Santa's Robe Coat (White),304,1,0,1,4,1
-24124,3,0,1,2,Spirit's Heavy Armored Attire,304,100,12,1,0,1
-24125,3,0,1,2,Spirit's Heavy Armored Attire,304,100,12,1,1,1
-24126,3,0,1,2,Spirit's Heavy Armored Attire,304,100,12,1,2,1
-24127,3,0,1,2,Spirit's Heavy Armored Attire,304,100,12,1,3,1
-24128,3,0,1,2,Spirit's Heavy Armored Attire,304,100,12,1,4,1
-24129,3,0,1,2,Fire King's Heavy Armored Attire,304,100,12,1,0,1
-24130,3,0,1,2,Fire King's Heavy Armored Attire,304,100,12,1,1,1
-24131,3,0,1,2,Fire King's Heavy Armored Attire,304,100,12,1,2,1
-24132,3,0,1,2,Fire King's Heavy Armored Attire,304,100,12,1,3,1
-24133,3,0,1,2,Fire King's Heavy Armored Attire,304,100,12,1,4,1
-24134,3,0,1,2,White Wings' Armored Attire,304,100,12,1,0,1
-24135,3,0,1,2,White Wings' Armored Attire,304,100,12,1,1,1
-24136,3,0,1,2,White Wings' Armored Attire,304,100,12,1,2,1
-24137,3,0,1,2,White Wings' Armored Attire,304,100,12,1,3,1
-24138,3,0,1,2,White Wings' Armored Attire,304,100,12,1,4,1
-24139,3,0,1,2,Golden Heavy Armor,304,100,12,1,0,1
-24140,3,0,1,2,Golden Heavy Armor,304,100,12,1,1,1
-24141,3,0,1,2,Golden Heavy Armor,304,100,12,1,2,1
-24142,3,0,1,2,Golden Heavy Armor,304,100,12,1,3,1
-24143,3,0,1,2,Golden Heavy Armor,304,100,12,1,4,1
-24144,3,0,1,7,Blackshatter Heavy Armor,304,100,12,1,0,1
-24145,3,0,1,7,Blackshatter Heavy Armor,304,100,12,1,1,1
-24146,3,0,1,7,Blackshatter Heavy Armor,304,100,12,1,2,1
-24147,3,0,1,7,Blackshatter Heavy Armor,304,100,12,1,3,1
-24148,3,0,1,7,Blackshatter Heavy Armor,304,100,12,1,4,1
-24224,3,0,1,2,Spirit's Light Armored Attire,304,100,14,1,0,1
-24225,3,0,1,2,Spirit's Light Armored Attire,304,100,14,1,1,1
-24226,3,0,1,2,Spirit's Light Armored Attire,304,100,14,1,2,1
-24227,3,0,1,2,Spirit's Light Armored Attire,304,100,14,1,3,1
-24228,3,0,1,2,Spirit's Light Armored Attire,304,100,14,1,4,1
-24229,3,0,1,2,Fire King's Light Armored Attire,304,100,14,1,0,1
-24230,3,0,1,2,Fire King's Light Armored Attire,304,100,14,1,1,1
-24231,3,0,1,2,Fire King's Light Armored Attire,304,100,14,1,2,1
-24232,3,0,1,2,Fire King's Light Armored Attire,304,100,14,1,3,1
-24233,3,0,1,2,Fire King's Light Armored Attire,304,100,14,1,4,1
-24234,3,0,1,2,White Wings' Light Armored Attire,304,100,14,1,0,1
-24235,3,0,1,2,White Wings' Light Armored Attire,304,100,14,1,1,1
-24236,3,0,1,2,White Wings' Light Armored Attire,304,100,14,1,2,1
-24237,3,0,1,2,White Wings' Light Armored Attire,304,100,14,1,3,1
-24238,3,0,1,2,White Wings' Light Armored Attire,304,100,14,1,4,1
-24239,3,0,1,2,Golden Light Armor,304,100,14,1,0,1
-24240,3,0,1,2,Golden Light Armor,304,100,14,1,1,1
-24241,3,0,1,2,Golden Light Armor,304,100,14,1,2,1
-24242,3,0,1,2,Golden Light Armor,304,100,14,1,3,1
-24243,3,0,1,2,Golden Light Armor,304,100,14,1,4,1
-24244,3,0,1,7,Blackshatter Light Armor,304,100,14,1,0,1
-24245,3,0,1,7,Blackshatter Light Armor,304,100,14,1,1,1
-24246,3,0,1,7,Blackshatter Light Armor,304,100,14,1,2,1
-24247,3,0,1,7,Blackshatter Light Armor,304,100,14,1,3,1
-24248,3,0,1,7,Blackshatter Light Armor,304,100,14,1,4,1
-24324,3,0,1,2,Spirit's Magick Robe,304,100,15,1,0,1
-24325,3,0,1,2,Spirit's Magick Robe,304,100,15,1,1,1
-24326,3,0,1,2,Spirit's Magick Robe,304,100,15,1,2,1
-24327,3,0,1,2,Spirit's Magick Robe,304,100,15,1,3,1
-24328,3,0,1,2,Spirit's Magick Robe,304,100,15,1,4,1
-24329,3,0,1,2,Fire King's Magick Robe,304,100,15,1,0,1
-24330,3,0,1,2,Fire King's Magick Robe,304,100,15,1,1,1
-24331,3,0,1,2,Fire King's Magick Robe,304,100,15,1,2,1
-24332,3,0,1,2,Fire King's Magick Robe,304,100,15,1,3,1
-24333,3,0,1,2,Fire King's Magick Robe,304,100,15,1,4,1
-24334,3,0,1,2,White Wings's Magick Robe,304,100,15,1,0,1
-24335,3,0,1,2,White Wings's Magick Robe,304,100,15,1,1,1
-24336,3,0,1,2,White Wings's Magick Robe,304,100,15,1,2,1
-24337,3,0,1,2,White Wings's Magick Robe,304,100,15,1,3,1
-24338,3,0,1,2,White Wings's Magick Robe,304,100,15,1,4,1
-24339,3,0,1,2,Golden Magick Robe,304,100,15,1,0,1
-24340,3,0,1,2,Golden Magick Robe,304,100,15,1,1,1
-24341,3,0,1,2,Golden Magick Robe,304,100,15,1,2,1
-24342,3,0,1,2,Golden Magick Robe,304,100,15,1,3,1
-24343,3,0,1,2,Golden Magick Robe,304,100,15,1,4,1
-24344,3,0,1,7,Blackshatter Magic Robe,304,100,15,1,0,1
-24345,3,0,1,7,Blackshatter Magic Robe,304,100,15,1,1,1
-24346,3,0,1,7,Blackshatter Magic Robe,304,100,15,1,2,1
-24347,3,0,1,7,Blackshatter Magic Robe,304,100,15,1,3,1
-24348,3,0,1,7,Blackshatter Magic Robe,304,100,15,1,4,1
-24424,3,0,1,2,Spirit's Magick Combat Attire,304,100,17,1,0,1
-24425,3,0,1,2,Spirit's Magick Combat Attire,304,100,17,1,1,1
-24426,3,0,1,2,Spirit's Magick Combat Attire,304,100,17,1,2,1
-24427,3,0,1,2,Spirit's Magick Combat Attire,304,100,17,1,3,1
-24428,3,0,1,2,Spirit's Magick Combat Attire,304,100,17,1,4,1
-24429,3,0,1,2,Fire King's Magick Combat Attire,304,100,17,1,0,1
-24430,3,0,1,2,Fire King's Magick Combat Attire,304,100,17,1,1,1
-24431,3,0,1,2,Fire King's Magick Combat Attire,304,100,17,1,2,1
-24432,3,0,1,2,Fire King's Magick Combat Attire,304,100,17,1,3,1
-24433,3,0,1,2,Fire King's Magick Combat Attire,304,100,17,1,4,1
-24434,3,0,1,2,White Wings' Combat Attire,304,100,17,1,0,1
-24435,3,0,1,2,White Wings' Combat Attire,304,100,17,1,1,1
-24436,3,0,1,2,White Wings' Combat Attire,304,100,17,1,2,1
-24437,3,0,1,2,White Wings' Combat Attire,304,100,17,1,3,1
-24438,3,0,1,2,White Wings' Combat Attire,304,100,17,1,4,1
-24439,3,0,1,2,Golden Magick Battle Dress,304,100,17,1,0,1
-24440,3,0,1,2,Golden Magick Battle Dress,304,100,17,1,1,1
-24441,3,0,1,2,Golden Magick Battle Dress,304,100,17,1,2,1
-24442,3,0,1,2,Golden Magick Battle Dress,304,100,17,1,3,1
-24443,3,0,1,2,Golden Magick Battle Dress,304,100,17,1,4,1
-24444,3,0,1,7,Blackshatter Battle Dress,304,100,17,1,0,1
-24445,3,0,1,7,Blackshatter Battle Dress,304,100,17,1,1,1
-24446,3,0,1,7,Blackshatter Battle Dress,304,100,17,1,2,1
-24447,3,0,1,7,Blackshatter Battle Dress,304,100,17,1,3,1
-24448,3,0,1,7,Blackshatter Battle Dress,304,100,17,1,4,1
+24124,3,0,1,130,Spirit's Heavy Armored Attire,304,100,12,1,0,1
+24125,3,0,1,130,Spirit's Heavy Armored Attire,304,100,12,1,1,1
+24126,3,0,1,130,Spirit's Heavy Armored Attire,304,100,12,1,2,1
+24127,3,0,1,130,Spirit's Heavy Armored Attire,304,100,12,1,3,1
+24128,3,0,1,130,Spirit's Heavy Armored Attire,304,100,12,1,4,1
+24129,3,0,1,130,Fire King's Heavy Armored Attire,304,100,12,1,0,1
+24130,3,0,1,130,Fire King's Heavy Armored Attire,304,100,12,1,1,1
+24131,3,0,1,130,Fire King's Heavy Armored Attire,304,100,12,1,2,1
+24132,3,0,1,130,Fire King's Heavy Armored Attire,304,100,12,1,3,1
+24133,3,0,1,130,Fire King's Heavy Armored Attire,304,100,12,1,4,1
+24134,3,0,1,130,White Wings' Armored Attire,304,100,12,1,0,1
+24135,3,0,1,130,White Wings' Armored Attire,304,100,12,1,1,1
+24136,3,0,1,130,White Wings' Armored Attire,304,100,12,1,2,1
+24137,3,0,1,130,White Wings' Armored Attire,304,100,12,1,3,1
+24138,3,0,1,130,White Wings' Armored Attire,304,100,12,1,4,1
+24139,3,0,1,130,Golden Heavy Armor,304,100,12,1,0,1
+24140,3,0,1,130,Golden Heavy Armor,304,100,12,1,1,1
+24141,3,0,1,130,Golden Heavy Armor,304,100,12,1,2,1
+24142,3,0,1,130,Golden Heavy Armor,304,100,12,1,3,1
+24143,3,0,1,130,Golden Heavy Armor,304,100,12,1,4,1
+24144,3,0,1,135,Blackshatter Heavy Armor,304,100,12,1,0,1
+24145,3,0,1,135,Blackshatter Heavy Armor,304,100,12,1,1,1
+24146,3,0,1,135,Blackshatter Heavy Armor,304,100,12,1,2,1
+24147,3,0,1,135,Blackshatter Heavy Armor,304,100,12,1,3,1
+24148,3,0,1,135,Blackshatter Heavy Armor,304,100,12,1,4,1
+24224,3,0,1,130,Spirit's Light Armored Attire,304,100,14,1,0,1
+24225,3,0,1,130,Spirit's Light Armored Attire,304,100,14,1,1,1
+24226,3,0,1,130,Spirit's Light Armored Attire,304,100,14,1,2,1
+24227,3,0,1,130,Spirit's Light Armored Attire,304,100,14,1,3,1
+24228,3,0,1,130,Spirit's Light Armored Attire,304,100,14,1,4,1
+24229,3,0,1,130,Fire King's Light Armored Attire,304,100,14,1,0,1
+24230,3,0,1,130,Fire King's Light Armored Attire,304,100,14,1,1,1
+24231,3,0,1,130,Fire King's Light Armored Attire,304,100,14,1,2,1
+24232,3,0,1,130,Fire King's Light Armored Attire,304,100,14,1,3,1
+24233,3,0,1,130,Fire King's Light Armored Attire,304,100,14,1,4,1
+24234,3,0,1,130,White Wings' Light Armored Attire,304,100,14,1,0,1
+24235,3,0,1,130,White Wings' Light Armored Attire,304,100,14,1,1,1
+24236,3,0,1,130,White Wings' Light Armored Attire,304,100,14,1,2,1
+24237,3,0,1,130,White Wings' Light Armored Attire,304,100,14,1,3,1
+24238,3,0,1,130,White Wings' Light Armored Attire,304,100,14,1,4,1
+24239,3,0,1,130,Golden Light Armor,304,100,14,1,0,1
+24240,3,0,1,130,Golden Light Armor,304,100,14,1,1,1
+24241,3,0,1,130,Golden Light Armor,304,100,14,1,2,1
+24242,3,0,1,130,Golden Light Armor,304,100,14,1,3,1
+24243,3,0,1,130,Golden Light Armor,304,100,14,1,4,1
+24244,3,0,1,135,Blackshatter Light Armor,304,100,14,1,0,1
+24245,3,0,1,135,Blackshatter Light Armor,304,100,14,1,1,1
+24246,3,0,1,135,Blackshatter Light Armor,304,100,14,1,2,1
+24247,3,0,1,135,Blackshatter Light Armor,304,100,14,1,3,1
+24248,3,0,1,135,Blackshatter Light Armor,304,100,14,1,4,1
+24324,3,0,1,130,Spirit's Magick Robe,304,100,15,1,0,1
+24325,3,0,1,130,Spirit's Magick Robe,304,100,15,1,1,1
+24326,3,0,1,130,Spirit's Magick Robe,304,100,15,1,2,1
+24327,3,0,1,130,Spirit's Magick Robe,304,100,15,1,3,1
+24328,3,0,1,130,Spirit's Magick Robe,304,100,15,1,4,1
+24329,3,0,1,130,Fire King's Magick Robe,304,100,15,1,0,1
+24330,3,0,1,130,Fire King's Magick Robe,304,100,15,1,1,1
+24331,3,0,1,130,Fire King's Magick Robe,304,100,15,1,2,1
+24332,3,0,1,130,Fire King's Magick Robe,304,100,15,1,3,1
+24333,3,0,1,130,Fire King's Magick Robe,304,100,15,1,4,1
+24334,3,0,1,130,White Wings's Magick Robe,304,100,15,1,0,1
+24335,3,0,1,130,White Wings's Magick Robe,304,100,15,1,1,1
+24336,3,0,1,130,White Wings's Magick Robe,304,100,15,1,2,1
+24337,3,0,1,130,White Wings's Magick Robe,304,100,15,1,3,1
+24338,3,0,1,130,White Wings's Magick Robe,304,100,15,1,4,1
+24339,3,0,1,130,Golden Magick Robe,304,100,15,1,0,1
+24340,3,0,1,130,Golden Magick Robe,304,100,15,1,1,1
+24341,3,0,1,130,Golden Magick Robe,304,100,15,1,2,1
+24342,3,0,1,130,Golden Magick Robe,304,100,15,1,3,1
+24343,3,0,1,130,Golden Magick Robe,304,100,15,1,4,1
+24344,3,0,1,135,Blackshatter Magic Robe,304,100,15,1,0,1
+24345,3,0,1,135,Blackshatter Magic Robe,304,100,15,1,1,1
+24346,3,0,1,135,Blackshatter Magic Robe,304,100,15,1,2,1
+24347,3,0,1,135,Blackshatter Magic Robe,304,100,15,1,3,1
+24348,3,0,1,135,Blackshatter Magic Robe,304,100,15,1,4,1
+24424,3,0,1,130,Spirit's Magick Combat Attire,304,100,17,1,0,1
+24425,3,0,1,130,Spirit's Magick Combat Attire,304,100,17,1,1,1
+24426,3,0,1,130,Spirit's Magick Combat Attire,304,100,17,1,2,1
+24427,3,0,1,130,Spirit's Magick Combat Attire,304,100,17,1,3,1
+24428,3,0,1,130,Spirit's Magick Combat Attire,304,100,17,1,4,1
+24429,3,0,1,130,Fire King's Magick Combat Attire,304,100,17,1,0,1
+24430,3,0,1,130,Fire King's Magick Combat Attire,304,100,17,1,1,1
+24431,3,0,1,130,Fire King's Magick Combat Attire,304,100,17,1,2,1
+24432,3,0,1,130,Fire King's Magick Combat Attire,304,100,17,1,3,1
+24433,3,0,1,130,Fire King's Magick Combat Attire,304,100,17,1,4,1
+24434,3,0,1,130,White Wings' Combat Attire,304,100,17,1,0,1
+24435,3,0,1,130,White Wings' Combat Attire,304,100,17,1,1,1
+24436,3,0,1,130,White Wings' Combat Attire,304,100,17,1,2,1
+24437,3,0,1,130,White Wings' Combat Attire,304,100,17,1,3,1
+24438,3,0,1,130,White Wings' Combat Attire,304,100,17,1,4,1
+24439,3,0,1,130,Golden Magick Battle Dress,304,100,17,1,0,1
+24440,3,0,1,130,Golden Magick Battle Dress,304,100,17,1,1,1
+24441,3,0,1,130,Golden Magick Battle Dress,304,100,17,1,2,1
+24442,3,0,1,130,Golden Magick Battle Dress,304,100,17,1,3,1
+24443,3,0,1,130,Golden Magick Battle Dress,304,100,17,1,4,1
+24444,3,0,1,135,Blackshatter Battle Dress,304,100,17,1,0,1
+24445,3,0,1,135,Blackshatter Battle Dress,304,100,17,1,1,1
+24446,3,0,1,135,Blackshatter Battle Dress,304,100,17,1,2,1
+24447,3,0,1,135,Blackshatter Battle Dress,304,100,17,1,3,1
+24448,3,0,1,135,Blackshatter Battle Dress,304,100,17,1,4,1
 24609,3,0,1,12,Pleiades Robe,304,1,0,1,4,1
 24614,3,0,1,12,Valkyrian Armor,304,1,0,1,4,1
-24700,3,50000,1,2,Survivor Leather Coat,304,1,0,4,4,1
+24700,3,50000,1,130,Survivor Leather Coat,304,1,0,4,4,1
 24916,3,10000,1,1,Southern Country Pareo (Red),304,1,0,1,0,1
 24917,3,10000,1,1,Southern Country Pareo (Blue),304,1,0,1,0,1
 24918,3,10000,1,1,Southern Country Pareo (Purple),304,1,0,1,0,1
@@ -14954,70 +14954,70 @@
 24921,3,10000,1,1,Southern Country Pareo (Orange),304,1,0,1,0,1
 24935,3,10000,1,1,God of War's Chest,304,1,0,1,4,1
 24939,3,10000,1,1,Spriggan Breastplate,304,1,0,1,4,1
-25015,3,50000,1,2,Combat Leather Coat,304,1,0,4,4,1
+25015,3,50000,1,130,Combat Leather Coat,304,1,0,4,4,1
 25225,3,10000,1,1,Holy Seal's Generous Armor,304,1,0,1,4,1
 25229,3,10000,1,1,Tricksters' Generous Coat,304,1,0,1,4,1
 25233,3,10000,1,1,Hero's Generous Armor,304,1,0,1,4,1
-25241,3,25100,1,12,Savage Courage Assault Mail,304,105,12,1,0,1
-25242,3,25100,1,12,Savage Courage Assault Mail,304,105,12,1,1,1
-25243,3,25100,1,12,Savage Courage Assault Mail,304,105,12,1,2,1
-25244,3,25100,1,12,Savage Courage Assault Mail,304,105,12,1,3,1
-25245,3,25100,1,12,Savage Courage Assault Mail,304,105,12,1,4,1
-25261,3,25100,1,1,Solitary Assault Armor,304,110,12,1,0,1
-25262,3,25100,1,1,Solitary Assault Armor,304,110,12,1,1,1
-25263,3,25100,1,1,Solitary Assault Armor,304,110,12,1,2,1
-25264,3,25100,1,1,Solitary Assault Armor,304,110,12,1,3,1
-25265,3,25100,1,1,Solitary Assault Armor,304,110,12,1,4,1
-25281,3,25100,1,6,Hero's Assault Armor,304,115,12,1,0,1
-25282,3,25100,1,6,Hero's Assault Armor,304,115,12,1,1,1
-25283,3,25100,1,6,Hero's Assault Armor,304,115,12,1,2,1
-25284,3,25100,1,6,Hero's Assault Armor,304,115,12,1,3,1
-25285,3,25100,1,6,Hero's Assault Armor,304,115,12,1,4,1
-25301,3,25100,1,12,Savage Courage Snipe vest,304,105,14,1,0,1
-25302,3,25100,1,12,Savage Courage Snipe vest,304,105,14,1,1,1
-25303,3,25100,1,12,Savage Courage Snipe vest,304,105,14,1,2,1
-25304,3,25100,1,12,Savage Courage Snipe vest,304,105,14,1,3,1
-25305,3,25100,1,12,Savage Courage Snipe vest,304,105,14,1,4,1
-25321,3,25100,1,1,Solitary's Snipe Vest,304,110,14,1,0,1
-25322,3,25100,1,1,Solitary's Snipe Vest,304,110,14,1,1,1
-25323,3,25100,1,1,Solitary's Snipe Vest,304,110,14,1,2,1
-25324,3,25100,1,1,Solitary's Snipe Vest,304,110,14,1,3,1
-25325,3,25100,1,1,Solitary's Snipe Vest,304,110,14,1,4,1
-25341,3,25100,1,6,Hero's Snipe Jacket,304,115,14,1,0,1
-25342,3,25100,1,6,Hero's Snipe Jacket,304,115,14,1,1,1
-25343,3,25100,1,6,Hero's Snipe Jacket,304,115,14,1,2,1
-25344,3,25100,1,6,Hero's Snipe Jacket,304,115,14,1,3,1
-25345,3,25100,1,6,Hero's Snipe Jacket,304,115,14,1,4,1
-25361,3,25100,1,12,Savage Courage Magic Robe,304,105,15,1,0,1
-25362,3,25100,1,12,Savage Courage Magic Robe,304,105,15,1,1,1
-25363,3,25100,1,12,Savage Courage Magic Robe,304,105,15,1,2,1
-25364,3,25100,1,12,Savage Courage Magic Robe,304,105,15,1,3,1
-25365,3,25100,1,12,Savage Courage Magic Robe,304,105,15,1,4,1
-25381,3,25100,1,1,Solitary Magic Jacket,304,110,15,1,0,1
-25382,3,25100,1,1,Solitary Magic Jacket,304,110,15,1,1,1
-25383,3,25100,1,1,Solitary Magic Jacket,304,110,15,1,2,1
-25384,3,25100,1,1,Solitary Magic Jacket,304,110,15,1,3,1
-25385,3,25100,1,1,Solitary Magic Jacket,304,110,15,1,4,1
-25401,3,25100,1,6,Hero's Magic Breast,304,115,15,1,0,1
-25402,3,25100,1,6,Hero's Magic Breast,304,115,15,1,1,1
-25403,3,25100,1,6,Hero's Magic Breast,304,115,15,1,2,1
-25404,3,25100,1,6,Hero's Magic Breast,304,115,15,1,3,1
-25405,3,25100,1,6,Hero's Magic Breast,304,115,15,1,4,1
-25421,3,25100,1,12,Savage Courage Ranger Armor,304,105,17,1,0,1
-25422,3,25100,1,12,Savage Courage Ranger Armor,304,105,17,1,1,1
-25423,3,25100,1,12,Savage Courage Ranger Armor,304,105,17,1,2,1
-25424,3,25100,1,12,Savage Courage Ranger Armor,304,105,17,1,3,1
-25425,3,25100,1,12,Savage Courage Ranger Armor,304,105,17,1,4,1
-25441,3,25100,1,1,Solitary Ranger's Robe,304,110,17,1,0,1
-25442,3,25100,1,1,Solitary Ranger's Robe,304,110,17,1,1,1
-25443,3,25100,1,1,Solitary Ranger's Robe,304,110,17,1,2,1
-25444,3,25100,1,1,Solitary Ranger's Robe,304,110,17,1,3,1
-25445,3,25100,1,1,Solitary Ranger's Robe,304,110,17,1,4,1
-25461,3,25100,1,6,Hero's Ranger Coat,304,115,17,1,0,1
-25462,3,25100,1,6,Hero's Ranger Coat,304,115,17,1,1,1
-25463,3,25100,1,6,Hero's Ranger Coat,304,115,17,1,2,1
-25464,3,25100,1,6,Hero's Ranger Coat,304,115,17,1,3,1
-25465,3,25100,1,6,Hero's Ranger Coat,304,115,17,1,4,1
+25241,3,25100,1,140,Savage Courage Assault Mail,304,105,12,1,0,1
+25242,3,25100,1,140,Savage Courage Assault Mail,304,105,12,1,1,1
+25243,3,25100,1,140,Savage Courage Assault Mail,304,105,12,1,2,1
+25244,3,25100,1,140,Savage Courage Assault Mail,304,105,12,1,3,1
+25245,3,25100,1,140,Savage Courage Assault Mail,304,105,12,1,4,1
+25261,3,25100,1,145,Solitary Assault Armor,304,110,12,1,0,1
+25262,3,25100,1,145,Solitary Assault Armor,304,110,12,1,1,1
+25263,3,25100,1,145,Solitary Assault Armor,304,110,12,1,2,1
+25264,3,25100,1,145,Solitary Assault Armor,304,110,12,1,3,1
+25265,3,25100,1,145,Solitary Assault Armor,304,110,12,1,4,1
+25281,3,25100,1,150,Hero's Assault Armor,304,115,12,1,0,1
+25282,3,25100,1,150,Hero's Assault Armor,304,115,12,1,1,1
+25283,3,25100,1,150,Hero's Assault Armor,304,115,12,1,2,1
+25284,3,25100,1,150,Hero's Assault Armor,304,115,12,1,3,1
+25285,3,25100,1,150,Hero's Assault Armor,304,115,12,1,4,1
+25301,3,25100,1,140,Savage Courage Snipe vest,304,105,14,1,0,1
+25302,3,25100,1,140,Savage Courage Snipe vest,304,105,14,1,1,1
+25303,3,25100,1,140,Savage Courage Snipe vest,304,105,14,1,2,1
+25304,3,25100,1,140,Savage Courage Snipe vest,304,105,14,1,3,1
+25305,3,25100,1,140,Savage Courage Snipe vest,304,105,14,1,4,1
+25321,3,25100,1,145,Solitary's Snipe Vest,304,110,14,1,0,1
+25322,3,25100,1,145,Solitary's Snipe Vest,304,110,14,1,1,1
+25323,3,25100,1,145,Solitary's Snipe Vest,304,110,14,1,2,1
+25324,3,25100,1,145,Solitary's Snipe Vest,304,110,14,1,3,1
+25325,3,25100,1,145,Solitary's Snipe Vest,304,110,14,1,4,1
+25341,3,25100,1,150,Hero's Snipe Jacket,304,115,14,1,0,1
+25342,3,25100,1,150,Hero's Snipe Jacket,304,115,14,1,1,1
+25343,3,25100,1,150,Hero's Snipe Jacket,304,115,14,1,2,1
+25344,3,25100,1,150,Hero's Snipe Jacket,304,115,14,1,3,1
+25345,3,25100,1,150,Hero's Snipe Jacket,304,115,14,1,4,1
+25361,3,25100,1,140,Savage Courage Magic Robe,304,105,15,1,0,1
+25362,3,25100,1,140,Savage Courage Magic Robe,304,105,15,1,1,1
+25363,3,25100,1,140,Savage Courage Magic Robe,304,105,15,1,2,1
+25364,3,25100,1,140,Savage Courage Magic Robe,304,105,15,1,3,1
+25365,3,25100,1,140,Savage Courage Magic Robe,304,105,15,1,4,1
+25381,3,25100,1,145,Solitary Magic Jacket,304,110,15,1,0,1
+25382,3,25100,1,145,Solitary Magic Jacket,304,110,15,1,1,1
+25383,3,25100,1,145,Solitary Magic Jacket,304,110,15,1,2,1
+25384,3,25100,1,145,Solitary Magic Jacket,304,110,15,1,3,1
+25385,3,25100,1,145,Solitary Magic Jacket,304,110,15,1,4,1
+25401,3,25100,1,150,Hero's Magic Breast,304,115,15,1,0,1
+25402,3,25100,1,150,Hero's Magic Breast,304,115,15,1,1,1
+25403,3,25100,1,150,Hero's Magic Breast,304,115,15,1,2,1
+25404,3,25100,1,150,Hero's Magic Breast,304,115,15,1,3,1
+25405,3,25100,1,150,Hero's Magic Breast,304,115,15,1,4,1
+25421,3,25100,1,140,Savage Courage Ranger Armor,304,105,17,1,0,1
+25422,3,25100,1,140,Savage Courage Ranger Armor,304,105,17,1,1,1
+25423,3,25100,1,140,Savage Courage Ranger Armor,304,105,17,1,2,1
+25424,3,25100,1,140,Savage Courage Ranger Armor,304,105,17,1,3,1
+25425,3,25100,1,140,Savage Courage Ranger Armor,304,105,17,1,4,1
+25441,3,25100,1,145,Solitary Ranger's Robe,304,110,17,1,0,1
+25442,3,25100,1,145,Solitary Ranger's Robe,304,110,17,1,1,1
+25443,3,25100,1,145,Solitary Ranger's Robe,304,110,17,1,2,1
+25444,3,25100,1,145,Solitary Ranger's Robe,304,110,17,1,3,1
+25445,3,25100,1,145,Solitary Ranger's Robe,304,110,17,1,4,1
+25461,3,25100,1,150,Hero's Ranger Coat,304,115,17,1,0,1
+25462,3,25100,1,150,Hero's Ranger Coat,304,115,17,1,1,1
+25463,3,25100,1,150,Hero's Ranger Coat,304,115,17,1,2,1
+25464,3,25100,1,150,Hero's Ranger Coat,304,115,17,1,3,1
+25465,3,25100,1,150,Hero's Ranger Coat,304,115,17,1,4,1
 25531,3,10000,1,1,Holy Seal's Trust Coat,304,1,0,1,4,1
 25535,3,10000,1,1,Holy Seal's Lively Robe,304,1,0,1,4,1
 25539,3,10000,1,1,Holy Seal's Grandiose Apron,304,1,0,1,4,1
@@ -15308,49 +15308,49 @@
 10458,3,4000,1,12,Enforcer's Sacred Clothing (Crimson),305,1,0,0,2,1
 10459,3,4000,1,12,Enforcer's Sacred Clothing (Crimson),305,1,0,0,3,1
 10460,3,4000,1,12,Enforcer's Sacred Clothing (Crimson),305,1,0,0,4,1
-10512,3,5000,1,9,Enforcer's Sacred Clothing (Moonflower),305,55,0,0,4,1
-10517,3,5000,1,8,Enforcer's Sacred Clothing (Dark Night),305,60,0,0,4,1
+10512,3,5000,1,25,Enforcer's Sacred Clothing (Moonflower),305,55,0,0,4,1
+10517,3,5000,1,40,Enforcer's Sacred Clothing (Dark Night),305,60,0,0,4,1
 11751,3,6000,1,1,Invisible Underwear,305,1,0,0,0,1
 13073,3,2018,1,15,Correct Bracers,305,62,0,0,0,1
 13074,3,2018,1,15,Correct Bracers,305,62,0,0,1,1
 13075,3,2018,1,15,Correct Bracers,305,62,0,0,2,1
 13076,3,2018,1,15,Correct Bracers,305,62,0,0,3,1
 13077,3,2018,1,15,Correct Bracers,305,62,0,0,4,1
-13078,3,2218,1,4,Dapper Wear,305,65,0,0,0,1
-13079,3,2218,1,4,Dapper Wear,305,65,0,0,1,1
-13080,3,2218,1,4,Dapper Wear,305,65,0,0,2,1
-13081,3,2218,1,4,Dapper Wear,305,65,0,0,3,1
-13082,3,2218,1,4,Dapper Wear,305,65,0,0,4,1
-13083,3,2218,1,9,Silver Breastplate,305,65,0,0,0,1
-13084,3,2218,1,9,Silver Breastplate,305,65,0,0,1,1
-13085,3,2218,1,9,Silver Breastplate,305,65,0,0,2,1
-13086,3,2218,1,9,Silver Breastplate,305,65,0,0,3,1
-13087,3,2218,1,9,Silver Breastplate,305,65,0,0,4,1
-13088,3,2218,1,14,High Solid Quilted Shirt,305,65,0,0,0,1
-13089,3,2218,1,14,High Solid Quilted Shirt,305,65,0,0,1,1
-13090,3,2218,1,14,High Solid Quilted Shirt,305,65,0,0,2,1
-13091,3,2218,1,14,High Solid Quilted Shirt,305,65,0,0,3,1
-13092,3,2218,1,14,High Solid Quilted Shirt,305,65,0,0,4,1
-13093,3,2357,1,14,Heavenly Silk,305,67,0,0,0,1
-13094,3,2357,1,14,Heavenly Silk,305,67,0,0,1,1
-13095,3,2357,1,14,Heavenly Silk,305,67,0,0,2,1
-13096,3,2357,1,14,Heavenly Silk,305,67,0,0,3,1
-13097,3,2357,1,14,Heavenly Silk,305,67,0,0,4,1
-13098,3,2573,1,3,Nabla Armor,305,70,0,0,0,1
-13099,3,2573,1,3,Nabla Armor,305,70,0,0,1,1
-13100,3,2573,1,3,Nabla Armor,305,70,0,0,2,1
-13101,3,2573,1,3,Nabla Armor,305,70,0,0,3,1
-13102,3,2573,1,3,Nabla Armor,305,70,0,0,4,1
-13103,3,2573,1,8,Imperial Chain,305,70,0,0,0,1
-13104,3,2573,1,8,Imperial Chain,305,70,0,0,1,1
-13105,3,2573,1,8,Imperial Chain,305,70,0,0,2,1
-13106,3,2573,1,8,Imperial Chain,305,70,0,0,3,1
-13107,3,2573,1,8,Imperial Chain,305,70,0,0,4,1
-13108,3,2573,1,13,Dragon Hide Vest,305,70,0,0,0,1
-13109,3,2573,1,13,Dragon Hide Vest,305,70,0,0,1,1
-13110,3,2573,1,13,Dragon Hide Vest,305,70,0,0,2,1
-13111,3,2573,1,13,Dragon Hide Vest,305,70,0,0,3,1
-13112,3,2573,1,13,Dragon Hide Vest,305,70,0,0,4,1
+13078,3,2218,1,20,Dapper Wear,305,65,0,0,0,1
+13079,3,2218,1,20,Dapper Wear,305,65,0,0,1,1
+13080,3,2218,1,20,Dapper Wear,305,65,0,0,2,1
+13081,3,2218,1,20,Dapper Wear,305,65,0,0,3,1
+13082,3,2218,1,20,Dapper Wear,305,65,0,0,4,1
+13083,3,2218,1,25,Silver Breastplate,305,65,0,0,0,1
+13084,3,2218,1,25,Silver Breastplate,305,65,0,0,1,1
+13085,3,2218,1,25,Silver Breastplate,305,65,0,0,2,1
+13086,3,2218,1,25,Silver Breastplate,305,65,0,0,3,1
+13087,3,2218,1,25,Silver Breastplate,305,65,0,0,4,1
+13088,3,2218,1,30,High Solid Quilted Shirt,305,65,0,0,0,1
+13089,3,2218,1,30,High Solid Quilted Shirt,305,65,0,0,1,1
+13090,3,2218,1,30,High Solid Quilted Shirt,305,65,0,0,2,1
+13091,3,2218,1,30,High Solid Quilted Shirt,305,65,0,0,3,1
+13092,3,2218,1,30,High Solid Quilted Shirt,305,65,0,0,4,1
+13093,3,2357,1,30,Heavenly Silk,305,67,0,0,0,1
+13094,3,2357,1,30,Heavenly Silk,305,67,0,0,1,1
+13095,3,2357,1,30,Heavenly Silk,305,67,0,0,2,1
+13096,3,2357,1,30,Heavenly Silk,305,67,0,0,3,1
+13097,3,2357,1,30,Heavenly Silk,305,67,0,0,4,1
+13098,3,2573,1,35,Nabla Armor,305,70,0,0,0,1
+13099,3,2573,1,35,Nabla Armor,305,70,0,0,1,1
+13100,3,2573,1,35,Nabla Armor,305,70,0,0,2,1
+13101,3,2573,1,35,Nabla Armor,305,70,0,0,3,1
+13102,3,2573,1,35,Nabla Armor,305,70,0,0,4,1
+13103,3,2573,1,40,Imperial Chain,305,70,0,0,0,1
+13104,3,2573,1,40,Imperial Chain,305,70,0,0,1,1
+13105,3,2573,1,40,Imperial Chain,305,70,0,0,2,1
+13106,3,2573,1,40,Imperial Chain,305,70,0,0,3,1
+13107,3,2573,1,40,Imperial Chain,305,70,0,0,4,1
+13108,3,2573,1,45,Dragon Hide Vest,305,70,0,0,0,1
+13109,3,2573,1,45,Dragon Hide Vest,305,70,0,0,1,1
+13110,3,2573,1,45,Dragon Hide Vest,305,70,0,0,2,1
+13111,3,2573,1,45,Dragon Hide Vest,305,70,0,0,3,1
+13112,3,2573,1,45,Dragon Hide Vest,305,70,0,0,4,1
 13600,3,3500,1,11,Marquis Wear,305,1,0,0,0,1
 13601,3,3500,1,11,Marquis Wear,305,1,0,0,1,1
 13602,3,3500,1,11,Marquis Wear,305,1,0,0,2,1
@@ -15362,139 +15362,139 @@
 14157,3,10000,1,7,Night Black Swimsuit (Top),305,1,0,0,0,1
 14159,3,10000,1,7,Silver Gray Swimsuit (Top),305,1,0,0,0,1
 14161,3,10000,1,7,Setting Sun Swimsuit (Top),305,1,0,0,0,1
-15148,3,2722,1,13,Questing Tunic,305,72,0,0,0,1
-15149,3,2722,1,13,Questing Tunic,305,72,0,0,1,1
-15150,3,2722,1,13,Questing Tunic,305,72,0,0,2,1
-15151,3,2722,1,13,Questing Tunic,305,72,0,0,3,1
-15152,3,2722,1,13,Questing Tunic,305,72,0,0,4,1
-15153,3,2953,1,2,Hero's Vest,305,75,0,0,0,1
-15154,3,2953,1,2,Hero's Vest,305,75,0,0,1,1
-15155,3,2953,1,2,Hero's Vest,305,75,0,0,2,1
-15156,3,2953,1,2,Hero's Vest,305,75,0,0,3,1
-15157,3,2953,1,2,Hero's Vest,305,75,0,0,4,1
-15158,3,2953,1,7,Leaf Bandages,305,75,0,0,0,1
-15159,3,2953,1,7,Leaf Bandages,305,75,0,0,1,1
-15160,3,2953,1,7,Leaf Bandages,305,75,0,0,2,1
-15161,3,2953,1,7,Leaf Bandages,305,75,0,0,3,1
-15162,3,2953,1,7,Leaf Bandages,305,75,0,0,4,1
-15163,3,2953,1,12,Phindymian Breastplate,305,75,0,0,0,1
-15164,3,2953,1,12,Phindymian Breastplate,305,75,0,0,1,1
-15165,3,2953,1,12,Phindymian Breastplate,305,75,0,0,2,1
-15166,3,2953,1,12,Phindymian Breastplate,305,75,0,0,3,1
-15167,3,2953,1,12,Phindymian Breastplate,305,75,0,0,4,1
-15168,3,3113,1,12,Pallid Wear,305,77,0,0,0,1
-15169,3,3113,1,12,Pallid Wear,305,77,0,0,1,1
-15170,3,3113,1,12,Pallid Wear,305,77,0,0,2,1
-15171,3,3113,1,12,Pallid Wear,305,77,0,0,3,1
-15172,3,3113,1,12,Pallid Wear,305,77,0,0,4,1
-15173,3,3360,1,1,Dark Gray Brigandine,305,80,0,0,0,1
-15174,3,3360,1,1,Dark Gray Brigandine,305,80,0,0,1,1
-15175,3,3360,1,1,Dark Gray Brigandine,305,80,0,0,2,1
-15176,3,3360,1,1,Dark Gray Brigandine,305,80,0,0,3,1
-15177,3,3360,1,1,Dark Gray Brigandine,305,80,0,0,4,1
-15178,3,3360,1,6,Holy Breastplate,305,80,0,0,0,1
-15179,3,3360,1,6,Holy Breastplate,305,80,0,0,1,1
-15180,3,3360,1,6,Holy Breastplate,305,80,0,0,2,1
-15181,3,3360,1,6,Holy Breastplate,305,80,0,0,3,1
-15182,3,3360,1,6,Holy Breastplate,305,80,0,0,4,1
-15183,3,3360,1,11,Azure Gambeson,305,80,0,0,0,1
-15184,3,3360,1,11,Azure Gambeson,305,80,0,0,1,1
-15185,3,3360,1,11,Azure Gambeson,305,80,0,0,2,1
-15186,3,3360,1,11,Azure Gambeson,305,80,0,0,3,1
-15187,3,3360,1,11,Azure Gambeson,305,80,0,0,4,1
-15188,3,5000,1,7,Duke Wear (Dark Night),305,70,0,0,4,1
-15193,3,5000,1,6,Duke Wear (Moonflower),305,75,0,0,4,1
+15148,3,2722,1,45,Questing Tunic,305,72,0,0,0,1
+15149,3,2722,1,45,Questing Tunic,305,72,0,0,1,1
+15150,3,2722,1,45,Questing Tunic,305,72,0,0,2,1
+15151,3,2722,1,45,Questing Tunic,305,72,0,0,3,1
+15152,3,2722,1,45,Questing Tunic,305,72,0,0,4,1
+15153,3,2953,1,50,Hero's Vest,305,75,0,0,0,1
+15154,3,2953,1,50,Hero's Vest,305,75,0,0,1,1
+15155,3,2953,1,50,Hero's Vest,305,75,0,0,2,1
+15156,3,2953,1,50,Hero's Vest,305,75,0,0,3,1
+15157,3,2953,1,50,Hero's Vest,305,75,0,0,4,1
+15158,3,2953,1,55,Leaf Bandages,305,75,0,0,0,1
+15159,3,2953,1,55,Leaf Bandages,305,75,0,0,1,1
+15160,3,2953,1,55,Leaf Bandages,305,75,0,0,2,1
+15161,3,2953,1,55,Leaf Bandages,305,75,0,0,3,1
+15162,3,2953,1,55,Leaf Bandages,305,75,0,0,4,1
+15163,3,2953,1,60,Phindymian Breastplate,305,75,0,0,0,1
+15164,3,2953,1,60,Phindymian Breastplate,305,75,0,0,1,1
+15165,3,2953,1,60,Phindymian Breastplate,305,75,0,0,2,1
+15166,3,2953,1,60,Phindymian Breastplate,305,75,0,0,3,1
+15167,3,2953,1,60,Phindymian Breastplate,305,75,0,0,4,1
+15168,3,3113,1,60,Pallid Wear,305,77,0,0,0,1
+15169,3,3113,1,60,Pallid Wear,305,77,0,0,1,1
+15170,3,3113,1,60,Pallid Wear,305,77,0,0,2,1
+15171,3,3113,1,60,Pallid Wear,305,77,0,0,3,1
+15172,3,3113,1,60,Pallid Wear,305,77,0,0,4,1
+15173,3,3360,1,65,Dark Gray Brigandine,305,80,0,0,0,1
+15174,3,3360,1,65,Dark Gray Brigandine,305,80,0,0,1,1
+15175,3,3360,1,65,Dark Gray Brigandine,305,80,0,0,2,1
+15176,3,3360,1,65,Dark Gray Brigandine,305,80,0,0,3,1
+15177,3,3360,1,65,Dark Gray Brigandine,305,80,0,0,4,1
+15178,3,3360,1,70,Holy Breastplate,305,80,0,0,0,1
+15179,3,3360,1,70,Holy Breastplate,305,80,0,0,1,1
+15180,3,3360,1,70,Holy Breastplate,305,80,0,0,2,1
+15181,3,3360,1,70,Holy Breastplate,305,80,0,0,3,1
+15182,3,3360,1,70,Holy Breastplate,305,80,0,0,4,1
+15183,3,3360,1,75,Azure Gambeson,305,80,0,0,0,1
+15184,3,3360,1,75,Azure Gambeson,305,80,0,0,1,1
+15185,3,3360,1,75,Azure Gambeson,305,80,0,0,2,1
+15186,3,3360,1,75,Azure Gambeson,305,80,0,0,3,1
+15187,3,3360,1,75,Azure Gambeson,305,80,0,0,4,1
+15188,3,5000,1,55,Duke Wear (Dark Night),305,70,0,0,4,1
+15193,3,5000,1,70,Duke Wear (Moonflower),305,75,0,0,4,1
 16790,3,100,1,1,Christmas Wear,305,1,0,0,4,1
 16797,3,100,1,1,Christmas Wear (White),305,1,0,0,4,1
-17811,3,3363,1,0,Arabesque Wear,305,80,0,0,0,1
-17812,3,3363,1,0,Arabesque Wear,305,80,0,0,1,1
-17813,3,3363,1,0,Arabesque Wear,305,80,0,0,2,1
-17814,3,3363,1,0,Arabesque Wear,305,80,0,0,3,1
-17815,3,3363,1,0,Arabesque Wear,305,80,0,0,4,1
-17816,3,3605,1,5,Biyabaan Mail,305,83,0,0,0,1
-17817,3,3605,1,5,Biyabaan Mail,305,83,0,0,1,1
-17818,3,3605,1,5,Biyabaan Mail,305,83,0,0,2,1
-17819,3,3605,1,5,Biyabaan Mail,305,83,0,0,3,1
-17820,3,3605,1,5,Biyabaan Mail,305,83,0,0,4,1
-17821,3,3767,1,10,Acrean Tunic,305,85,0,0,0,1
-17822,3,3767,1,10,Acrean Tunic,305,85,0,0,1,1
-17823,3,3767,1,10,Acrean Tunic,305,85,0,0,2,1
-17824,3,3767,1,10,Acrean Tunic,305,85,0,0,3,1
-17825,3,3767,1,10,Acrean Tunic,305,85,0,0,4,1
+17811,3,3363,1,80,Arabesque Wear,305,80,0,0,0,1
+17812,3,3363,1,80,Arabesque Wear,305,80,0,0,1,1
+17813,3,3363,1,80,Arabesque Wear,305,80,0,0,2,1
+17814,3,3363,1,80,Arabesque Wear,305,80,0,0,3,1
+17815,3,3363,1,80,Arabesque Wear,305,80,0,0,4,1
+17816,3,3605,1,85,Biyabaan Mail,305,83,0,0,0,1
+17817,3,3605,1,85,Biyabaan Mail,305,83,0,0,1,1
+17818,3,3605,1,85,Biyabaan Mail,305,83,0,0,2,1
+17819,3,3605,1,85,Biyabaan Mail,305,83,0,0,3,1
+17820,3,3605,1,85,Biyabaan Mail,305,83,0,0,4,1
+17821,3,3767,1,90,Acrean Tunic,305,85,0,0,0,1
+17822,3,3767,1,90,Acrean Tunic,305,85,0,0,1,1
+17823,3,3767,1,90,Acrean Tunic,305,85,0,0,2,1
+17824,3,3767,1,90,Acrean Tunic,305,85,0,0,3,1
+17825,3,3767,1,90,Acrean Tunic,305,85,0,0,4,1
 17954,3,5000,1,7,Alluring Swimsuit Top (Glittering Gold),305,1,0,0,0,1
-18439,3,3767,1,10,Asker Suit,305,85,0,0,0,1
-18440,3,3767,1,10,Asker Suit,305,85,0,0,1,1
-18441,3,3767,1,10,Asker Suit,305,85,0,0,2,1
-18442,3,3767,1,10,Asker Suit,305,85,0,0,3,1
-18443,3,3767,1,10,Asker Suit,305,85,0,0,4,1
-18444,3,4029,1,15,Krall Breastplate,305,88,0,0,0,1
-18445,3,4029,1,15,Krall Breastplate,305,88,0,0,1,1
-18446,3,4029,1,15,Krall Breastplate,305,88,0,0,2,1
-18447,3,4029,1,15,Krall Breastplate,305,88,0,0,3,1
-18448,3,4029,1,15,Krall Breastplate,305,88,0,0,4,1
-18449,3,4185,1,4,Casanance Tunic,305,90,0,0,0,1
-18450,3,4185,1,4,Casanance Tunic,305,90,0,0,1,1
-18451,3,4185,1,4,Casanance Tunic,305,90,0,0,2,1
-18452,3,4185,1,4,Casanance Tunic,305,90,0,0,3,1
-18453,3,4185,1,4,Casanance Tunic,305,90,0,0,4,1
-18589,3,7000,1,13,Black Venom Wear,305,1,0,0,0,1
-18590,3,7000,1,2,Black Venom Wear,305,1,0,0,1,1
-18591,3,7000,1,7,Black Venom Wear,305,1,0,0,2,1
-18592,3,7000,1,12,Black Venom Wear,305,1,0,0,3,1
-18593,3,7000,1,6,Black Venom Wear,305,1,0,0,4,1
+18439,3,3767,1,90,Asker Suit,305,85,0,0,0,1
+18440,3,3767,1,90,Asker Suit,305,85,0,0,1,1
+18441,3,3767,1,90,Asker Suit,305,85,0,0,2,1
+18442,3,3767,1,90,Asker Suit,305,85,0,0,3,1
+18443,3,3767,1,90,Asker Suit,305,85,0,0,4,1
+18444,3,4029,1,95,Krall Breastplate,305,88,0,0,0,1
+18445,3,4029,1,95,Krall Breastplate,305,88,0,0,1,1
+18446,3,4029,1,95,Krall Breastplate,305,88,0,0,2,1
+18447,3,4029,1,95,Krall Breastplate,305,88,0,0,3,1
+18448,3,4029,1,95,Krall Breastplate,305,88,0,0,4,1
+18449,3,4185,1,100,Casanance Tunic,305,90,0,0,0,1
+18450,3,4185,1,100,Casanance Tunic,305,90,0,0,1,1
+18451,3,4185,1,100,Casanance Tunic,305,90,0,0,2,1
+18452,3,4185,1,100,Casanance Tunic,305,90,0,0,3,1
+18453,3,4185,1,100,Casanance Tunic,305,90,0,0,4,1
+18589,3,7000,1,45,Black Venom Wear,305,1,0,0,0,1
+18590,3,7000,1,50,Black Venom Wear,305,1,0,0,1,1
+18591,3,7000,1,55,Black Venom Wear,305,1,0,0,2,1
+18592,3,7000,1,60,Black Venom Wear,305,1,0,0,3,1
+18593,3,7000,1,70,Black Venom Wear,305,1,0,0,4,1
 19135,3,10000,1,7,Alluring Swimsuit Top (Vivid Green),305,1,0,0,0,1
 19136,3,10000,1,7,Alluring Swimsuit Top (Indigo Blue),305,1,0,0,0,1
 19137,3,10000,1,7,Alluring Swimsuit Top (Bluish Purple),305,1,0,0,0,1
 19138,3,10000,1,7,Alluring Swimsuit Top (Night Black),305,1,0,0,0,1
 19139,3,10000,1,7,Alluring Swimsuit Top (Silver Gray),305,1,0,0,0,1
 19140,3,10000,1,7,Alluring Swimsuit Top (Setting Sun),305,1,0,0,0,1
-19455,3,10000,1,0,Boundless Tempest Gown,305,1,0,0,4,1
-19463,3,10000,1,3,Boundless Tempest Vest,305,1,0,0,4,1
+19455,3,10000,1,80,Boundless Tempest Gown,305,1,0,0,4,1
+19463,3,10000,1,83,Boundless Tempest Vest,305,1,0,0,4,1
 19501,3,15000,1,10,Magical Night Pumpkin Jacket,305,1,0,0,4,1
 19503,3,10000,1,10,Magical Night Witch Coat,305,1,0,0,4,1
 19605,3,10000,1,7,Basic Pajamas - Blue,305,1,0,0,0,1
 19606,3,10000,1,7,Basic Pajamas - Pink,305,1,0,0,0,1
 19609,3,10000,1,7,Cutie Wear - Berry,305,1,0,0,0,1
 19610,3,10000,1,7,Cutie Wear - Marine,305,1,0,0,0,1
-20698,3,4200,1,4,Rahatz Surcoat,305,90,0,0,0,1
-20699,3,4200,1,4,Rahatz Surcoat,305,90,0,0,1,1
-20700,3,4200,1,4,Rahatz Surcoat,305,90,0,0,2,1
-20701,3,4200,1,4,Rahatz Surcoat,305,90,0,0,3,1
-20702,3,4200,1,4,Rahatz Surcoat,305,90,0,0,4,1
-20703,3,4410,1,9,Kenneby's Wear,305,93,0,0,0,1
-20704,3,4410,1,9,Kenneby's Wear,305,93,0,0,1,1
-20705,3,4410,1,9,Kenneby's Wear,305,93,0,0,2,1
-20706,3,4410,1,9,Kenneby's Wear,305,93,0,0,3,1
-20707,3,4410,1,9,Kenneby's Wear,305,93,0,0,4,1
-20708,3,4620,1,14,Macera Mesh,305,95,0,0,0,1
-20709,3,4620,1,14,Macera Mesh,305,95,0,0,1,1
-20710,3,4620,1,14,Macera Mesh,305,95,0,0,2,1
-20711,3,4620,1,14,Macera Mesh,305,95,0,0,3,1
-20712,3,4620,1,14,Macera Mesh,305,95,0,0,4,1
-21042,3,4620,1,14,Rébellion Suit,305,95,0,0,0,1
-21043,3,4620,1,14,Rébellion Suit,305,95,0,0,1,1
-21044,3,4620,1,14,Rébellion Suit,305,95,0,0,2,1
-21045,3,4620,1,14,Rébellion Suit,305,95,0,0,3,1
-21046,3,4620,1,14,Rébellion Suit,305,95,0,0,4,1
-21047,3,4830,1,3,Traître Gambeson,305,98,0,0,0,1
-21048,3,4830,1,3,Traître Gambeson,305,98,0,0,1,1
-21049,3,4830,1,3,Traître Gambeson,305,98,0,0,2,1
-21050,3,4830,1,3,Traître Gambeson,305,98,0,0,3,1
-21051,3,4830,1,3,Traître Gambeson,305,98,0,0,4,1
-21052,3,5040,1,8,Revanche Wear,305,100,0,0,0,1
-21053,3,5040,1,8,Revanche Wear,305,100,0,0,1,1
-21054,3,5040,1,8,Revanche Wear,305,100,0,0,2,1
-21055,3,5040,1,8,Revanche Wear,305,100,0,0,3,1
-21056,3,5040,1,8,Revanche Wear,305,100,0,0,4,1
-21113,3,10000,1,12,Maestro Wear,305,1,0,0,4,1
-20753,3,10000,1,10,Crimson Leather Suit,305,90,0,0,4,1
-21096,3,10000,1,4,White Smoke Leather Suit,305,95,0,0,4,1
+20698,3,4200,1,100,Rahatz Surcoat,305,90,0,0,0,1
+20699,3,4200,1,100,Rahatz Surcoat,305,90,0,0,1,1
+20700,3,4200,1,100,Rahatz Surcoat,305,90,0,0,2,1
+20701,3,4200,1,100,Rahatz Surcoat,305,90,0,0,3,1
+20702,3,4200,1,100,Rahatz Surcoat,305,90,0,0,4,1
+20703,3,4410,1,105,Kenneby's Wear,305,93,0,0,0,1
+20704,3,4410,1,105,Kenneby's Wear,305,93,0,0,1,1
+20705,3,4410,1,105,Kenneby's Wear,305,93,0,0,2,1
+20706,3,4410,1,105,Kenneby's Wear,305,93,0,0,3,1
+20707,3,4410,1,105,Kenneby's Wear,305,93,0,0,4,1
+20708,3,4620,1,110,Macera Mesh,305,95,0,0,0,1
+20709,3,4620,1,110,Macera Mesh,305,95,0,0,1,1
+20710,3,4620,1,110,Macera Mesh,305,95,0,0,2,1
+20711,3,4620,1,110,Macera Mesh,305,95,0,0,3,1
+20712,3,4620,1,110,Macera Mesh,305,95,0,0,4,1
+21042,3,4620,1,110,Rébellion Suit,305,95,0,0,0,1
+21043,3,4620,1,110,Rébellion Suit,305,95,0,0,1,1
+21044,3,4620,1,110,Rébellion Suit,305,95,0,0,2,1
+21045,3,4620,1,110,Rébellion Suit,305,95,0,0,3,1
+21046,3,4620,1,110,Rébellion Suit,305,95,0,0,4,1
+21047,3,4830,1,115,Traître Gambeson,305,98,0,0,0,1
+21048,3,4830,1,115,Traître Gambeson,305,98,0,0,1,1
+21049,3,4830,1,115,Traître Gambeson,305,98,0,0,2,1
+21050,3,4830,1,115,Traître Gambeson,305,98,0,0,3,1
+21051,3,4830,1,115,Traître Gambeson,305,98,0,0,4,1
+21052,3,5040,1,120,Revanche Wear,305,100,0,0,0,1
+21053,3,5040,1,120,Revanche Wear,305,100,0,0,1,1
+21054,3,5040,1,120,Revanche Wear,305,100,0,0,2,1
+21055,3,5040,1,120,Revanche Wear,305,100,0,0,3,1
+21056,3,5040,1,120,Revanche Wear,305,100,0,0,4,1
+21113,3,10000,1,92,Maestro Wear,305,1,0,0,4,1
+20753,3,10000,1,106,Crimson Leather Suit,305,90,0,0,4,1
+21096,3,10000,1,116,White Smoke Leather Suit,305,95,0,0,4,1
 20436,3,10000,1,10,Magical Night Terror Jacket,305,1,0,0,4,1
 20438,3,10000,1,10,Magical Night Scream Coat,305,1,0,0,4,1
 20759,3,10000,1,7,Midsummer Feather Necklace (Red),305,1,0,0,0,2
-21162,3,10000,1,15,Virtuoso Wear,305,1,0,0,4,1
-21171,3,10000,1,12,Lord Knight Leather Suit,305,90,0,0,4,1
-21179,3,10000,1,6,Selenite Leather Suit,305,95,0,0,4,1
+21162,3,10000,1,95,Virtuoso Wear,305,1,0,0,4,1
+21171,3,10000,1,108,Lord Knight Leather Suit,305,90,0,0,4,1
+21179,3,10000,1,118,Selenite Leather Suit,305,95,0,0,4,1
 21188,3,10000,1,7,Midsummer Glamorous Bikini (Red),305,1,0,0,0,3
 21334,3,10000,1,7,Midsummer Feather Necklace (Gold),305,1,0,0,0,2
 21335,3,10000,1,7,Midsummer Feather Necklace (Green),305,1,0,0,0,2
@@ -15506,9 +15506,9 @@
 21351,3,10000,1,7,Midsummer Glamorous Bikini (Purple),305,1,0,0,0,3
 21352,3,10000,1,7,Midsummer Glamorous Bikini (White),305,1,0,0,0,3
 21353,3,10000,1,7,Midsummer Glamorous Bikini (Black),305,1,0,0,0,3
-21686,3,10000,1,11,Bustier Dress (White),305,1,0,0,4,1
-21687,3,10000,1,11,Bustier Dress (Black),305,1,0,0,4,1
-21688,3,10000,1,11,Bustier Dress (Purple),305,1,0,0,4,1
+21686,3,10000,1,75,Bustier Dress (White),305,1,0,0,4,1
+21687,3,10000,1,75,Bustier Dress (Black),305,1,0,0,4,1
+21688,3,10000,1,75,Bustier Dress (Purple),305,1,0,0,4,1
 23381,3,10000,1,1,Mischievous Parade Vest,305,1,0,0,4,1
 23388,3,10000,1,1,Mischievous Moonlight Vest,305,1,0,0,4,1
 23389,3,10000,1,1,Mischievous Party Onepiece,305,1,0,0,4,1
@@ -15521,32 +15521,32 @@
 23457,3,100,1,1,Reindeer's Costume (White),305,1,0,0,4,1
 23461,3,100,1,1,Christmas Tree Onepiece,305,1,0,0,4,1
 24615,3,0,1,12,Pleiades Clothing,305,1,0,0,4,1
-24619,3,0,1,2,Spirit's Underwear,305,100,0,0,0,1
-24623,3,0,1,2,Spirit's Underwear,305,100,0,0,1,1
-24624,3,0,1,2,Spirit's Underwear,305,100,0,0,2,1
-24625,3,0,1,2,Spirit's Underwear,305,100,0,0,3,1
-24626,3,0,1,2,Spirit's Underwear,305,100,0,0,4,1
-24620,3,0,1,2,Fire King's Underwear,305,100,0,0,0,1
-24627,3,0,1,2,Fire King's Underwear,305,100,0,0,1,1
-24628,3,0,1,2,Fire King's Underwear,305,100,0,0,2,1
-24629,3,0,1,2,Fire King's Underwear,305,100,0,0,3,1
-24630,3,0,1,2,Fire King's Underwear,305,100,0,0,4,1
-24621,3,0,1,2,White Wings' Underwear,305,100,0,0,0,1
-24631,3,0,1,2,White Wings' Underwear,305,100,0,0,1,1
-24632,3,0,1,2,White Wings' Underwear,305,100,0,0,2,1
-24633,3,0,1,2,White Wings' Underwear,305,100,0,0,3,1
-24634,3,0,1,2,White Wings' Underwear,305,100,0,0,4,1
-24622,3,0,1,2,Golden Underwear,305,100,0,0,0,1
-24635,3,0,1,2,Golden Underwear,305,100,0,0,1,1
-24636,3,0,1,2,Golden Underwear,305,100,0,0,2,1
-24637,3,0,1,2,Golden Underwear,305,100,0,0,3,1
-24638,3,0,1,2,Golden Underwear,305,100,0,0,4,1
-24639,3,0,1,7,Blackshatter Underwear,305,100,0,0,0,1
-24640,3,0,1,7,Blackshatter Underwear,305,100,0,0,1,1
-24641,3,0,1,7,Blackshatter Underwear,305,100,0,0,2,1
-24642,3,0,1,7,Blackshatter Underwear,305,100,0,0,3,1
-24643,3,0,1,7,Blackshatter Underwear,305,100,0,0,4,1
-24702,3,10000,1,2,Survivor Leather Suit,305,1,0,0,4,1
+24619,3,0,1,130,Spirit's Underwear,305,100,0,0,0,1
+24623,3,0,1,130,Spirit's Underwear,305,100,0,0,1,1
+24624,3,0,1,130,Spirit's Underwear,305,100,0,0,2,1
+24625,3,0,1,130,Spirit's Underwear,305,100,0,0,3,1
+24626,3,0,1,130,Spirit's Underwear,305,100,0,0,4,1
+24620,3,0,1,130,Fire King's Underwear,305,100,0,0,0,1
+24627,3,0,1,130,Fire King's Underwear,305,100,0,0,1,1
+24628,3,0,1,130,Fire King's Underwear,305,100,0,0,2,1
+24629,3,0,1,130,Fire King's Underwear,305,100,0,0,3,1
+24630,3,0,1,130,Fire King's Underwear,305,100,0,0,4,1
+24621,3,0,1,130,White Wings' Underwear,305,100,0,0,0,1
+24631,3,0,1,130,White Wings' Underwear,305,100,0,0,1,1
+24632,3,0,1,130,White Wings' Underwear,305,100,0,0,2,1
+24633,3,0,1,130,White Wings' Underwear,305,100,0,0,3,1
+24634,3,0,1,130,White Wings' Underwear,305,100,0,0,4,1
+24622,3,0,1,130,Golden Underwear,305,100,0,0,0,1
+24635,3,0,1,130,Golden Underwear,305,100,0,0,1,1
+24636,3,0,1,130,Golden Underwear,305,100,0,0,2,1
+24637,3,0,1,130,Golden Underwear,305,100,0,0,3,1
+24638,3,0,1,130,Golden Underwear,305,100,0,0,4,1
+24639,3,0,1,135,Blackshatter Underwear,305,100,0,0,0,1
+24640,3,0,1,135,Blackshatter Underwear,305,100,0,0,1,1
+24641,3,0,1,135,Blackshatter Underwear,305,100,0,0,2,1
+24642,3,0,1,135,Blackshatter Underwear,305,100,0,0,3,1
+24643,3,0,1,135,Blackshatter Underwear,305,100,0,0,4,1
+24702,3,10000,1,130,Survivor Leather Suit,305,1,0,0,4,1
 24886,3,10000,1,1,Basic Pajamas - Green,305,1,0,0,0,1
 24888,3,10000,1,1,Cutie Wear - Yellow,305,1,0,0,0,1
 24896,3,10000,1,1,Southern Country Tattoo Seal A,305,1,0,0,0,2
@@ -15558,22 +15558,22 @@
 24908,3,10000,1,1,Southern Country Glamorous Bikini (White),305,1,0,0,0,3
 24909,3,10000,1,1,Southern Country Glamorous Bikini (Orange),305,1,0,0,0,3
 24927,3,10000,1,1,Bustier Dress (Deep Red),305,1,0,0,0,1
-25017,3,10000,1,2,Combat Leather Suit,305,1,0,0,4,1
-25476,3,5100,1,12,Holy Seal's Lively Gambeson,305,105,0,0,0,1
-25477,3,5100,1,12,Holy Seal's Lively Gambeson,305,105,0,0,1,1
-25478,3,5100,1,12,Holy Seal's Lively Gambeson,305,105,0,0,2,1
-25479,3,5100,1,12,Holy Seal's Lively Gambeson,305,105,0,0,3,1
-25480,3,5100,1,12,Holy Seal's Lively Gambeson,305,105,0,0,4,1
-25491,3,5100,1,1,Trickster's Lively Clothing,305,110,0,0,0,1
-25492,3,5100,1,1,Trickster's Lively Clothing,305,110,0,0,1,1
-25493,3,5100,1,1,Trickster's Lively Clothing,305,110,0,0,2,1
-25494,3,5100,1,1,Trickster's Lively Clothing,305,110,0,0,3,1
-25495,3,5100,1,1,Trickster's Lively Clothing,305,110,0,0,4,1
-25506,3,5100,1,6,Hero's Lively Top,305,115,0,0,0,1
-25507,3,5100,1,6,Hero's Lively Top,305,115,0,0,1,1
-25508,3,5100,1,6,Hero's Lively Top,305,115,0,0,2,1
-25509,3,5100,1,6,Hero's Lively Top,305,115,0,0,3,1
-25510,3,5100,1,6,Hero's Lively Top,305,115,0,0,4,1
+25017,3,10000,1,130,Combat Leather Suit,305,1,0,0,4,1
+25476,3,5100,1,140,Holy Seal's Lively Gambeson,305,105,0,0,0,1
+25477,3,5100,1,140,Holy Seal's Lively Gambeson,305,105,0,0,1,1
+25478,3,5100,1,140,Holy Seal's Lively Gambeson,305,105,0,0,2,1
+25479,3,5100,1,140,Holy Seal's Lively Gambeson,305,105,0,0,3,1
+25480,3,5100,1,140,Holy Seal's Lively Gambeson,305,105,0,0,4,1
+25491,3,5100,1,145,Trickster's Lively Clothing,305,110,0,0,0,1
+25492,3,5100,1,145,Trickster's Lively Clothing,305,110,0,0,1,1
+25493,3,5100,1,145,Trickster's Lively Clothing,305,110,0,0,2,1
+25494,3,5100,1,145,Trickster's Lively Clothing,305,110,0,0,3,1
+25495,3,5100,1,145,Trickster's Lively Clothing,305,110,0,0,4,1
+25506,3,5100,1,150,Hero's Lively Top,305,115,0,0,0,1
+25507,3,5100,1,150,Hero's Lively Top,305,115,0,0,1,1
+25508,3,5100,1,150,Hero's Lively Top,305,115,0,0,2,1
+25509,3,5100,1,150,Hero's Lively Top,305,115,0,0,3,1
+25510,3,5100,1,150,Hero's Lively Top,305,115,0,0,4,1
 434,3,30,1,1,Leather Gloves,306,3,12,0,0,1
 2046,3,30,1,1,Leather Gloves,306,3,12,0,1,1
 3069,3,30,1,1,Leather Gloves,306,3,12,0,2,1
@@ -15734,11 +15734,11 @@
 3246,3,2960,1,9,Twilight Bracers,306,45,12,0,2,1
 4269,3,2960,1,9,Twilight Bracers,306,45,12,0,3,1
 5292,3,2960,1,9,Twilight Bracers,306,45,12,0,4,1
-612,3,7351,1,3,Faith Gauntlets,306,70,12,0,0,1
-2224,3,7351,1,3,Faith Gauntlets,306,70,12,0,1,1
-3247,3,7351,1,3,Faith Gauntlets,306,70,12,0,2,1
-4270,3,7351,1,3,Faith Gauntlets,306,70,12,0,3,1
-5293,3,7351,1,3,Faith Gauntlets,306,70,12,0,4,1
+612,3,7351,1,35,Faith Gauntlets,306,70,12,0,0,1
+2224,3,7351,1,35,Faith Gauntlets,306,70,12,0,1,1
+3247,3,7351,1,35,Faith Gauntlets,306,70,12,0,2,1
+4270,3,7351,1,35,Faith Gauntlets,306,70,12,0,3,1
+5293,3,7351,1,35,Faith Gauntlets,306,70,12,0,4,1
 613,3,3535,1,10,Silver Gauntlets,306,49,12,0,0,1
 2225,3,3535,1,10,Silver Gauntlets,306,49,12,0,1,1
 3248,3,3535,1,10,Silver Gauntlets,306,49,12,0,2,1
@@ -15864,11 +15864,11 @@
 3352,3,2960,1,9,Leader Gloves,306,45,14,0,2,1
 4375,3,2960,1,9,Leader Gloves,306,45,14,0,3,1
 5398,3,2960,1,9,Leader Gloves,306,45,14,0,4,1
-718,3,7351,1,3,Faith Gloves,306,70,14,0,0,1
-2330,3,7351,1,3,Faith Gloves,306,70,14,0,1,1
-3353,3,7351,1,3,Faith Gloves,306,70,14,0,2,1
-4376,3,7351,1,3,Faith Gloves,306,70,14,0,3,1
-5399,3,7351,1,3,Faith Gloves,306,70,14,0,4,1
+718,3,7351,1,35,Faith Gloves,306,70,14,0,0,1
+2330,3,7351,1,35,Faith Gloves,306,70,14,0,1,1
+3353,3,7351,1,35,Faith Gloves,306,70,14,0,2,1
+4376,3,7351,1,35,Faith Gloves,306,70,14,0,3,1
+5399,3,7351,1,35,Faith Gloves,306,70,14,0,4,1
 719,3,3385,1,10,Executor Arms,306,46,14,0,0,1
 2331,3,3385,1,10,Executor Arms,306,46,14,0,1,1
 3354,3,3385,1,10,Executor Arms,306,46,14,0,2,1
@@ -15914,11 +15914,11 @@
 3362,3,5760,1,12,Rubedo Gloves,306,60,3,0,2,1
 4385,3,5760,1,12,Rubedo Gloves,306,60,3,0,3,1
 5408,3,5760,1,12,Rubedo Gloves,306,60,3,0,4,1
-728,3,6339,1,4,Supernal Hands,306,65,14,0,0,1
-2340,3,6339,1,4,Supernal Hands,306,65,14,0,1,1
-3363,3,6339,1,4,Supernal Hands,306,65,14,0,2,1
-4386,3,6339,1,4,Supernal Hands,306,65,14,0,3,1
-5409,3,6339,1,4,Supernal Hands,306,65,14,0,4,1
+728,3,6339,1,20,Supernal Hands,306,65,14,0,0,1
+2340,3,6339,1,20,Supernal Hands,306,65,14,0,1,1
+3363,3,6339,1,20,Supernal Hands,306,65,14,0,2,1
+4386,3,6339,1,20,Supernal Hands,306,65,14,0,3,1
+5409,3,6339,1,20,Supernal Hands,306,65,14,0,4,1
 729,3,5015,1,12,Fulfillment,306,58,14,0,0,1
 2341,3,5015,1,12,Fulfillment,306,58,14,0,1,1
 3364,3,5015,1,12,Fulfillment,306,58,14,0,2,1
@@ -15994,11 +15994,11 @@
 3459,3,2960,1,9,Adept Bangles,306,45,15,0,2,1
 4482,3,2960,1,9,Adept Bangles,306,45,15,0,3,1
 5505,3,2960,1,9,Adept Bangles,306,45,15,0,4,1
-825,3,7351,1,3,Faith Bangles,306,70,15,0,0,1
-2437,3,7351,1,3,Faith Bangles,306,70,15,0,1,1
-3460,3,7351,1,3,Faith Bangles,306,70,15,0,2,1
-4483,3,7351,1,3,Faith Bangles,306,70,15,0,3,1
-5506,3,7351,1,3,Faith Bangles,306,70,15,0,4,1
+825,3,7351,1,35,Faith Bangles,306,70,15,0,0,1
+2437,3,7351,1,35,Faith Bangles,306,70,15,0,1,1
+3460,3,7351,1,35,Faith Bangles,306,70,15,0,2,1
+4483,3,7351,1,35,Faith Bangles,306,70,15,0,3,1
+5506,3,7351,1,35,Faith Bangles,306,70,15,0,4,1
 826,3,3535,1,11,Aeon Bangles,306,52,15,0,0,1
 2438,3,3535,1,11,Aeon Bangles,306,52,15,0,1,1
 3461,3,3535,1,11,Aeon Bangles,306,52,15,0,2,1
@@ -16129,11 +16129,11 @@
 3564,3,2960,1,9,Gruel Knuckles,306,45,17,0,2,1
 4587,3,2960,1,9,Gruel Knuckles,306,45,17,0,3,1
 5610,3,2960,1,9,Gruel Knuckles,306,45,17,0,4,1
-930,3,7351,1,3,Genius Arms,306,70,17,0,0,1
-2542,3,7351,1,3,Genius Arms,306,70,17,0,1,1
-3565,3,7351,1,3,Genius Arms,306,70,17,0,2,1
-4588,3,7351,1,3,Genius Arms,306,70,17,0,3,1
-5611,3,7351,1,3,Genius Arms,306,70,17,0,4,1
+930,3,7351,1,35,Genius Arms,306,70,17,0,0,1
+2542,3,7351,1,35,Genius Arms,306,70,17,0,1,1
+3565,3,7351,1,35,Genius Arms,306,70,17,0,2,1
+4588,3,7351,1,35,Genius Arms,306,70,17,0,3,1
+5611,3,7351,1,35,Genius Arms,306,70,17,0,4,1
 931,3,3535,1,12,Maverick Arms,306,56,17,0,0,1
 2543,3,3535,1,12,Maverick Arms,306,56,17,0,1,1
 3566,3,3535,1,12,Maverick Arms,306,56,17,0,2,1
@@ -16179,11 +16179,11 @@
 3574,3,5015,1,12,Gloves of Sacred Protection,306,58,17,0,2,1
 4597,3,5015,1,12,Gloves of Sacred Protection,306,58,17,0,3,1
 5620,3,5015,1,12,Gloves of Sacred Protection,306,58,17,0,4,1
-940,3,6339,1,4,Heavenly Arms,306,65,17,0,0,1
-2552,3,6339,1,4,Heavenly Arms,306,65,17,0,1,1
-3575,3,6339,1,4,Heavenly Arms,306,65,17,0,2,1
-4598,3,6339,1,4,Heavenly Arms,306,65,17,0,3,1
-5621,3,6339,1,4,Heavenly Arms,306,65,17,0,4,1
+940,3,6339,1,20,Heavenly Arms,306,65,17,0,0,1
+2552,3,6339,1,20,Heavenly Arms,306,65,17,0,1,1
+3575,3,6339,1,20,Heavenly Arms,306,65,17,0,2,1
+4598,3,6339,1,20,Heavenly Arms,306,65,17,0,3,1
+5621,3,6339,1,20,Heavenly Arms,306,65,17,0,4,1
 969,3,110,1,2,Mighty Gloves,306,7,0,0,0,1
 2581,3,110,1,2,Mighty Gloves,306,7,0,0,1,1
 3604,3,110,1,2,Mighty Gloves,306,7,0,0,2,1
@@ -16348,666 +16348,666 @@
 10950,3,5000,1,12,Rathian Vambraces,306,30,16,3,2,1
 10951,3,5000,1,12,Rathian Vambraces,306,30,16,3,3,1
 10952,3,5000,1,12,Rathian Vambraces,306,30,16,3,4,1
-10953,3,5000,1,6,Silver Sol Vambraces,306,55,13,3,0,1
-10954,3,5000,1,6,Silver Sol Vambraces,306,55,13,3,1,1
-10955,3,5000,1,6,Silver Sol Vambraces,306,55,13,3,2,1
-10956,3,5000,1,6,Silver Sol Vambraces,306,55,13,3,3,1
-10957,3,5000,1,6,Silver Sol Vambraces,306,55,13,3,4,1
-10958,3,5000,1,6,Gold Luna Vambraces,306,55,16,3,0,1
-10959,3,5000,1,6,Gold Luna Vambraces,306,55,16,3,1,1
-10960,3,5000,1,6,Gold Luna Vambraces,306,55,16,3,2,1
-10961,3,5000,1,6,Gold Luna Vambraces,306,55,16,3,3,1
-10962,3,5000,1,6,Gold Luna Vambraces,306,55,16,3,4,1
+10953,3,5000,1,70,Silver Sol Vambraces,306,55,13,3,0,1
+10954,3,5000,1,70,Silver Sol Vambraces,306,55,13,3,1,1
+10955,3,5000,1,70,Silver Sol Vambraces,306,55,13,3,2,1
+10956,3,5000,1,70,Silver Sol Vambraces,306,55,13,3,3,1
+10957,3,5000,1,70,Silver Sol Vambraces,306,55,13,3,4,1
+10958,3,5000,1,70,Gold Luna Vambraces,306,55,16,3,0,1
+10959,3,5000,1,70,Gold Luna Vambraces,306,55,16,3,1,1
+10960,3,5000,1,70,Gold Luna Vambraces,306,55,16,3,2,1
+10961,3,5000,1,70,Gold Luna Vambraces,306,55,16,3,3,1
+10962,3,5000,1,70,Gold Luna Vambraces,306,55,16,3,4,1
 11752,3,6000,1,1,Invisible Gloves,306,1,0,0,0,1
-12793,3,6339,1,4,Damascus Guard,306,65,12,0,0,1
-12794,3,6339,1,4,Damascus Guard,306,65,12,0,1,1
-12795,3,6339,1,4,Damascus Guard,306,65,12,0,2,1
-12796,3,6339,1,4,Damascus Guard,306,65,12,0,3,1
-12797,3,6339,1,4,Damascus Guard,306,65,12,0,4,1
-12798,3,6339,1,9,Immortal's Gauntlets,306,65,12,0,0,1
-12799,3,6339,1,9,Immortal's Gauntlets,306,65,12,0,1,1
-12800,3,6339,1,9,Immortal's Gauntlets,306,65,12,0,2,1
-12801,3,6339,1,9,Immortal's Gauntlets,306,65,12,0,3,1
-12802,3,6339,1,9,Immortal's Gauntlets,306,65,12,0,4,1
-12803,3,6339,1,14,Enlightenment Hands,306,65,12,0,0,1
-12804,3,6339,1,14,Enlightenment Hands,306,65,12,0,1,1
-12805,3,6339,1,14,Enlightenment Hands,306,65,12,0,2,1
-12806,3,6339,1,14,Enlightenment Hands,306,65,12,0,3,1
-12807,3,6339,1,14,Enlightenment Hands,306,65,12,0,4,1
-12808,3,6735,1,14,Barbarian Arms,306,67,12,0,0,1
-12809,3,6735,1,14,Barbarian Arms,306,67,12,0,1,1
-12810,3,6735,1,14,Barbarian Arms,306,67,12,0,2,1
-12811,3,6735,1,14,Barbarian Arms,306,67,12,0,3,1
-12812,3,6735,1,14,Barbarian Arms,306,67,12,0,4,1
-12813,3,7351,1,8,Alloy Gloves,306,70,12,0,0,1
-12814,3,7351,1,8,Alloy Gloves,306,70,12,0,1,1
-12815,3,7351,1,8,Alloy Gloves,306,70,12,0,2,1
-12816,3,7351,1,8,Alloy Gloves,306,70,12,0,3,1
-12817,3,7351,1,8,Alloy Gloves,306,70,12,0,4,1
-12818,3,7351,1,13,Predator Gauntlets,306,70,12,0,0,1
-12819,3,7351,1,13,Predator Gauntlets,306,70,12,0,1,1
-12820,3,7351,1,13,Predator Gauntlets,306,70,12,0,2,1
-12821,3,7351,1,13,Predator Gauntlets,306,70,12,0,3,1
-12822,3,7351,1,13,Predator Gauntlets,306,70,12,0,4,1
-12823,3,6339,1,4,Pride Bangles,306,65,15,0,0,1
-12824,3,6339,1,4,Pride Bangles,306,65,15,0,1,1
-12825,3,6339,1,4,Pride Bangles,306,65,15,0,2,1
-12826,3,6339,1,4,Pride Bangles,306,65,15,0,3,1
-12827,3,6339,1,4,Pride Bangles,306,65,15,0,4,1
-12828,3,6339,1,9,Faith Bangles,306,65,15,0,0,1
-12829,3,6339,1,9,Faith Bangles,306,65,15,0,1,1
-12830,3,6339,1,9,Faith Bangles,306,65,15,0,2,1
-12831,3,6339,1,9,Faith Bangles,306,65,15,0,3,1
-12832,3,6339,1,9,Faith Bangles,306,65,15,0,4,1
-12833,3,6339,1,14,Bishop Gloves,306,65,15,0,0,1
-12834,3,6339,1,14,Bishop Gloves,306,65,15,0,1,1
-12835,3,6339,1,14,Bishop Gloves,306,65,15,0,2,1
-12836,3,6339,1,14,Bishop Gloves,306,65,15,0,3,1
-12837,3,6339,1,14,Bishop Gloves,306,65,15,0,4,1
-12838,3,6735,1,14,Morality Sleeves,306,67,15,0,0,1
-12839,3,6735,1,14,Morality Sleeves,306,67,15,0,1,1
-12840,3,6735,1,14,Morality Sleeves,306,67,15,0,2,1
-12841,3,6735,1,14,Morality Sleeves,306,67,15,0,3,1
-12842,3,6735,1,14,Morality Sleeves,306,67,15,0,4,1
-12843,3,7351,1,8,Libertas Sleeves,306,70,15,0,0,1
-12844,3,7351,1,8,Libertas Sleeves,306,70,15,0,1,1
-12845,3,7351,1,8,Libertas Sleeves,306,70,15,0,2,1
-12846,3,7351,1,8,Libertas Sleeves,306,70,15,0,3,1
-12847,3,7351,1,8,Libertas Sleeves,306,70,15,0,4,1
-12848,3,7351,1,13,Carrion Claws,306,70,15,0,0,1
-12849,3,7351,1,13,Carrion Claws,306,70,15,0,1,1
-12850,3,7351,1,13,Carrion Claws,306,70,15,0,2,1
-12851,3,7351,1,13,Carrion Claws,306,70,15,0,3,1
-12852,3,7351,1,13,Carrion Claws,306,70,15,0,4,1
+12793,3,6339,1,20,Damascus Guard,306,65,12,0,0,1
+12794,3,6339,1,20,Damascus Guard,306,65,12,0,1,1
+12795,3,6339,1,20,Damascus Guard,306,65,12,0,2,1
+12796,3,6339,1,20,Damascus Guard,306,65,12,0,3,1
+12797,3,6339,1,20,Damascus Guard,306,65,12,0,4,1
+12798,3,6339,1,25,Immortal's Gauntlets,306,65,12,0,0,1
+12799,3,6339,1,25,Immortal's Gauntlets,306,65,12,0,1,1
+12800,3,6339,1,25,Immortal's Gauntlets,306,65,12,0,2,1
+12801,3,6339,1,25,Immortal's Gauntlets,306,65,12,0,3,1
+12802,3,6339,1,25,Immortal's Gauntlets,306,65,12,0,4,1
+12803,3,6339,1,30,Enlightenment Hands,306,65,12,0,0,1
+12804,3,6339,1,30,Enlightenment Hands,306,65,12,0,1,1
+12805,3,6339,1,30,Enlightenment Hands,306,65,12,0,2,1
+12806,3,6339,1,30,Enlightenment Hands,306,65,12,0,3,1
+12807,3,6339,1,30,Enlightenment Hands,306,65,12,0,4,1
+12808,3,6735,1,30,Barbarian Arms,306,67,12,0,0,1
+12809,3,6735,1,30,Barbarian Arms,306,67,12,0,1,1
+12810,3,6735,1,30,Barbarian Arms,306,67,12,0,2,1
+12811,3,6735,1,30,Barbarian Arms,306,67,12,0,3,1
+12812,3,6735,1,30,Barbarian Arms,306,67,12,0,4,1
+12813,3,7351,1,40,Alloy Gloves,306,70,12,0,0,1
+12814,3,7351,1,40,Alloy Gloves,306,70,12,0,1,1
+12815,3,7351,1,40,Alloy Gloves,306,70,12,0,2,1
+12816,3,7351,1,40,Alloy Gloves,306,70,12,0,3,1
+12817,3,7351,1,40,Alloy Gloves,306,70,12,0,4,1
+12818,3,7351,1,45,Predator Gauntlets,306,70,12,0,0,1
+12819,3,7351,1,45,Predator Gauntlets,306,70,12,0,1,1
+12820,3,7351,1,45,Predator Gauntlets,306,70,12,0,2,1
+12821,3,7351,1,45,Predator Gauntlets,306,70,12,0,3,1
+12822,3,7351,1,45,Predator Gauntlets,306,70,12,0,4,1
+12823,3,6339,1,20,Pride Bangles,306,65,15,0,0,1
+12824,3,6339,1,20,Pride Bangles,306,65,15,0,1,1
+12825,3,6339,1,20,Pride Bangles,306,65,15,0,2,1
+12826,3,6339,1,20,Pride Bangles,306,65,15,0,3,1
+12827,3,6339,1,20,Pride Bangles,306,65,15,0,4,1
+12828,3,6339,1,25,Faith Bangles,306,65,15,0,0,1
+12829,3,6339,1,25,Faith Bangles,306,65,15,0,1,1
+12830,3,6339,1,25,Faith Bangles,306,65,15,0,2,1
+12831,3,6339,1,25,Faith Bangles,306,65,15,0,3,1
+12832,3,6339,1,25,Faith Bangles,306,65,15,0,4,1
+12833,3,6339,1,30,Bishop Gloves,306,65,15,0,0,1
+12834,3,6339,1,30,Bishop Gloves,306,65,15,0,1,1
+12835,3,6339,1,30,Bishop Gloves,306,65,15,0,2,1
+12836,3,6339,1,30,Bishop Gloves,306,65,15,0,3,1
+12837,3,6339,1,30,Bishop Gloves,306,65,15,0,4,1
+12838,3,6735,1,30,Morality Sleeves,306,67,15,0,0,1
+12839,3,6735,1,30,Morality Sleeves,306,67,15,0,1,1
+12840,3,6735,1,30,Morality Sleeves,306,67,15,0,2,1
+12841,3,6735,1,30,Morality Sleeves,306,67,15,0,3,1
+12842,3,6735,1,30,Morality Sleeves,306,67,15,0,4,1
+12843,3,7351,1,40,Libertas Sleeves,306,70,15,0,0,1
+12844,3,7351,1,40,Libertas Sleeves,306,70,15,0,1,1
+12845,3,7351,1,40,Libertas Sleeves,306,70,15,0,2,1
+12846,3,7351,1,40,Libertas Sleeves,306,70,15,0,3,1
+12847,3,7351,1,40,Libertas Sleeves,306,70,15,0,4,1
+12848,3,7351,1,45,Carrion Claws,306,70,15,0,0,1
+12849,3,7351,1,45,Carrion Claws,306,70,15,0,1,1
+12850,3,7351,1,45,Carrion Claws,306,70,15,0,2,1
+12851,3,7351,1,45,Carrion Claws,306,70,15,0,3,1
+12852,3,7351,1,45,Carrion Claws,306,70,15,0,4,1
 12853,3,5767,1,15,Gloves of Gloom,306,62,17,0,0,1
 12854,3,5767,1,15,Gloves of Gloom,306,62,17,0,1,1
 12855,3,5767,1,15,Gloves of Gloom,306,62,17,0,2,1
 12856,3,5767,1,15,Gloves of Gloom,306,62,17,0,3,1
 12857,3,5767,1,15,Gloves of Gloom,306,62,17,0,4,1
-12858,3,6339,1,9,Armguards of Wisemen,306,65,17,0,0,1
-12859,3,6339,1,9,Armguards of Wisemen,306,65,17,0,1,1
-12860,3,6339,1,9,Armguards of Wisemen,306,65,17,0,2,1
-12861,3,6339,1,9,Armguards of Wisemen,306,65,17,0,3,1
-12862,3,6339,1,9,Armguards of Wisemen,306,65,17,0,4,1
-12863,3,6339,1,14,Saint's Arms,306,65,17,0,0,1
-12864,3,6339,1,14,Saint's Arms,306,65,17,0,1,1
-12865,3,6339,1,14,Saint's Arms,306,65,17,0,2,1
-12866,3,6339,1,14,Saint's Arms,306,65,17,0,3,1
-12867,3,6339,1,14,Saint's Arms,306,65,17,0,4,1
-12868,3,6735,1,14,Roaming Gloves,306,67,17,0,0,1
-12869,3,6735,1,14,Roaming Gloves,306,67,17,0,1,1
-12870,3,6735,1,14,Roaming Gloves,306,67,17,0,2,1
-12871,3,6735,1,14,Roaming Gloves,306,67,17,0,3,1
-12872,3,6735,1,14,Roaming Gloves,306,67,17,0,4,1
-12873,3,7351,1,8,Arms of Certainty,306,70,17,0,0,1
-12874,3,7351,1,8,Arms of Certainty,306,70,17,0,1,1
-12875,3,7351,1,8,Arms of Certainty,306,70,17,0,2,1
-12876,3,7351,1,8,Arms of Certainty,306,70,17,0,3,1
-12877,3,7351,1,8,Arms of Certainty,306,70,17,0,4,1
-12878,3,7351,1,13,Scholarly Arms,306,70,17,0,0,1
-12879,3,7351,1,13,Scholarly Arms,306,70,17,0,1,1
-12880,3,7351,1,13,Scholarly Arms,306,70,17,0,2,1
-12881,3,7351,1,13,Scholarly Arms,306,70,17,0,3,1
-12882,3,7351,1,13,Scholarly Arms,306,70,17,0,4,1
+12858,3,6339,1,25,Armguards of Wisemen,306,65,17,0,0,1
+12859,3,6339,1,25,Armguards of Wisemen,306,65,17,0,1,1
+12860,3,6339,1,25,Armguards of Wisemen,306,65,17,0,2,1
+12861,3,6339,1,25,Armguards of Wisemen,306,65,17,0,3,1
+12862,3,6339,1,25,Armguards of Wisemen,306,65,17,0,4,1
+12863,3,6339,1,30,Saint's Arms,306,65,17,0,0,1
+12864,3,6339,1,30,Saint's Arms,306,65,17,0,1,1
+12865,3,6339,1,30,Saint's Arms,306,65,17,0,2,1
+12866,3,6339,1,30,Saint's Arms,306,65,17,0,3,1
+12867,3,6339,1,30,Saint's Arms,306,65,17,0,4,1
+12868,3,6735,1,30,Roaming Gloves,306,67,17,0,0,1
+12869,3,6735,1,30,Roaming Gloves,306,67,17,0,1,1
+12870,3,6735,1,30,Roaming Gloves,306,67,17,0,2,1
+12871,3,6735,1,30,Roaming Gloves,306,67,17,0,3,1
+12872,3,6735,1,30,Roaming Gloves,306,67,17,0,4,1
+12873,3,7351,1,40,Arms of Certainty,306,70,17,0,0,1
+12874,3,7351,1,40,Arms of Certainty,306,70,17,0,1,1
+12875,3,7351,1,40,Arms of Certainty,306,70,17,0,2,1
+12876,3,7351,1,40,Arms of Certainty,306,70,17,0,3,1
+12877,3,7351,1,40,Arms of Certainty,306,70,17,0,4,1
+12878,3,7351,1,45,Scholarly Arms,306,70,17,0,0,1
+12879,3,7351,1,45,Scholarly Arms,306,70,17,0,1,1
+12880,3,7351,1,45,Scholarly Arms,306,70,17,0,2,1
+12881,3,7351,1,45,Scholarly Arms,306,70,17,0,3,1
+12882,3,7351,1,45,Scholarly Arms,306,70,17,0,4,1
 12883,3,5767,1,15,Splendid Arms,306,62,14,0,0,1
 12884,3,5767,1,15,Splendid Arms,306,62,14,0,1,1
 12885,3,5767,1,15,Splendid Arms,306,62,14,0,2,1
 12886,3,5767,1,15,Splendid Arms,306,62,14,0,3,1
 12887,3,5767,1,15,Splendid Arms,306,62,14,0,4,1
-12888,3,6339,1,9,Fear Gloves,306,65,14,0,0,1
-12889,3,6339,1,9,Fear Gloves,306,65,14,0,1,1
-12890,3,6339,1,9,Fear Gloves,306,65,14,0,2,1
-12891,3,6339,1,9,Fear Gloves,306,65,14,0,3,1
-12892,3,6339,1,9,Fear Gloves,306,65,14,0,4,1
-12893,3,6339,1,14,Paladin Gloves,306,65,14,0,0,1
-12894,3,6339,1,14,Paladin Gloves,306,65,14,0,1,1
-12895,3,6339,1,14,Paladin Gloves,306,65,14,0,2,1
-12896,3,6339,1,14,Paladin Gloves,306,65,14,0,3,1
-12897,3,6339,1,14,Paladin Gloves,306,65,14,0,4,1
-12898,3,6735,1,14,Sentinel Arms,306,67,14,0,0,1
-12899,3,6735,1,14,Sentinel Arms,306,67,14,0,1,1
-12900,3,6735,1,14,Sentinel Arms,306,67,14,0,2,1
-12901,3,6735,1,14,Sentinel Arms,306,67,14,0,3,1
-12902,3,6735,1,14,Sentinel Arms,306,67,14,0,4,1
-12903,3,7351,1,8,Aquila Gloves,306,70,14,0,0,1
-12904,3,7351,1,8,Aquila Gloves,306,70,14,0,1,1
-12905,3,7351,1,8,Aquila Gloves,306,70,14,0,2,1
-12906,3,7351,1,8,Aquila Gloves,306,70,14,0,3,1
-12907,3,7351,1,8,Aquila Gloves,306,70,14,0,4,1
-12908,3,7351,1,13,Gauntlets of Concealment,306,70,14,0,0,1
-12909,3,7351,1,13,Gauntlets of Concealment,306,70,14,0,1,1
-12910,3,7351,1,13,Gauntlets of Concealment,306,70,14,0,2,1
-12911,3,7351,1,13,Gauntlets of Concealment,306,70,14,0,3,1
-12912,3,7351,1,13,Gauntlets of Concealment,306,70,14,0,4,1
+12888,3,6339,1,25,Fear Gloves,306,65,14,0,0,1
+12889,3,6339,1,25,Fear Gloves,306,65,14,0,1,1
+12890,3,6339,1,25,Fear Gloves,306,65,14,0,2,1
+12891,3,6339,1,25,Fear Gloves,306,65,14,0,3,1
+12892,3,6339,1,25,Fear Gloves,306,65,14,0,4,1
+12893,3,6339,1,30,Paladin Gloves,306,65,14,0,0,1
+12894,3,6339,1,30,Paladin Gloves,306,65,14,0,1,1
+12895,3,6339,1,30,Paladin Gloves,306,65,14,0,2,1
+12896,3,6339,1,30,Paladin Gloves,306,65,14,0,3,1
+12897,3,6339,1,30,Paladin Gloves,306,65,14,0,4,1
+12898,3,6735,1,30,Sentinel Arms,306,67,14,0,0,1
+12899,3,6735,1,30,Sentinel Arms,306,67,14,0,1,1
+12900,3,6735,1,30,Sentinel Arms,306,67,14,0,2,1
+12901,3,6735,1,30,Sentinel Arms,306,67,14,0,3,1
+12902,3,6735,1,30,Sentinel Arms,306,67,14,0,4,1
+12903,3,7351,1,40,Aquila Gloves,306,70,14,0,0,1
+12904,3,7351,1,40,Aquila Gloves,306,70,14,0,1,1
+12905,3,7351,1,40,Aquila Gloves,306,70,14,0,2,1
+12906,3,7351,1,40,Aquila Gloves,306,70,14,0,3,1
+12907,3,7351,1,40,Aquila Gloves,306,70,14,0,4,1
+12908,3,7351,1,45,Gauntlets of Concealment,306,70,14,0,0,1
+12909,3,7351,1,45,Gauntlets of Concealment,306,70,14,0,1,1
+12910,3,7351,1,45,Gauntlets of Concealment,306,70,14,0,2,1
+12911,3,7351,1,45,Gauntlets of Concealment,306,70,14,0,3,1
+12912,3,7351,1,45,Gauntlets of Concealment,306,70,14,0,4,1
 13053,3,999,1,12,Ornament Arms,306,55,0,0,0,1
 13054,3,999,1,12,Ornament Arms,306,55,0,0,1,1
 13055,3,999,1,12,Ornament Arms,306,55,0,0,2,1
 13056,3,999,1,12,Ornament Arms,306,55,0,0,3,1
 13057,3,999,1,12,Ornament Arms,306,55,0,0,4,1
-13058,3,999,1,13,Admire Hands,306,72,0,0,0,1
-13059,3,999,1,13,Admire Hands,306,72,0,0,1,1
-13060,3,999,1,13,Admire Hands,306,72,0,0,2,1
-13061,3,999,1,13,Admire Hands,306,72,0,0,3,1
-13062,3,999,1,13,Admire Hands,306,72,0,0,4,1
+13058,3,999,1,45,Admire Hands,306,72,0,0,0,1
+13059,3,999,1,45,Admire Hands,306,72,0,0,1,1
+13060,3,999,1,45,Admire Hands,306,72,0,0,2,1
+13061,3,999,1,45,Admire Hands,306,72,0,0,3,1
+13062,3,999,1,45,Admire Hands,306,72,0,0,4,1
 13605,3,10000,1,11,Marquis Gloves,306,1,0,3,0,1
 13606,3,10000,1,11,Marquis Gloves,306,1,0,3,1,1
 13607,3,10000,1,11,Marquis Gloves,306,1,0,3,2,1
 13608,3,10000,1,11,Marquis Gloves,306,1,0,3,3,1
 13609,3,10000,1,11,Marquis Gloves,306,1,0,3,4,1
-15198,3,9601,1,11,Finnegan's Hands,306,80,0,3,0,1
-15199,3,9601,1,11,Finnegan's Hands,306,80,0,3,1,1
-15200,3,9601,1,11,Finnegan's Hands,306,80,0,3,2,1
-15201,3,9601,1,11,Finnegan's Hands,306,80,0,3,3,1
-15202,3,9601,1,11,Finnegan's Hands,306,80,0,3,4,1
-15203,3,9601,1,11,Greedy Hands,306,80,0,3,0,1
-15204,3,9601,1,11,Greedy Hands,306,80,0,3,1,1
-15205,3,9601,1,11,Greedy Hands,306,80,0,3,2,1
-15206,3,9601,1,11,Greedy Hands,306,80,0,3,3,1
-15207,3,9601,1,11,Greedy Hands,306,80,0,3,4,1
-15208,3,5000,1,7,Duke Gloves (Dark Night),306,70,0,3,4,1
-15213,3,5000,1,6,Duke Gloves (Moonflower),306,75,0,3,4,1
-15218,3,8439,1,2,Executioner's Arm Covers,306,75,12,0,0,1
-15219,3,8439,1,2,Executioner's Arm Covers,306,75,12,0,1,1
-15220,3,8439,1,2,Executioner's Arm Covers,306,75,12,0,2,1
-15221,3,8439,1,2,Executioner's Arm Covers,306,75,12,0,3,1
-15222,3,8439,1,2,Executioner's Arm Covers,306,75,12,0,4,1
-15223,3,8439,1,7,Ancient Beast Gauntlets,306,75,12,0,0,1
-15224,3,8439,1,7,Ancient Beast Gauntlets,306,75,12,0,1,1
-15225,3,8439,1,7,Ancient Beast Gauntlets,306,75,12,0,2,1
-15226,3,8439,1,7,Ancient Beast Gauntlets,306,75,12,0,3,1
-15227,3,8439,1,7,Ancient Beast Gauntlets,306,75,12,0,4,1
-15228,3,8439,1,12,Arms of Genocide,306,75,12,0,0,1
-15229,3,8439,1,12,Arms of Genocide,306,75,12,0,1,1
-15230,3,8439,1,12,Arms of Genocide,306,75,12,0,2,1
-15231,3,8439,1,12,Arms of Genocide,306,75,12,0,3,1
-15232,3,8439,1,12,Arms of Genocide,306,75,12,0,4,1
-15233,3,8895,1,12,Royal Guardsman's Gauntlets,306,77,12,0,0,1
-15234,3,8895,1,12,Royal Guardsman's Gauntlets,306,77,12,0,1,1
-15235,3,8895,1,12,Royal Guardsman's Gauntlets,306,77,12,0,2,1
-15236,3,8895,1,12,Royal Guardsman's Gauntlets,306,77,12,0,3,1
-15237,3,8895,1,12,Royal Guardsman's Gauntlets,306,77,12,0,4,1
-15238,3,9601,1,1,Northern Bracers,306,80,12,0,0,1
-15239,3,9601,1,1,Northern Bracers,306,80,12,0,1,1
-15240,3,9601,1,1,Northern Bracers,306,80,12,0,2,1
-15241,3,9601,1,1,Northern Bracers,306,80,12,0,3,1
-15242,3,9601,1,1,Northern Bracers,306,80,12,0,4,1
-15243,3,9601,1,6,Knight Gauntlets of Dawn,306,80,12,0,0,1
-15244,3,9601,1,6,Knight Gauntlets of Dawn,306,80,12,0,1,1
-15245,3,9601,1,6,Knight Gauntlets of Dawn,306,80,12,0,2,1
-15246,3,9601,1,6,Knight Gauntlets of Dawn,306,80,12,0,3,1
-15247,3,9601,1,6,Knight Gauntlets of Dawn,306,80,12,0,4,1
-15248,3,9601,1,11,Azure Gauntlets,306,80,12,0,0,1
-15249,3,9601,1,11,Azure Gauntlets,306,80,12,0,1,1
-15250,3,9601,1,11,Azure Gauntlets,306,80,12,0,2,1
-15251,3,9601,1,11,Azure Gauntlets,306,80,12,0,3,1
-15252,3,9601,1,11,Azure Gauntlets,306,80,12,0,4,1
-15253,3,8439,1,2,Innocent Covers,306,75,15,0,0,1
-15254,3,8439,1,2,Innocent Covers,306,75,15,0,1,1
-15255,3,8439,1,2,Innocent Covers,306,75,15,0,2,1
-15256,3,8439,1,2,Innocent Covers,306,75,15,0,3,1
-15257,3,8439,1,2,Innocent Covers,306,75,15,0,4,1
-15258,3,8439,1,7,Red Copper Bangles,306,75,15,0,0,1
-15259,3,8439,1,7,Red Copper Bangles,306,75,15,0,1,1
-15260,3,8439,1,7,Red Copper Bangles,306,75,15,0,2,1
-15261,3,8439,1,7,Red Copper Bangles,306,75,15,0,3,1
-15262,3,8439,1,7,Red Copper Bangles,306,75,15,0,4,1
-15263,3,8439,1,12,Enhanced Bracers,306,75,15,0,0,1
-15264,3,8439,1,12,Enhanced Bracers,306,75,15,0,1,1
-15265,3,8439,1,12,Enhanced Bracers,306,75,15,0,2,1
-15266,3,8439,1,12,Enhanced Bracers,306,75,15,0,3,1
-15267,3,8439,1,12,Enhanced Bracers,306,75,15,0,4,1
-15268,3,8895,1,12,Medium Arms,306,77,15,0,0,1
-15269,3,8895,1,12,Medium Arms,306,77,15,0,1,1
-15270,3,8895,1,12,Medium Arms,306,77,15,0,2,1
-15271,3,8895,1,12,Medium Arms,306,77,15,0,3,1
-15272,3,8895,1,12,Medium Arms,306,77,15,0,4,1
-15273,3,9601,1,1,Garrisoner's Bracers,306,80,15,0,0,1
-15274,3,9601,1,1,Garrisoner's Bracers,306,80,15,0,1,1
-15275,3,9601,1,1,Garrisoner's Bracers,306,80,15,0,2,1
-15276,3,9601,1,1,Garrisoner's Bracers,306,80,15,0,3,1
-15277,3,9601,1,1,Garrisoner's Bracers,306,80,15,0,4,1
-15278,3,9601,1,6,Ginkgo-dyed Gloves,306,80,15,0,0,1
-15279,3,9601,1,6,Ginkgo-dyed Gloves,306,80,15,0,1,1
-15280,3,9601,1,6,Ginkgo-dyed Gloves,306,80,15,0,2,1
-15281,3,9601,1,6,Ginkgo-dyed Gloves,306,80,15,0,3,1
-15282,3,9601,1,6,Ginkgo-dyed Gloves,306,80,15,0,4,1
-15283,3,9601,1,11,Azure Arms,306,80,15,0,0,1
-15284,3,9601,1,11,Azure Arms,306,80,15,0,1,1
-15285,3,9601,1,11,Azure Arms,306,80,15,0,2,1
-15286,3,9601,1,11,Azure Arms,306,80,15,0,3,1
-15287,3,9601,1,11,Azure Arms,306,80,15,0,4,1
-15288,3,8439,1,2,Continent Arms,306,75,17,0,0,1
-15289,3,8439,1,2,Continent Arms,306,75,17,0,1,1
-15290,3,8439,1,2,Continent Arms,306,75,17,0,2,1
-15291,3,8439,1,2,Continent Arms,306,75,17,0,3,1
-15292,3,8439,1,2,Continent Arms,306,75,17,0,4,1
-15293,3,8439,1,7,Arms of Keen Insight,306,75,17,0,0,1
-15294,3,8439,1,7,Arms of Keen Insight,306,75,17,0,1,1
-15295,3,8439,1,7,Arms of Keen Insight,306,75,17,0,2,1
-15296,3,8439,1,7,Arms of Keen Insight,306,75,17,0,3,1
-15297,3,8439,1,7,Arms of Keen Insight,306,75,17,0,4,1
-15298,3,8439,1,12,Fortress Arms,306,75,17,0,0,1
-15299,3,8439,1,12,Fortress Arms,306,75,17,0,1,1
-15300,3,8439,1,12,Fortress Arms,306,75,17,0,2,1
-15301,3,8439,1,12,Fortress Arms,306,75,17,0,3,1
-15302,3,8439,1,12,Fortress Arms,306,75,17,0,4,1
-15303,3,8895,1,12,Gloves of Benevolence,306,77,17,0,0,1
-15304,3,8895,1,12,Gloves of Benevolence,306,77,17,0,1,1
-15305,3,8895,1,12,Gloves of Benevolence,306,77,17,0,2,1
-15306,3,8895,1,12,Gloves of Benevolence,306,77,17,0,3,1
-15307,3,8895,1,12,Gloves of Benevolence,306,77,17,0,4,1
-15308,3,9601,1,1,Monochrome Gloves,306,80,17,0,0,1
-15309,3,9601,1,1,Monochrome Gloves,306,80,17,0,1,1
-15310,3,9601,1,1,Monochrome Gloves,306,80,17,0,2,1
-15311,3,9601,1,1,Monochrome Gloves,306,80,17,0,3,1
-15312,3,9601,1,1,Monochrome Gloves,306,80,17,0,4,1
-15313,3,9601,1,6,Dark Red Gloves,306,80,17,0,0,1
-15315,3,9601,1,6,Dark Red Gloves,306,80,17,0,1,1
-15316,3,9601,1,6,Dark Red Gloves,306,80,17,0,2,1
-15317,3,9601,1,6,Dark Red Gloves,306,80,17,0,3,1
-15318,3,9601,1,6,Dark Red Gloves,306,80,17,0,4,1
-15319,3,9601,1,11,Azure Mitts,306,80,17,0,0,1
-15320,3,9601,1,11,Azure Mitts,306,80,17,0,1,1
-15321,3,9601,1,11,Azure Mitts,306,80,17,0,2,1
-15322,3,9601,1,11,Azure Mitts,306,80,17,0,3,1
-15323,3,9601,1,11,Azure Mitts,306,80,17,0,4,1
-15324,3,8439,1,2,Mountaineer Bracers,306,75,14,0,0,1
-15325,3,8439,1,2,Mountaineer Bracers,306,75,14,0,1,1
-15326,3,8439,1,2,Mountaineer Bracers,306,75,14,0,2,1
-15327,3,8439,1,2,Mountaineer Bracers,306,75,14,0,3,1
-15328,3,8439,1,2,Mountaineer Bracers,306,75,14,0,4,1
-15329,3,8439,1,7,Ocean's Arms,306,75,14,0,0,1
-15330,3,8439,1,7,Ocean's Arms,306,75,14,0,1,1
-15331,3,8439,1,7,Ocean's Arms,306,75,14,0,2,1
-15332,3,8439,1,7,Ocean's Arms,306,75,14,0,3,1
-15333,3,8439,1,7,Ocean's Arms,306,75,14,0,4,1
-15334,3,8439,1,12,Forest Bracers,306,75,14,0,0,1
-15335,3,8439,1,12,Forest Bracers,306,75,14,0,1,1
-15336,3,8439,1,12,Forest Bracers,306,75,14,0,2,1
-15337,3,8439,1,12,Forest Bracers,306,75,14,0,3,1
-15338,3,8439,1,12,Forest Bracers,306,75,14,0,4,1
-15339,3,8895,1,12,Black Panther Sleeves,306,77,14,0,0,1
-15340,3,8895,1,12,Black Panther Sleeves,306,77,14,0,1,1
-15341,3,8895,1,12,Black Panther Sleeves,306,77,14,0,2,1
-15342,3,8895,1,12,Black Panther Sleeves,306,77,14,0,3,1
-15343,3,8895,1,12,Black Panther Sleeves,306,77,14,0,4,1
-15344,3,9601,1,1,Patrician Sleeves,306,80,14,0,0,1
-15345,3,9601,1,1,Patrician Sleeves,306,80,14,0,1,1
-15346,3,9601,1,1,Patrician Sleeves,306,80,14,0,2,1
-15347,3,9601,1,1,Patrician Sleeves,306,80,14,0,3,1
-15348,3,9601,1,1,Patrician Sleeves,306,80,14,0,4,1
-15349,3,9601,1,6,Gloves of Evening Mist,306,80,14,0,0,1
-15350,3,9601,1,6,Gloves of Evening Mist,306,80,14,0,1,1
-15351,3,9601,1,6,Gloves of Evening Mist,306,80,14,0,2,1
-15352,3,9601,1,6,Gloves of Evening Mist,306,80,14,0,3,1
-15353,3,9601,1,6,Gloves of Evening Mist,306,80,14,0,4,1
-15354,3,9601,1,11,Azure Gloves,306,80,14,0,0,1
-15355,3,9601,1,11,Azure Gloves,306,80,14,0,1,1
-15356,3,9601,1,11,Azure Gloves,306,80,14,0,2,1
-15357,3,9601,1,11,Azure Gloves,306,80,14,0,3,1
-15358,3,9601,1,11,Azure Gloves,306,80,14,0,4,1
+15198,3,9601,1,75,Finnegan's Hands,306,80,0,3,0,1
+15199,3,9601,1,75,Finnegan's Hands,306,80,0,3,1,1
+15200,3,9601,1,75,Finnegan's Hands,306,80,0,3,2,1
+15201,3,9601,1,75,Finnegan's Hands,306,80,0,3,3,1
+15202,3,9601,1,75,Finnegan's Hands,306,80,0,3,4,1
+15203,3,9601,1,75,Greedy Hands,306,80,0,3,0,1
+15204,3,9601,1,75,Greedy Hands,306,80,0,3,1,1
+15205,3,9601,1,75,Greedy Hands,306,80,0,3,2,1
+15206,3,9601,1,75,Greedy Hands,306,80,0,3,3,1
+15207,3,9601,1,75,Greedy Hands,306,80,0,3,4,1
+15208,3,5000,1,55,Duke Gloves (Dark Night),306,70,0,3,4,1
+15213,3,5000,1,70,Duke Gloves (Moonflower),306,75,0,3,4,1
+15218,3,8439,1,50,Executioner's Arm Covers,306,75,12,0,0,1
+15219,3,8439,1,50,Executioner's Arm Covers,306,75,12,0,1,1
+15220,3,8439,1,50,Executioner's Arm Covers,306,75,12,0,2,1
+15221,3,8439,1,50,Executioner's Arm Covers,306,75,12,0,3,1
+15222,3,8439,1,50,Executioner's Arm Covers,306,75,12,0,4,1
+15223,3,8439,1,55,Ancient Beast Gauntlets,306,75,12,0,0,1
+15224,3,8439,1,55,Ancient Beast Gauntlets,306,75,12,0,1,1
+15225,3,8439,1,55,Ancient Beast Gauntlets,306,75,12,0,2,1
+15226,3,8439,1,55,Ancient Beast Gauntlets,306,75,12,0,3,1
+15227,3,8439,1,55,Ancient Beast Gauntlets,306,75,12,0,4,1
+15228,3,8439,1,60,Arms of Genocide,306,75,12,0,0,1
+15229,3,8439,1,60,Arms of Genocide,306,75,12,0,1,1
+15230,3,8439,1,60,Arms of Genocide,306,75,12,0,2,1
+15231,3,8439,1,60,Arms of Genocide,306,75,12,0,3,1
+15232,3,8439,1,60,Arms of Genocide,306,75,12,0,4,1
+15233,3,8895,1,60,Royal Guardsman's Gauntlets,306,77,12,0,0,1
+15234,3,8895,1,60,Royal Guardsman's Gauntlets,306,77,12,0,1,1
+15235,3,8895,1,60,Royal Guardsman's Gauntlets,306,77,12,0,2,1
+15236,3,8895,1,60,Royal Guardsman's Gauntlets,306,77,12,0,3,1
+15237,3,8895,1,60,Royal Guardsman's Gauntlets,306,77,12,0,4,1
+15238,3,9601,1,65,Northern Bracers,306,80,12,0,0,1
+15239,3,9601,1,65,Northern Bracers,306,80,12,0,1,1
+15240,3,9601,1,65,Northern Bracers,306,80,12,0,2,1
+15241,3,9601,1,65,Northern Bracers,306,80,12,0,3,1
+15242,3,9601,1,65,Northern Bracers,306,80,12,0,4,1
+15243,3,9601,1,70,Knight Gauntlets of Dawn,306,80,12,0,0,1
+15244,3,9601,1,70,Knight Gauntlets of Dawn,306,80,12,0,1,1
+15245,3,9601,1,70,Knight Gauntlets of Dawn,306,80,12,0,2,1
+15246,3,9601,1,70,Knight Gauntlets of Dawn,306,80,12,0,3,1
+15247,3,9601,1,70,Knight Gauntlets of Dawn,306,80,12,0,4,1
+15248,3,9601,1,75,Azure Gauntlets,306,80,12,0,0,1
+15249,3,9601,1,75,Azure Gauntlets,306,80,12,0,1,1
+15250,3,9601,1,75,Azure Gauntlets,306,80,12,0,2,1
+15251,3,9601,1,75,Azure Gauntlets,306,80,12,0,3,1
+15252,3,9601,1,75,Azure Gauntlets,306,80,12,0,4,1
+15253,3,8439,1,50,Innocent Covers,306,75,15,0,0,1
+15254,3,8439,1,50,Innocent Covers,306,75,15,0,1,1
+15255,3,8439,1,50,Innocent Covers,306,75,15,0,2,1
+15256,3,8439,1,50,Innocent Covers,306,75,15,0,3,1
+15257,3,8439,1,50,Innocent Covers,306,75,15,0,4,1
+15258,3,8439,1,55,Red Copper Bangles,306,75,15,0,0,1
+15259,3,8439,1,55,Red Copper Bangles,306,75,15,0,1,1
+15260,3,8439,1,55,Red Copper Bangles,306,75,15,0,2,1
+15261,3,8439,1,55,Red Copper Bangles,306,75,15,0,3,1
+15262,3,8439,1,55,Red Copper Bangles,306,75,15,0,4,1
+15263,3,8439,1,60,Enhanced Bracers,306,75,15,0,0,1
+15264,3,8439,1,60,Enhanced Bracers,306,75,15,0,1,1
+15265,3,8439,1,60,Enhanced Bracers,306,75,15,0,2,1
+15266,3,8439,1,60,Enhanced Bracers,306,75,15,0,3,1
+15267,3,8439,1,60,Enhanced Bracers,306,75,15,0,4,1
+15268,3,8895,1,60,Medium Arms,306,77,15,0,0,1
+15269,3,8895,1,60,Medium Arms,306,77,15,0,1,1
+15270,3,8895,1,60,Medium Arms,306,77,15,0,2,1
+15271,3,8895,1,60,Medium Arms,306,77,15,0,3,1
+15272,3,8895,1,60,Medium Arms,306,77,15,0,4,1
+15273,3,9601,1,65,Garrisoner's Bracers,306,80,15,0,0,1
+15274,3,9601,1,65,Garrisoner's Bracers,306,80,15,0,1,1
+15275,3,9601,1,65,Garrisoner's Bracers,306,80,15,0,2,1
+15276,3,9601,1,65,Garrisoner's Bracers,306,80,15,0,3,1
+15277,3,9601,1,65,Garrisoner's Bracers,306,80,15,0,4,1
+15278,3,9601,1,70,Ginkgo-dyed Gloves,306,80,15,0,0,1
+15279,3,9601,1,70,Ginkgo-dyed Gloves,306,80,15,0,1,1
+15280,3,9601,1,70,Ginkgo-dyed Gloves,306,80,15,0,2,1
+15281,3,9601,1,70,Ginkgo-dyed Gloves,306,80,15,0,3,1
+15282,3,9601,1,70,Ginkgo-dyed Gloves,306,80,15,0,4,1
+15283,3,9601,1,75,Azure Arms,306,80,15,0,0,1
+15284,3,9601,1,75,Azure Arms,306,80,15,0,1,1
+15285,3,9601,1,75,Azure Arms,306,80,15,0,2,1
+15286,3,9601,1,75,Azure Arms,306,80,15,0,3,1
+15287,3,9601,1,75,Azure Arms,306,80,15,0,4,1
+15288,3,8439,1,50,Continent Arms,306,75,17,0,0,1
+15289,3,8439,1,50,Continent Arms,306,75,17,0,1,1
+15290,3,8439,1,50,Continent Arms,306,75,17,0,2,1
+15291,3,8439,1,50,Continent Arms,306,75,17,0,3,1
+15292,3,8439,1,50,Continent Arms,306,75,17,0,4,1
+15293,3,8439,1,55,Arms of Keen Insight,306,75,17,0,0,1
+15294,3,8439,1,55,Arms of Keen Insight,306,75,17,0,1,1
+15295,3,8439,1,55,Arms of Keen Insight,306,75,17,0,2,1
+15296,3,8439,1,55,Arms of Keen Insight,306,75,17,0,3,1
+15297,3,8439,1,55,Arms of Keen Insight,306,75,17,0,4,1
+15298,3,8439,1,60,Fortress Arms,306,75,17,0,0,1
+15299,3,8439,1,60,Fortress Arms,306,75,17,0,1,1
+15300,3,8439,1,60,Fortress Arms,306,75,17,0,2,1
+15301,3,8439,1,60,Fortress Arms,306,75,17,0,3,1
+15302,3,8439,1,60,Fortress Arms,306,75,17,0,4,1
+15303,3,8895,1,60,Gloves of Benevolence,306,77,17,0,0,1
+15304,3,8895,1,60,Gloves of Benevolence,306,77,17,0,1,1
+15305,3,8895,1,60,Gloves of Benevolence,306,77,17,0,2,1
+15306,3,8895,1,60,Gloves of Benevolence,306,77,17,0,3,1
+15307,3,8895,1,60,Gloves of Benevolence,306,77,17,0,4,1
+15308,3,9601,1,65,Monochrome Gloves,306,80,17,0,0,1
+15309,3,9601,1,65,Monochrome Gloves,306,80,17,0,1,1
+15310,3,9601,1,65,Monochrome Gloves,306,80,17,0,2,1
+15311,3,9601,1,65,Monochrome Gloves,306,80,17,0,3,1
+15312,3,9601,1,65,Monochrome Gloves,306,80,17,0,4,1
+15313,3,9601,1,70,Dark Red Gloves,306,80,17,0,0,1
+15315,3,9601,1,70,Dark Red Gloves,306,80,17,0,1,1
+15316,3,9601,1,70,Dark Red Gloves,306,80,17,0,2,1
+15317,3,9601,1,70,Dark Red Gloves,306,80,17,0,3,1
+15318,3,9601,1,70,Dark Red Gloves,306,80,17,0,4,1
+15319,3,9601,1,75,Azure Mitts,306,80,17,0,0,1
+15320,3,9601,1,75,Azure Mitts,306,80,17,0,1,1
+15321,3,9601,1,75,Azure Mitts,306,80,17,0,2,1
+15322,3,9601,1,75,Azure Mitts,306,80,17,0,3,1
+15323,3,9601,1,75,Azure Mitts,306,80,17,0,4,1
+15324,3,8439,1,50,Mountaineer Bracers,306,75,14,0,0,1
+15325,3,8439,1,50,Mountaineer Bracers,306,75,14,0,1,1
+15326,3,8439,1,50,Mountaineer Bracers,306,75,14,0,2,1
+15327,3,8439,1,50,Mountaineer Bracers,306,75,14,0,3,1
+15328,3,8439,1,50,Mountaineer Bracers,306,75,14,0,4,1
+15329,3,8439,1,55,Ocean's Arms,306,75,14,0,0,1
+15330,3,8439,1,55,Ocean's Arms,306,75,14,0,1,1
+15331,3,8439,1,55,Ocean's Arms,306,75,14,0,2,1
+15332,3,8439,1,55,Ocean's Arms,306,75,14,0,3,1
+15333,3,8439,1,55,Ocean's Arms,306,75,14,0,4,1
+15334,3,8439,1,60,Forest Bracers,306,75,14,0,0,1
+15335,3,8439,1,60,Forest Bracers,306,75,14,0,1,1
+15336,3,8439,1,60,Forest Bracers,306,75,14,0,2,1
+15337,3,8439,1,60,Forest Bracers,306,75,14,0,3,1
+15338,3,8439,1,60,Forest Bracers,306,75,14,0,4,1
+15339,3,8895,1,60,Black Panther Sleeves,306,77,14,0,0,1
+15340,3,8895,1,60,Black Panther Sleeves,306,77,14,0,1,1
+15341,3,8895,1,60,Black Panther Sleeves,306,77,14,0,2,1
+15342,3,8895,1,60,Black Panther Sleeves,306,77,14,0,3,1
+15343,3,8895,1,60,Black Panther Sleeves,306,77,14,0,4,1
+15344,3,9601,1,65,Patrician Sleeves,306,80,14,0,0,1
+15345,3,9601,1,65,Patrician Sleeves,306,80,14,0,1,1
+15346,3,9601,1,65,Patrician Sleeves,306,80,14,0,2,1
+15347,3,9601,1,65,Patrician Sleeves,306,80,14,0,3,1
+15348,3,9601,1,65,Patrician Sleeves,306,80,14,0,4,1
+15349,3,9601,1,70,Gloves of Evening Mist,306,80,14,0,0,1
+15350,3,9601,1,70,Gloves of Evening Mist,306,80,14,0,1,1
+15351,3,9601,1,70,Gloves of Evening Mist,306,80,14,0,2,1
+15352,3,9601,1,70,Gloves of Evening Mist,306,80,14,0,3,1
+15353,3,9601,1,70,Gloves of Evening Mist,306,80,14,0,4,1
+15354,3,9601,1,75,Azure Gloves,306,80,14,0,0,1
+15355,3,9601,1,75,Azure Gloves,306,80,14,0,1,1
+15356,3,9601,1,75,Azure Gloves,306,80,14,0,2,1
+15357,3,9601,1,75,Azure Gloves,306,80,14,0,3,1
+15358,3,9601,1,75,Azure Gloves,306,80,14,0,4,1
 16492,3,100,1,1,Dragoon Arms (Decoration),306,1,0,0,4,1
 16493,3,100,1,1,Wyrm's Grasp (Decoration),306,1,0,0,4,1
 16494,3,100,1,1,Ddraig Palmae (Decoration),306,1,0,0,4,1
 16495,3,100,1,1,Drachennägel (Decoration),306,1,0,0,4,1
-17691,3,9622,1,0,Brigand Gauntlets,306,80,12,0,0,1
-17692,3,9622,1,0,Brigand Gauntlets,306,80,12,0,1,1
-17693,3,9622,1,0,Brigand Gauntlets,306,80,12,0,2,1
-17694,3,9622,1,0,Brigand Gauntlets,306,80,12,0,3,1
-17695,3,9622,1,0,Brigand Gauntlets,306,80,12,0,4,1
-17696,3,10315,1,5,Gelmez Gloves,306,83,12,0,0,1
-17697,3,10315,1,5,Gelmez Gloves,306,83,12,0,1,1
-17698,3,10315,1,5,Gelmez Gloves,306,83,12,0,2,1
-17699,3,10315,1,5,Gelmez Gloves,306,83,12,0,3,1
-17700,3,10315,1,5,Gelmez Gloves,306,83,12,0,4,1
-17701,3,10777,1,10,Acrean Gauntlets,306,85,12,0,0,1
-17702,3,10777,1,10,Acrean Gauntlets,306,85,12,0,1,1
-17703,3,10777,1,10,Acrean Gauntlets,306,85,12,0,2,1
-17704,3,10777,1,10,Acrean Gauntlets,306,85,12,0,3,1
-17705,3,10777,1,10,Acrean Gauntlets,306,85,12,0,4,1
-17706,3,9622,1,0,Modestly Arms,306,80,15,0,0,1
-17707,3,9622,1,0,Modestly Arms,306,80,15,0,1,1
-17708,3,9622,1,0,Modestly Arms,306,80,15,0,2,1
-17709,3,9622,1,0,Modestly Arms,306,80,15,0,3,1
-17710,3,9622,1,0,Modestly Arms,306,80,15,0,4,1
-17711,3,10315,1,5,Duarev Bangles,306,83,15,0,0,1
-17712,3,10315,1,5,Duarev Bangles,306,83,15,0,1,1
-17713,3,10315,1,5,Duarev Bangles,306,83,15,0,2,1
-17714,3,10315,1,5,Duarev Bangles,306,83,15,0,3,1
-17715,3,10315,1,5,Duarev Bangles,306,83,15,0,4,1
-17716,3,10777,1,10,Acrean Bangles,306,85,15,0,0,1
-17717,3,10777,1,10,Acrean Bangles,306,85,15,0,1,1
-17718,3,10777,1,10,Acrean Bangles,306,85,15,0,2,1
-17719,3,10777,1,10,Acrean Bangles,306,85,15,0,3,1
-17720,3,10777,1,10,Acrean Bangles,306,85,15,0,4,1
-17721,3,9622,1,0,Brass Gloves,306,80,17,0,0,1
-17722,3,9622,1,0,Brass Gloves,306,80,17,0,1,1
-17723,3,9622,1,0,Brass Gloves,306,80,17,0,2,1
-17724,3,9622,1,0,Brass Gloves,306,80,17,0,3,1
-17725,3,9622,1,0,Brass Gloves,306,80,17,0,4,1
-17726,3,10315,1,5,Sizjak Arms,306,83,17,0,0,1
-17727,3,10315,1,5,Sizjak Arms,306,83,17,0,1,1
-17728,3,10315,1,5,Sizjak Arms,306,83,17,0,2,1
-17729,3,10315,1,5,Sizjak Arms,306,83,17,0,3,1
-17730,3,10315,1,5,Sizjak Arms,306,83,17,0,4,1
-17731,3,10777,1,10,Acrean Hands,306,85,17,0,0,1
-17732,3,10777,1,10,Acrean Hands,306,85,17,0,1,1
-17733,3,10777,1,10,Acrean Hands,306,85,17,0,2,1
-17734,3,10777,1,10,Acrean Hands,306,85,17,0,3,1
-17735,3,10777,1,10,Acrean Hands,306,85,17,0,4,1
-17736,3,9622,1,0,Armguards of Warm Winds,306,80,14,0,0,1
-17737,3,9622,1,0,Armguards of Warm Winds,306,80,14,0,1,1
-17738,3,9622,1,0,Armguards of Warm Winds,306,80,14,0,2,1
-17739,3,9622,1,0,Armguards of Warm Winds,306,80,14,0,3,1
-17740,3,9622,1,0,Armguards of Warm Winds,306,80,14,0,4,1
-17741,3,10315,1,5,Shahabad Bracers,306,83,14,0,0,1
-17742,3,10315,1,5,Shahabad Bracers,306,83,14,0,1,1
-17743,3,10315,1,5,Shahabad Bracers,306,83,14,0,2,1
-17744,3,10315,1,5,Shahabad Bracers,306,83,14,0,3,1
-17745,3,10315,1,5,Shahabad Bracers,306,83,14,0,4,1
-17746,3,10777,1,10,Acrean Gloves,306,85,14,0,0,1
-17747,3,10777,1,10,Acrean Gloves,306,85,14,0,1,1
-17748,3,10777,1,10,Acrean Gloves,306,85,14,0,2,1
-17749,3,10777,1,10,Acrean Gloves,306,85,14,0,3,1
-17750,3,10777,1,10,Acrean Gloves,306,85,14,0,4,1
-18319,3,10777,1,10,Courage Arms,306,85,12,0,0,1
-18320,3,10777,1,10,Courage Arms,306,85,12,0,1,1
-18321,3,10777,1,10,Courage Arms,306,85,12,0,2,1
-18322,3,10777,1,10,Courage Arms,306,85,12,0,3,1
-18323,3,10777,1,10,Courage Arms,306,85,12,0,4,1
-18324,3,11375,1,15,Emine Bracers,306,88,12,0,0,1
-18325,3,11375,1,15,Emine Bracers,306,88,12,0,1,1
-18326,3,11375,1,15,Emine Bracers,306,88,12,0,2,1
-18327,3,11375,1,15,Emine Bracers,306,88,12,0,3,1
-18328,3,11375,1,15,Emine Bracers,306,88,12,0,4,1
-18329,3,11974,1,4,Dools Arms,306,90,12,0,0,1
-18330,3,11974,1,4,Dools Arms,306,90,12,0,1,1
-18331,3,11974,1,4,Dools Arms,306,90,12,0,2,1
-18332,3,11974,1,4,Dools Arms,306,90,12,0,3,1
-18333,3,11974,1,4,Dools Arms,306,90,12,0,4,1
-18334,3,10777,1,10,Magnus Hands,306,85,15,0,0,1
-18335,3,10777,1,10,Magnus Hands,306,85,15,0,1,1
-18336,3,10777,1,10,Magnus Hands,306,85,15,0,2,1
-18337,3,10777,1,10,Magnus Hands,306,85,15,0,3,1
-18338,3,10777,1,10,Magnus Hands,306,85,15,0,4,1
-18339,3,11375,1,15,Bangles of Hope,306,88,15,0,0,1
-18340,3,11375,1,15,Bangles of Hope,306,88,15,0,1,1
-18341,3,11375,1,15,Bangles of Hope,306,88,15,0,2,1
-18342,3,11375,1,15,Bangles of Hope,306,88,15,0,3,1
-18343,3,11375,1,15,Bangles of Hope,306,88,15,0,4,1
-18344,3,11974,1,4,Dools Gloves,306,90,15,0,0,1
-18345,3,11974,1,4,Dools Gloves,306,90,15,0,1,1
-18346,3,11974,1,4,Dools Gloves,306,90,15,0,2,1
-18347,3,11974,1,4,Dools Gloves,306,90,15,0,3,1
-18348,3,11974,1,4,Dools Gloves,306,90,15,0,4,1
-18349,3,10777,1,10,Kelsus Vambraces,306,85,17,0,0,1
-18350,3,10777,1,10,Kelsus Vambraces,306,85,17,0,1,1
-18351,3,10777,1,10,Kelsus Vambraces,306,85,17,0,2,1
-18352,3,10777,1,10,Kelsus Vambraces,306,85,17,0,3,1
-18353,3,10777,1,10,Kelsus Vambraces,306,85,17,0,4,1
-18354,3,11375,1,15,Kier Gauntlets,306,88,17,0,0,1
-18355,3,11375,1,15,Kier Gauntlets,306,88,17,0,1,1
-18356,3,11375,1,15,Kier Gauntlets,306,88,17,0,2,1
-18357,3,11375,1,15,Kier Gauntlets,306,88,17,0,3,1
-18358,3,11375,1,15,Kier Gauntlets,306,88,17,0,4,1
-18359,3,11974,1,4,Dools Gauntlets,306,90,17,0,0,1
-18360,3,11974,1,4,Dools Gauntlets,306,90,17,0,1,1
-18361,3,11974,1,4,Dools Gauntlets,306,90,17,0,2,1
-18362,3,11974,1,4,Dools Gauntlets,306,90,17,0,3,1
-18363,3,11974,1,4,Dools Gauntlets,306,90,17,0,4,1
-18364,3,10777,1,10,Aura Gloves,306,85,14,0,0,1
-18365,3,10777,1,10,Aura Gloves,306,85,14,0,1,1
-18366,3,10777,1,10,Aura Gloves,306,85,14,0,2,1
-18367,3,10777,1,10,Aura Gloves,306,85,14,0,3,1
-18368,3,10777,1,10,Aura Gloves,306,85,14,0,4,1
-18369,3,11375,1,15,Niloufar Gloves,306,88,14,0,0,1
-18370,3,11375,1,15,Niloufar Gloves,306,88,14,0,1,1
-18371,3,11375,1,15,Niloufar Gloves,306,88,14,0,2,1
-18372,3,11375,1,15,Niloufar Gloves,306,88,14,0,3,1
-18373,3,11375,1,15,Niloufar Gloves,306,88,14,0,4,1
-18374,3,11974,1,4,Dools Bracers,306,90,14,0,0,1
-18375,3,11974,1,4,Dools Bracers,306,90,14,0,1,1
-18376,3,11974,1,4,Dools Bracers,306,90,14,0,2,1
-18377,3,11974,1,4,Dools Bracers,306,90,14,0,3,1
-18378,3,11974,1,4,Dools Bracers,306,90,14,0,4,1
+17691,3,9622,1,80,Brigand Gauntlets,306,80,12,0,0,1
+17692,3,9622,1,80,Brigand Gauntlets,306,80,12,0,1,1
+17693,3,9622,1,80,Brigand Gauntlets,306,80,12,0,2,1
+17694,3,9622,1,80,Brigand Gauntlets,306,80,12,0,3,1
+17695,3,9622,1,80,Brigand Gauntlets,306,80,12,0,4,1
+17696,3,10315,1,85,Gelmez Gloves,306,83,12,0,0,1
+17697,3,10315,1,85,Gelmez Gloves,306,83,12,0,1,1
+17698,3,10315,1,85,Gelmez Gloves,306,83,12,0,2,1
+17699,3,10315,1,85,Gelmez Gloves,306,83,12,0,3,1
+17700,3,10315,1,85,Gelmez Gloves,306,83,12,0,4,1
+17701,3,10777,1,90,Acrean Gauntlets,306,85,12,0,0,1
+17702,3,10777,1,90,Acrean Gauntlets,306,85,12,0,1,1
+17703,3,10777,1,90,Acrean Gauntlets,306,85,12,0,2,1
+17704,3,10777,1,90,Acrean Gauntlets,306,85,12,0,3,1
+17705,3,10777,1,90,Acrean Gauntlets,306,85,12,0,4,1
+17706,3,9622,1,80,Modestly Arms,306,80,15,0,0,1
+17707,3,9622,1,80,Modestly Arms,306,80,15,0,1,1
+17708,3,9622,1,80,Modestly Arms,306,80,15,0,2,1
+17709,3,9622,1,80,Modestly Arms,306,80,15,0,3,1
+17710,3,9622,1,80,Modestly Arms,306,80,15,0,4,1
+17711,3,10315,1,85,Duarev Bangles,306,83,15,0,0,1
+17712,3,10315,1,85,Duarev Bangles,306,83,15,0,1,1
+17713,3,10315,1,85,Duarev Bangles,306,83,15,0,2,1
+17714,3,10315,1,85,Duarev Bangles,306,83,15,0,3,1
+17715,3,10315,1,85,Duarev Bangles,306,83,15,0,4,1
+17716,3,10777,1,90,Acrean Bangles,306,85,15,0,0,1
+17717,3,10777,1,90,Acrean Bangles,306,85,15,0,1,1
+17718,3,10777,1,90,Acrean Bangles,306,85,15,0,2,1
+17719,3,10777,1,90,Acrean Bangles,306,85,15,0,3,1
+17720,3,10777,1,90,Acrean Bangles,306,85,15,0,4,1
+17721,3,9622,1,80,Brass Gloves,306,80,17,0,0,1
+17722,3,9622,1,80,Brass Gloves,306,80,17,0,1,1
+17723,3,9622,1,80,Brass Gloves,306,80,17,0,2,1
+17724,3,9622,1,80,Brass Gloves,306,80,17,0,3,1
+17725,3,9622,1,80,Brass Gloves,306,80,17,0,4,1
+17726,3,10315,1,85,Sizjak Arms,306,83,17,0,0,1
+17727,3,10315,1,85,Sizjak Arms,306,83,17,0,1,1
+17728,3,10315,1,85,Sizjak Arms,306,83,17,0,2,1
+17729,3,10315,1,85,Sizjak Arms,306,83,17,0,3,1
+17730,3,10315,1,85,Sizjak Arms,306,83,17,0,4,1
+17731,3,10777,1,90,Acrean Hands,306,85,17,0,0,1
+17732,3,10777,1,90,Acrean Hands,306,85,17,0,1,1
+17733,3,10777,1,90,Acrean Hands,306,85,17,0,2,1
+17734,3,10777,1,90,Acrean Hands,306,85,17,0,3,1
+17735,3,10777,1,90,Acrean Hands,306,85,17,0,4,1
+17736,3,9622,1,80,Armguards of Warm Winds,306,80,14,0,0,1
+17737,3,9622,1,80,Armguards of Warm Winds,306,80,14,0,1,1
+17738,3,9622,1,80,Armguards of Warm Winds,306,80,14,0,2,1
+17739,3,9622,1,80,Armguards of Warm Winds,306,80,14,0,3,1
+17740,3,9622,1,80,Armguards of Warm Winds,306,80,14,0,4,1
+17741,3,10315,1,85,Shahabad Bracers,306,83,14,0,0,1
+17742,3,10315,1,85,Shahabad Bracers,306,83,14,0,1,1
+17743,3,10315,1,85,Shahabad Bracers,306,83,14,0,2,1
+17744,3,10315,1,85,Shahabad Bracers,306,83,14,0,3,1
+17745,3,10315,1,85,Shahabad Bracers,306,83,14,0,4,1
+17746,3,10777,1,90,Acrean Gloves,306,85,14,0,0,1
+17747,3,10777,1,90,Acrean Gloves,306,85,14,0,1,1
+17748,3,10777,1,90,Acrean Gloves,306,85,14,0,2,1
+17749,3,10777,1,90,Acrean Gloves,306,85,14,0,3,1
+17750,3,10777,1,90,Acrean Gloves,306,85,14,0,4,1
+18319,3,10777,1,90,Courage Arms,306,85,12,0,0,1
+18320,3,10777,1,90,Courage Arms,306,85,12,0,1,1
+18321,3,10777,1,90,Courage Arms,306,85,12,0,2,1
+18322,3,10777,1,90,Courage Arms,306,85,12,0,3,1
+18323,3,10777,1,90,Courage Arms,306,85,12,0,4,1
+18324,3,11375,1,95,Emine Bracers,306,88,12,0,0,1
+18325,3,11375,1,95,Emine Bracers,306,88,12,0,1,1
+18326,3,11375,1,95,Emine Bracers,306,88,12,0,2,1
+18327,3,11375,1,95,Emine Bracers,306,88,12,0,3,1
+18328,3,11375,1,95,Emine Bracers,306,88,12,0,4,1
+18329,3,11974,1,100,Dools Arms,306,90,12,0,0,1
+18330,3,11974,1,100,Dools Arms,306,90,12,0,1,1
+18331,3,11974,1,100,Dools Arms,306,90,12,0,2,1
+18332,3,11974,1,100,Dools Arms,306,90,12,0,3,1
+18333,3,11974,1,100,Dools Arms,306,90,12,0,4,1
+18334,3,10777,1,90,Magnus Hands,306,85,15,0,0,1
+18335,3,10777,1,90,Magnus Hands,306,85,15,0,1,1
+18336,3,10777,1,90,Magnus Hands,306,85,15,0,2,1
+18337,3,10777,1,90,Magnus Hands,306,85,15,0,3,1
+18338,3,10777,1,90,Magnus Hands,306,85,15,0,4,1
+18339,3,11375,1,95,Bangles of Hope,306,88,15,0,0,1
+18340,3,11375,1,95,Bangles of Hope,306,88,15,0,1,1
+18341,3,11375,1,95,Bangles of Hope,306,88,15,0,2,1
+18342,3,11375,1,95,Bangles of Hope,306,88,15,0,3,1
+18343,3,11375,1,95,Bangles of Hope,306,88,15,0,4,1
+18344,3,11974,1,100,Dools Gloves,306,90,15,0,0,1
+18345,3,11974,1,100,Dools Gloves,306,90,15,0,1,1
+18346,3,11974,1,100,Dools Gloves,306,90,15,0,2,1
+18347,3,11974,1,100,Dools Gloves,306,90,15,0,3,1
+18348,3,11974,1,100,Dools Gloves,306,90,15,0,4,1
+18349,3,10777,1,90,Kelsus Vambraces,306,85,17,0,0,1
+18350,3,10777,1,90,Kelsus Vambraces,306,85,17,0,1,1
+18351,3,10777,1,90,Kelsus Vambraces,306,85,17,0,2,1
+18352,3,10777,1,90,Kelsus Vambraces,306,85,17,0,3,1
+18353,3,10777,1,90,Kelsus Vambraces,306,85,17,0,4,1
+18354,3,11375,1,95,Kier Gauntlets,306,88,17,0,0,1
+18355,3,11375,1,95,Kier Gauntlets,306,88,17,0,1,1
+18356,3,11375,1,95,Kier Gauntlets,306,88,17,0,2,1
+18357,3,11375,1,95,Kier Gauntlets,306,88,17,0,3,1
+18358,3,11375,1,95,Kier Gauntlets,306,88,17,0,4,1
+18359,3,11974,1,100,Dools Gauntlets,306,90,17,0,0,1
+18360,3,11974,1,100,Dools Gauntlets,306,90,17,0,1,1
+18361,3,11974,1,100,Dools Gauntlets,306,90,17,0,2,1
+18362,3,11974,1,100,Dools Gauntlets,306,90,17,0,3,1
+18363,3,11974,1,100,Dools Gauntlets,306,90,17,0,4,1
+18364,3,10777,1,90,Aura Gloves,306,85,14,0,0,1
+18365,3,10777,1,90,Aura Gloves,306,85,14,0,1,1
+18366,3,10777,1,90,Aura Gloves,306,85,14,0,2,1
+18367,3,10777,1,90,Aura Gloves,306,85,14,0,3,1
+18368,3,10777,1,90,Aura Gloves,306,85,14,0,4,1
+18369,3,11375,1,95,Niloufar Gloves,306,88,14,0,0,1
+18370,3,11375,1,95,Niloufar Gloves,306,88,14,0,1,1
+18371,3,11375,1,95,Niloufar Gloves,306,88,14,0,2,1
+18372,3,11375,1,95,Niloufar Gloves,306,88,14,0,3,1
+18373,3,11375,1,95,Niloufar Gloves,306,88,14,0,4,1
+18374,3,11974,1,100,Dools Bracers,306,90,14,0,0,1
+18375,3,11974,1,100,Dools Bracers,306,90,14,0,1,1
+18376,3,11974,1,100,Dools Bracers,306,90,14,0,2,1
+18377,3,11974,1,100,Dools Bracers,306,90,14,0,3,1
+18378,3,11974,1,100,Dools Bracers,306,90,14,0,4,1
 18495,3,100,1,1,Volcanic Gloves,306,75,0,0,4,1
-19246,3,0,1,10,Gauntlets of the First King,306,80,0,3,0,1
-19247,3,0,1,4,Gauntlets of the First King,306,80,0,3,1,1
-19248,3,0,1,9,Gauntlets of the First King,306,80,0,3,2,1
-19249,3,0,1,14,Gauntlets of the First King,306,80,0,3,3,1
-19250,3,0,1,8,Gauntlets of the First King,306,80,0,3,4,1
-19456,3,10000,1,0,Boundless Tempest Gloves,306,1,0,3,4,1
-19460,3,10000,1,3,Boundless Tempest Arms,306,1,0,3,4,1
-20464,3,11900,1,4,Maddest Bracers,306,90,12,0,0,1
-20465,3,11900,1,4,Maddest Bracers,306,90,12,0,1,1
-20466,3,11900,1,4,Maddest Bracers,306,90,12,0,2,1
-20467,3,11900,1,4,Maddest Bracers,306,90,12,0,3,1
-20468,3,11900,1,4,Maddest Bracers,306,90,12,0,4,1
-20469,3,12495,1,9,Corail Gauntlets,306,93,12,0,0,1
-20470,3,12495,1,9,Corail Gauntlets,306,93,12,0,1,1
-20471,3,12495,1,9,Corail Gauntlets,306,93,12,0,2,1
-20472,3,12495,1,9,Corail Gauntlets,306,93,12,0,3,1
-20473,3,12495,1,9,Corail Gauntlets,306,93,12,0,4,1
-20474,3,13090,1,14,Mehizaf Cutter,306,95,12,0,0,1
-20475,3,13090,1,14,Mehizaf Cutter,306,95,12,0,1,1
-20476,3,13090,1,14,Mehizaf Cutter,306,95,12,0,2,1
-20477,3,13090,1,14,Mehizaf Cutter,306,95,12,0,3,1
-20478,3,13090,1,14,Mehizaf Cutter,306,95,12,0,4,1
-20792,3,13090,1,14,Courage Arms,306,95,12,0,0,1
-20793,3,13090,1,14,Courage Arms,306,95,12,0,1,1
-20794,3,13090,1,14,Courage Arms,306,95,12,0,2,1
-20795,3,13090,1,14,Courage Arms,306,95,12,0,3,1
-20796,3,13090,1,14,Courage Arms,306,95,12,0,4,1
-20797,3,13685,1,3,Confidence Gauntlets,306,98,12,0,0,1
-20798,3,13685,1,3,Confidence Gauntlets,306,98,12,0,1,1
-20799,3,13685,1,3,Confidence Gauntlets,306,98,12,0,2,1
-20800,3,13685,1,3,Confidence Gauntlets,306,98,12,0,3,1
-20801,3,13685,1,3,Confidence Gauntlets,306,98,12,0,4,1
-20802,3,14280,1,8,Ambition Arms,306,100,12,0,0,1
-20803,3,14280,1,8,Ambition Arms,306,100,12,0,1,1
-20804,3,14280,1,8,Ambition Arms,306,100,12,0,2,1
-20805,3,14280,1,8,Ambition Arms,306,100,12,0,3,1
-20806,3,14280,1,8,Ambition Arms,306,100,12,0,4,1
-20524,3,11900,1,4,Capable Bracers,306,90,14,0,0,1
-20525,3,11900,1,4,Capable Bracers,306,90,14,0,1,1
-20526,3,11900,1,4,Capable Bracers,306,90,14,0,2,1
-20527,3,11900,1,4,Capable Bracers,306,90,14,0,3,1
-20528,3,11900,1,4,Capable Bracers,306,90,14,0,4,1
-20529,3,12495,1,9,Cuivre Arms,306,93,14,0,0,1
-20530,3,12495,1,9,Cuivre Arms,306,93,14,0,1,1
-20531,3,12495,1,9,Cuivre Arms,306,93,14,0,2,1
-20532,3,12495,1,9,Cuivre Arms,306,93,14,0,3,1
-20533,3,12495,1,9,Cuivre Arms,306,93,14,0,4,1
-20534,3,13090,1,14,Mehizaf Glove,306,95,14,0,0,1
-20535,3,13090,1,14,Mehizaf Glove,306,95,14,0,1,1
-20536,3,13090,1,14,Mehizaf Glove,306,95,14,0,2,1
-20537,3,13090,1,14,Mehizaf Glove,306,95,14,0,3,1
-20538,3,13090,1,14,Mehizaf Glove,306,95,14,0,4,1
-20852,3,13090,1,14,Hardy Sleeves,306,95,14,0,0,1
-20853,3,13090,1,14,Hardy Sleeves,306,95,14,0,1,1
-20854,3,13090,1,14,Hardy Sleeves,306,95,14,0,2,1
-20855,3,13090,1,14,Hardy Sleeves,306,95,14,0,3,1
-20856,3,13090,1,14,Hardy Sleeves,306,95,14,0,4,1
-20857,3,13685,1,3,Taciturne Gloves,306,98,14,0,0,1
-20858,3,13685,1,3,Taciturne Gloves,306,98,14,0,1,1
-20859,3,13685,1,3,Taciturne Gloves,306,98,14,0,2,1
-20860,3,13685,1,3,Taciturne Gloves,306,98,14,0,3,1
-20861,3,13685,1,3,Taciturne Gloves,306,98,14,0,4,1
-20862,3,14280,1,8,Mission Armguards,306,100,14,0,0,1
-20863,3,14280,1,8,Mission Armguards,306,100,14,0,1,1
-20864,3,14280,1,8,Mission Armguards,306,100,14,0,2,1
-20865,3,14280,1,8,Mission Armguards,306,100,14,0,3,1
-20866,3,14280,1,8,Mission Armguards,306,100,14,0,4,1
-20584,3,11900,1,4,Bangles of Sacrament,306,90,15,0,0,1
-20585,3,11900,1,4,Bangles of Sacrament,306,90,15,0,1,1
-20586,3,11900,1,4,Bangles of Sacrament,306,90,15,0,2,1
-20587,3,11900,1,4,Bangles of Sacrament,306,90,15,0,3,1
-20588,3,11900,1,4,Bangles of Sacrament,306,90,15,0,4,1
-20589,3,12495,1,9,June Bracers,306,93,15,0,0,1
-20590,3,12495,1,9,June Bracers,306,93,15,0,1,1
-20591,3,12495,1,9,June Bracers,306,93,15,0,2,1
-20592,3,12495,1,9,June Bracers,306,93,15,0,3,1
-20593,3,12495,1,9,June Bracers,306,93,15,0,4,1
-20594,3,13090,1,14,Mehizaf Gauntlets,306,95,15,0,0,1
-20595,3,13090,1,14,Mehizaf Gauntlets,306,95,15,0,1,1
-20596,3,13090,1,14,Mehizaf Gauntlets,306,95,15,0,2,1
-20597,3,13090,1,14,Mehizaf Gauntlets,306,95,15,0,3,1
-20598,3,13090,1,14,Mehizaf Gauntlets,306,95,15,0,4,1
-20912,3,13090,1,14,Miséricorde Bangles,306,95,15,0,0,1
-20913,3,13090,1,14,Miséricorde Bangles,306,95,15,0,1,1
-20914,3,13090,1,14,Miséricorde Bangles,306,95,15,0,2,1
-20915,3,13090,1,14,Miséricorde Bangles,306,95,15,0,3,1
-20916,3,13090,1,14,Miséricorde Bangles,306,95,15,0,4,1
-20917,3,13685,1,3,Charité Bangles,306,98,15,0,0,1
-20918,3,13685,1,3,Charité Bangles,306,98,15,0,1,1
-20919,3,13685,1,3,Charité Bangles,306,98,15,0,2,1
-20920,3,13685,1,3,Charité Bangles,306,98,15,0,3,1
-20921,3,13685,1,3,Charité Bangles,306,98,15,0,4,1
-20922,3,14280,1,8,Redoutable Arms,306,100,15,0,0,1
-20923,3,14280,1,8,Redoutable Arms,306,100,15,0,1,1
-20924,3,14280,1,8,Redoutable Arms,306,100,15,0,2,1
-20925,3,14280,1,8,Redoutable Arms,306,100,15,0,3,1
-20926,3,14280,1,8,Redoutable Arms,306,100,15,0,4,1
-20644,3,11900,1,4,Pundit Gloves,306,90,17,0,0,1
-20645,3,11900,1,4,Pundit Gloves,306,90,17,0,1,1
-20646,3,11900,1,4,Pundit Gloves,306,90,17,0,2,1
-20647,3,11900,1,4,Pundit Gloves,306,90,17,0,3,1
-20648,3,11900,1,4,Pundit Gloves,306,90,17,0,4,1
-20649,3,12495,1,9,Briller Arms,306,93,17,0,0,1
-20650,3,12495,1,9,Briller Arms,306,93,17,0,1,1
-20651,3,12495,1,9,Briller Arms,306,93,17,0,2,1
-20652,3,12495,1,9,Briller Arms,306,93,17,0,3,1
-20653,3,12495,1,9,Briller Arms,306,93,17,0,4,1
-20654,3,13090,1,14,Mehizaf Bangle,306,95,17,0,0,1
-20655,3,13090,1,14,Mehizaf Bangle,306,95,17,0,1,1
-20656,3,13090,1,14,Mehizaf Bangle,306,95,17,0,2,1
-20657,3,13090,1,14,Mehizaf Bangle,306,95,17,0,3,1
-20658,3,13090,1,14,Mehizaf Bangle,306,95,17,0,4,1
-20972,3,13090,1,14,Positivité Arms,306,95,17,0,0,1
-20973,3,13090,1,14,Positivité Arms,306,95,17,0,1,1
-20974,3,13090,1,14,Positivité Arms,306,95,17,0,2,1
-20975,3,13090,1,14,Positivité Arms,306,95,17,0,3,1
-20976,3,13090,1,14,Positivité Arms,306,95,17,0,4,1
-20977,3,13685,1,3,Solidarité Hands,306,98,17,0,0,1
-20978,3,13685,1,3,Solidarité Hands,306,98,17,0,1,1
-20979,3,13685,1,3,Solidarité Hands,306,98,17,0,2,1
-20980,3,13685,1,3,Solidarité Hands,306,98,17,0,3,1
-20981,3,13685,1,3,Solidarité Hands,306,98,17,0,4,1
-20982,3,14280,1,8,Ideal Arms,306,100,17,0,0,1
-20983,3,14280,1,8,Ideal Arms,306,100,17,0,1,1
-20984,3,14280,1,8,Ideal Arms,306,100,17,0,2,1
-20985,3,14280,1,8,Ideal Arms,306,100,17,0,3,1
-20986,3,14280,1,8,Ideal Arms,306,100,17,0,4,1
+19246,3,0,1,90,Gauntlets of the First King,306,80,0,3,0,1
+19247,3,0,1,100,Gauntlets of the First King,306,80,0,3,1,1
+19248,3,0,1,105,Gauntlets of the First King,306,80,0,3,2,1
+19249,3,0,1,110,Gauntlets of the First King,306,80,0,3,3,1
+19250,3,0,1,120,Gauntlets of the First King,306,80,0,3,4,1
+19456,3,10000,1,80,Boundless Tempest Gloves,306,1,0,3,4,1
+19460,3,10000,1,83,Boundless Tempest Arms,306,1,0,3,4,1
+20464,3,11900,1,100,Maddest Bracers,306,90,12,0,0,1
+20465,3,11900,1,100,Maddest Bracers,306,90,12,0,1,1
+20466,3,11900,1,100,Maddest Bracers,306,90,12,0,2,1
+20467,3,11900,1,100,Maddest Bracers,306,90,12,0,3,1
+20468,3,11900,1,100,Maddest Bracers,306,90,12,0,4,1
+20469,3,12495,1,105,Corail Gauntlets,306,93,12,0,0,1
+20470,3,12495,1,105,Corail Gauntlets,306,93,12,0,1,1
+20471,3,12495,1,105,Corail Gauntlets,306,93,12,0,2,1
+20472,3,12495,1,105,Corail Gauntlets,306,93,12,0,3,1
+20473,3,12495,1,105,Corail Gauntlets,306,93,12,0,4,1
+20474,3,13090,1,110,Mehizaf Cutter,306,95,12,0,0,1
+20475,3,13090,1,110,Mehizaf Cutter,306,95,12,0,1,1
+20476,3,13090,1,110,Mehizaf Cutter,306,95,12,0,2,1
+20477,3,13090,1,110,Mehizaf Cutter,306,95,12,0,3,1
+20478,3,13090,1,110,Mehizaf Cutter,306,95,12,0,4,1
+20792,3,13090,1,110,Courage Arms,306,95,12,0,0,1
+20793,3,13090,1,110,Courage Arms,306,95,12,0,1,1
+20794,3,13090,1,110,Courage Arms,306,95,12,0,2,1
+20795,3,13090,1,110,Courage Arms,306,95,12,0,3,1
+20796,3,13090,1,110,Courage Arms,306,95,12,0,4,1
+20797,3,13685,1,115,Confidence Gauntlets,306,98,12,0,0,1
+20798,3,13685,1,115,Confidence Gauntlets,306,98,12,0,1,1
+20799,3,13685,1,115,Confidence Gauntlets,306,98,12,0,2,1
+20800,3,13685,1,115,Confidence Gauntlets,306,98,12,0,3,1
+20801,3,13685,1,115,Confidence Gauntlets,306,98,12,0,4,1
+20802,3,14280,1,120,Ambition Arms,306,100,12,0,0,1
+20803,3,14280,1,120,Ambition Arms,306,100,12,0,1,1
+20804,3,14280,1,120,Ambition Arms,306,100,12,0,2,1
+20805,3,14280,1,120,Ambition Arms,306,100,12,0,3,1
+20806,3,14280,1,120,Ambition Arms,306,100,12,0,4,1
+20524,3,11900,1,100,Capable Bracers,306,90,14,0,0,1
+20525,3,11900,1,100,Capable Bracers,306,90,14,0,1,1
+20526,3,11900,1,100,Capable Bracers,306,90,14,0,2,1
+20527,3,11900,1,100,Capable Bracers,306,90,14,0,3,1
+20528,3,11900,1,100,Capable Bracers,306,90,14,0,4,1
+20529,3,12495,1,105,Cuivre Arms,306,93,14,0,0,1
+20530,3,12495,1,105,Cuivre Arms,306,93,14,0,1,1
+20531,3,12495,1,105,Cuivre Arms,306,93,14,0,2,1
+20532,3,12495,1,105,Cuivre Arms,306,93,14,0,3,1
+20533,3,12495,1,105,Cuivre Arms,306,93,14,0,4,1
+20534,3,13090,1,110,Mehizaf Glove,306,95,14,0,0,1
+20535,3,13090,1,110,Mehizaf Glove,306,95,14,0,1,1
+20536,3,13090,1,110,Mehizaf Glove,306,95,14,0,2,1
+20537,3,13090,1,110,Mehizaf Glove,306,95,14,0,3,1
+20538,3,13090,1,110,Mehizaf Glove,306,95,14,0,4,1
+20852,3,13090,1,110,Hardy Sleeves,306,95,14,0,0,1
+20853,3,13090,1,110,Hardy Sleeves,306,95,14,0,1,1
+20854,3,13090,1,110,Hardy Sleeves,306,95,14,0,2,1
+20855,3,13090,1,110,Hardy Sleeves,306,95,14,0,3,1
+20856,3,13090,1,110,Hardy Sleeves,306,95,14,0,4,1
+20857,3,13685,1,115,Taciturne Gloves,306,98,14,0,0,1
+20858,3,13685,1,115,Taciturne Gloves,306,98,14,0,1,1
+20859,3,13685,1,115,Taciturne Gloves,306,98,14,0,2,1
+20860,3,13685,1,115,Taciturne Gloves,306,98,14,0,3,1
+20861,3,13685,1,115,Taciturne Gloves,306,98,14,0,4,1
+20862,3,14280,1,120,Mission Armguards,306,100,14,0,0,1
+20863,3,14280,1,120,Mission Armguards,306,100,14,0,1,1
+20864,3,14280,1,120,Mission Armguards,306,100,14,0,2,1
+20865,3,14280,1,120,Mission Armguards,306,100,14,0,3,1
+20866,3,14280,1,120,Mission Armguards,306,100,14,0,4,1
+20584,3,11900,1,100,Bangles of Sacrament,306,90,15,0,0,1
+20585,3,11900,1,100,Bangles of Sacrament,306,90,15,0,1,1
+20586,3,11900,1,100,Bangles of Sacrament,306,90,15,0,2,1
+20587,3,11900,1,100,Bangles of Sacrament,306,90,15,0,3,1
+20588,3,11900,1,100,Bangles of Sacrament,306,90,15,0,4,1
+20589,3,12495,1,105,June Bracers,306,93,15,0,0,1
+20590,3,12495,1,105,June Bracers,306,93,15,0,1,1
+20591,3,12495,1,105,June Bracers,306,93,15,0,2,1
+20592,3,12495,1,105,June Bracers,306,93,15,0,3,1
+20593,3,12495,1,105,June Bracers,306,93,15,0,4,1
+20594,3,13090,1,110,Mehizaf Gauntlets,306,95,15,0,0,1
+20595,3,13090,1,110,Mehizaf Gauntlets,306,95,15,0,1,1
+20596,3,13090,1,110,Mehizaf Gauntlets,306,95,15,0,2,1
+20597,3,13090,1,110,Mehizaf Gauntlets,306,95,15,0,3,1
+20598,3,13090,1,110,Mehizaf Gauntlets,306,95,15,0,4,1
+20912,3,13090,1,110,Miséricorde Bangles,306,95,15,0,0,1
+20913,3,13090,1,110,Miséricorde Bangles,306,95,15,0,1,1
+20914,3,13090,1,110,Miséricorde Bangles,306,95,15,0,2,1
+20915,3,13090,1,110,Miséricorde Bangles,306,95,15,0,3,1
+20916,3,13090,1,110,Miséricorde Bangles,306,95,15,0,4,1
+20917,3,13685,1,115,Charité Bangles,306,98,15,0,0,1
+20918,3,13685,1,115,Charité Bangles,306,98,15,0,1,1
+20919,3,13685,1,115,Charité Bangles,306,98,15,0,2,1
+20920,3,13685,1,115,Charité Bangles,306,98,15,0,3,1
+20921,3,13685,1,115,Charité Bangles,306,98,15,0,4,1
+20922,3,14280,1,120,Redoutable Arms,306,100,15,0,0,1
+20923,3,14280,1,120,Redoutable Arms,306,100,15,0,1,1
+20924,3,14280,1,120,Redoutable Arms,306,100,15,0,2,1
+20925,3,14280,1,120,Redoutable Arms,306,100,15,0,3,1
+20926,3,14280,1,120,Redoutable Arms,306,100,15,0,4,1
+20644,3,11900,1,100,Pundit Gloves,306,90,17,0,0,1
+20645,3,11900,1,100,Pundit Gloves,306,90,17,0,1,1
+20646,3,11900,1,100,Pundit Gloves,306,90,17,0,2,1
+20647,3,11900,1,100,Pundit Gloves,306,90,17,0,3,1
+20648,3,11900,1,100,Pundit Gloves,306,90,17,0,4,1
+20649,3,12495,1,105,Briller Arms,306,93,17,0,0,1
+20650,3,12495,1,105,Briller Arms,306,93,17,0,1,1
+20651,3,12495,1,105,Briller Arms,306,93,17,0,2,1
+20652,3,12495,1,105,Briller Arms,306,93,17,0,3,1
+20653,3,12495,1,105,Briller Arms,306,93,17,0,4,1
+20654,3,13090,1,110,Mehizaf Bangle,306,95,17,0,0,1
+20655,3,13090,1,110,Mehizaf Bangle,306,95,17,0,1,1
+20656,3,13090,1,110,Mehizaf Bangle,306,95,17,0,2,1
+20657,3,13090,1,110,Mehizaf Bangle,306,95,17,0,3,1
+20658,3,13090,1,110,Mehizaf Bangle,306,95,17,0,4,1
+20972,3,13090,1,110,Positivité Arms,306,95,17,0,0,1
+20973,3,13090,1,110,Positivité Arms,306,95,17,0,1,1
+20974,3,13090,1,110,Positivité Arms,306,95,17,0,2,1
+20975,3,13090,1,110,Positivité Arms,306,95,17,0,3,1
+20976,3,13090,1,110,Positivité Arms,306,95,17,0,4,1
+20977,3,13685,1,115,Solidarité Hands,306,98,17,0,0,1
+20978,3,13685,1,115,Solidarité Hands,306,98,17,0,1,1
+20979,3,13685,1,115,Solidarité Hands,306,98,17,0,2,1
+20980,3,13685,1,115,Solidarité Hands,306,98,17,0,3,1
+20981,3,13685,1,115,Solidarité Hands,306,98,17,0,4,1
+20982,3,14280,1,120,Ideal Arms,306,100,17,0,0,1
+20983,3,14280,1,120,Ideal Arms,306,100,17,0,1,1
+20984,3,14280,1,120,Ideal Arms,306,100,17,0,2,1
+20985,3,14280,1,120,Ideal Arms,306,100,17,0,3,1
+20986,3,14280,1,120,Ideal Arms,306,100,17,0,4,1
 20690,3,100,1,1,War God's Gauntlets,306,1,0,0,4,1
 21022,3,100,1,1,Refined Arms,306,1,0,0,4,1
 21027,3,100,1,1,Noble Arms,306,1,0,0,4,1
-21114,3,10000,1,12,Maestro Gloves,306,1,0,3,4,1
-21163,3,10000,1,15,Virtuoso Gloves,306,1,0,3,4,1
+21114,3,10000,1,92,Maestro Gloves,306,1,0,3,4,1
+21163,3,10000,1,95,Virtuoso Gloves,306,1,0,3,4,1
 21398,3,500,1,12,Cursed Arms,306,1,0,0,0,1
 21402,3,500,1,12,Chaos Gloves,306,1,0,0,0,1
-21698,3,10000,1,11,Winter Gloves (White),306,1,0,0,4,1
-21699,3,10000,1,11,Winter Gloves (Black),306,1,0,0,4,1
-21700,3,10000,1,11,Winter Gloves (Brown),306,1,0,0,4,1
-24149,3,0,1,2,Spirit's Heavy Armored Arm Gear,306,100,12,0,0,1
-24150,3,0,1,2,Spirit's Heavy Armored Arm Gear,306,100,12,0,1,1
-24151,3,0,1,2,Spirit's Heavy Armored Arm Gear,306,100,12,0,2,1
-24152,3,0,1,2,Spirit's Heavy Armored Arm Gear,306,100,12,0,3,1
-24153,3,0,1,2,Spirit's Heavy Armored Arm Gear,306,100,12,0,4,1
-24154,3,0,1,2,Fire King's Heavy Armored Arm Gear,306,100,12,0,0,1
-24155,3,0,1,2,Fire King's Heavy Armored Arm Gear,306,100,12,0,1,1
-24156,3,0,1,2,Fire King's Heavy Armored Arm Gear,306,100,12,0,2,1
-24157,3,0,1,2,Fire King's Heavy Armored Arm Gear,306,100,12,0,3,1
-24158,3,0,1,2,Fire King's Heavy Armored Arm Gear,306,100,12,0,4,1
-24159,3,0,1,2,White Wings' Heavy Armored Arm Gear,306,100,12,0,0,1
-24160,3,0,1,2,White Wings' Heavy Armored Arm Gear,306,100,12,0,1,1
-24161,3,0,1,2,White Wings' Heavy Armored Arm Gear,306,100,12,0,2,1
-24162,3,0,1,2,White Wings' Heavy Armored Arm Gear,306,100,12,0,3,1
-24163,3,0,1,2,White Wings' Heavy Armored Arm Gear,306,100,12,0,4,1
-24164,3,0,1,2,Golden Heavy Arms,306,100,12,0,0,1
-24165,3,0,1,2,Golden Heavy Arms,306,100,12,0,1,1
-24166,3,0,1,2,Golden Heavy Arms,306,100,12,0,2,1
-24167,3,0,1,2,Golden Heavy Arms,306,100,12,0,3,1
-24168,3,0,1,2,Golden Heavy Arms,306,100,12,0,4,1
-24169,3,0,1,7,Blackshatter Heavy Gauntlet,306,100,12,0,0,1
-24170,3,0,1,7,Blackshatter Heavy Gauntlet,306,100,12,0,1,1
-24171,3,0,1,7,Blackshatter Heavy Gauntlet,306,100,12,0,2,1
-24172,3,0,1,7,Blackshatter Heavy Gauntlet,306,100,12,0,3,1
-24173,3,0,1,7,Blackshatter Heavy Gauntlet,306,100,12,0,4,1
-24249,3,0,1,2,Spirit's Light Armored Arm Gear,306,100,14,0,0,1
-24250,3,0,1,2,Spirit's Light Armored Arm Gear,306,100,14,0,1,1
-24251,3,0,1,2,Spirit's Light Armored Arm Gear,306,100,14,0,2,1
-24252,3,0,1,2,Spirit's Light Armored Arm Gear,306,100,14,0,3,1
-24253,3,0,1,2,Spirit's Light Armored Arm Gear,306,100,14,0,4,1
-24254,3,0,1,2,Fire King's Armored Arm Gear,306,100,14,0,0,1
-24255,3,0,1,2,Fire King's Armored Arm Gear,306,100,14,0,1,1
-24256,3,0,1,2,Fire King's Armored Arm Gear,306,100,14,0,2,1
-24257,3,0,1,2,Fire King's Armored Arm Gear,306,100,14,0,3,1
-24258,3,0,1,2,Fire King's Armored Arm Gear,306,100,14,0,4,1
-24259,3,0,1,2,White Wings' Light Armored Arm Gear,306,100,14,0,0,1
-24260,3,0,1,2,White Wings' Light Armored Arm Gear,306,100,14,0,1,1
-24261,3,0,1,2,White Wings' Light Armored Arm Gear,306,100,14,0,2,1
-24262,3,0,1,2,White Wings' Light Armored Arm Gear,306,100,14,0,3,1
-24263,3,0,1,2,White Wings' Light Armored Arm Gear,306,100,14,0,4,1
-24264,3,0,1,2,Golden Light Armor Gloves,306,100,14,0,0,1
-24265,3,0,1,2,Golden Light Armor Gloves,306,100,14,0,1,1
-24266,3,0,1,2,Golden Light Armor Gloves,306,100,14,0,2,1
-24267,3,0,1,2,Golden Light Armor Gloves,306,100,14,0,3,1
-24268,3,0,1,2,Golden Light Armor Gloves,306,100,14,0,4,1
-24269,3,0,1,7,Blackshatter Light Arm,306,100,14,0,0,1
-24270,3,0,1,7,Blackshatter Light Arm,306,100,14,0,1,1
-24271,3,0,1,7,Blackshatter Light Arm,306,100,14,0,2,1
-24272,3,0,1,7,Blackshatter Light Arm,306,100,14,0,3,1
-24273,3,0,1,7,Blackshatter Light Arm,306,100,14,0,4,1
-24349,3,0,1,2,Spirit's Magick Gloves,306,100,15,0,0,1
-24350,3,0,1,2,Spirit's Magick Gloves,306,100,15,0,1,1
-24351,3,0,1,2,Spirit's Magick Gloves,306,100,15,0,2,1
-24352,3,0,1,2,Spirit's Magick Gloves,306,100,15,0,3,1
-24353,3,0,1,2,Spirit's Magick Gloves,306,100,15,0,4,1
-24354,3,0,1,2,Fire King's Magick Gloves,306,100,15,0,0,1
-24355,3,0,1,2,Fire King's Magick Gloves,306,100,15,0,1,1
-24356,3,0,1,2,Fire King's Magick Gloves,306,100,15,0,2,1
-24357,3,0,1,2,Fire King's Magick Gloves,306,100,15,0,3,1
-24358,3,0,1,2,Fire King's Magick Gloves,306,100,15,0,4,1
-24359,3,0,1,2,White Wing's Magick Gloves,306,100,15,0,0,1
-24360,3,0,1,2,White Wing's Magick Gloves,306,100,15,0,1,1
-24361,3,0,1,2,White Wing's Magick Gloves,306,100,15,0,2,1
-24362,3,0,1,2,White Wing's Magick Gloves,306,100,15,0,3,1
-24363,3,0,1,2,White Wing's Magick Gloves,306,100,15,0,4,1
-24364,3,0,1,2,Golden Magick Gloves,306,100,15,0,0,1
-24365,3,0,1,2,Golden Magick Gloves,306,100,15,0,1,1
-24366,3,0,1,2,Golden Magick Gloves,306,100,15,0,2,1
-24367,3,0,1,2,Golden Magick Gloves,306,100,15,0,3,1
-24368,3,0,1,2,Golden Magick Gloves,306,100,15,0,4,1
-24369,3,0,1,7,Blackshatter Magic Arm,306,100,15,0,0,1
-24370,3,0,1,7,Blackshatter Magic Arm,306,100,15,0,1,1
-24371,3,0,1,7,Blackshatter Magic Arm,306,100,15,0,2,1
-24372,3,0,1,7,Blackshatter Magic Arm,306,100,15,0,3,1
-24373,3,0,1,7,Blackshatter Magic Arm,306,100,15,0,4,1
-24449,3,0,1,2,Spirit's Magick Combat Arms,306,100,17,0,0,1
-24450,3,0,1,2,Spirit's Magick Combat Arms,306,100,17,0,1,1
-24451,3,0,1,2,Spirit's Magick Combat Arms,306,100,17,0,2,1
-24452,3,0,1,2,Spirit's Magick Combat Arms,306,100,17,0,3,1
-24453,3,0,1,2,Spirit's Magick Combat Arms,306,100,17,0,4,1
-24454,3,0,1,2,Fire King's Magick Combat Arms,306,100,17,0,0,1
-24455,3,0,1,2,Fire King's Magick Combat Arms,306,100,17,0,1,1
-24456,3,0,1,2,Fire King's Magick Combat Arms,306,100,17,0,2,1
-24457,3,0,1,2,Fire King's Magick Combat Arms,306,100,17,0,3,1
-24458,3,0,1,2,Fire King's Magick Combat Arms,306,100,17,0,4,1
-24459,3,0,1,2,White Wings' Combat Arms,306,100,17,0,0,1
-24460,3,0,1,2,White Wings' Combat Arms,306,100,17,0,1,1
-24461,3,0,1,2,White Wings' Combat Arms,306,100,17,0,2,1
-24462,3,0,1,2,White Wings' Combat Arms,306,100,17,0,3,1
-24463,3,0,1,2,White Wings' Combat Arms,306,100,17,0,4,1
-24464,3,0,1,2,Golden Magick Battle Arm,306,100,17,0,0,1
-24465,3,0,1,2,Golden Magick Battle Arm,306,100,17,0,1,1
-24466,3,0,1,2,Golden Magick Battle Arm,306,100,17,0,2,1
-24467,3,0,1,2,Golden Magick Battle Arm,306,100,17,0,3,1
-24468,3,0,1,2,Golden Magick Battle Arm,306,100,17,0,4,1
-24469,3,0,1,7,Blackshatter Magic Arm,306,100,17,0,0,1
-24470,3,0,1,7,Blackshatter Magic Arm,306,100,17,0,1,1
-24471,3,0,1,7,Blackshatter Magic Arm,306,100,17,0,2,1
-24472,3,0,1,7,Blackshatter Magic Arm,306,100,17,0,3,1
-24473,3,0,1,7,Blackshatter Magic Arm,306,100,17,0,4,1
+21698,3,10000,1,75,Winter Gloves (White),306,1,0,0,4,1
+21699,3,10000,1,75,Winter Gloves (Black),306,1,0,0,4,1
+21700,3,10000,1,75,Winter Gloves (Brown),306,1,0,0,4,1
+24149,3,0,1,130,Spirit's Heavy Armored Arm Gear,306,100,12,0,0,1
+24150,3,0,1,130,Spirit's Heavy Armored Arm Gear,306,100,12,0,1,1
+24151,3,0,1,130,Spirit's Heavy Armored Arm Gear,306,100,12,0,2,1
+24152,3,0,1,130,Spirit's Heavy Armored Arm Gear,306,100,12,0,3,1
+24153,3,0,1,130,Spirit's Heavy Armored Arm Gear,306,100,12,0,4,1
+24154,3,0,1,130,Fire King's Heavy Armored Arm Gear,306,100,12,0,0,1
+24155,3,0,1,130,Fire King's Heavy Armored Arm Gear,306,100,12,0,1,1
+24156,3,0,1,130,Fire King's Heavy Armored Arm Gear,306,100,12,0,2,1
+24157,3,0,1,130,Fire King's Heavy Armored Arm Gear,306,100,12,0,3,1
+24158,3,0,1,130,Fire King's Heavy Armored Arm Gear,306,100,12,0,4,1
+24159,3,0,1,130,White Wings' Heavy Armored Arm Gear,306,100,12,0,0,1
+24160,3,0,1,130,White Wings' Heavy Armored Arm Gear,306,100,12,0,1,1
+24161,3,0,1,130,White Wings' Heavy Armored Arm Gear,306,100,12,0,2,1
+24162,3,0,1,130,White Wings' Heavy Armored Arm Gear,306,100,12,0,3,1
+24163,3,0,1,130,White Wings' Heavy Armored Arm Gear,306,100,12,0,4,1
+24164,3,0,1,130,Golden Heavy Arms,306,100,12,0,0,1
+24165,3,0,1,130,Golden Heavy Arms,306,100,12,0,1,1
+24166,3,0,1,130,Golden Heavy Arms,306,100,12,0,2,1
+24167,3,0,1,130,Golden Heavy Arms,306,100,12,0,3,1
+24168,3,0,1,130,Golden Heavy Arms,306,100,12,0,4,1
+24169,3,0,1,135,Blackshatter Heavy Gauntlet,306,100,12,0,0,1
+24170,3,0,1,135,Blackshatter Heavy Gauntlet,306,100,12,0,1,1
+24171,3,0,1,135,Blackshatter Heavy Gauntlet,306,100,12,0,2,1
+24172,3,0,1,135,Blackshatter Heavy Gauntlet,306,100,12,0,3,1
+24173,3,0,1,135,Blackshatter Heavy Gauntlet,306,100,12,0,4,1
+24249,3,0,1,130,Spirit's Light Armored Arm Gear,306,100,14,0,0,1
+24250,3,0,1,130,Spirit's Light Armored Arm Gear,306,100,14,0,1,1
+24251,3,0,1,130,Spirit's Light Armored Arm Gear,306,100,14,0,2,1
+24252,3,0,1,130,Spirit's Light Armored Arm Gear,306,100,14,0,3,1
+24253,3,0,1,130,Spirit's Light Armored Arm Gear,306,100,14,0,4,1
+24254,3,0,1,130,Fire King's Armored Arm Gear,306,100,14,0,0,1
+24255,3,0,1,130,Fire King's Armored Arm Gear,306,100,14,0,1,1
+24256,3,0,1,130,Fire King's Armored Arm Gear,306,100,14,0,2,1
+24257,3,0,1,130,Fire King's Armored Arm Gear,306,100,14,0,3,1
+24258,3,0,1,130,Fire King's Armored Arm Gear,306,100,14,0,4,1
+24259,3,0,1,130,White Wings' Light Armored Arm Gear,306,100,14,0,0,1
+24260,3,0,1,130,White Wings' Light Armored Arm Gear,306,100,14,0,1,1
+24261,3,0,1,130,White Wings' Light Armored Arm Gear,306,100,14,0,2,1
+24262,3,0,1,130,White Wings' Light Armored Arm Gear,306,100,14,0,3,1
+24263,3,0,1,130,White Wings' Light Armored Arm Gear,306,100,14,0,4,1
+24264,3,0,1,130,Golden Light Armor Gloves,306,100,14,0,0,1
+24265,3,0,1,130,Golden Light Armor Gloves,306,100,14,0,1,1
+24266,3,0,1,130,Golden Light Armor Gloves,306,100,14,0,2,1
+24267,3,0,1,130,Golden Light Armor Gloves,306,100,14,0,3,1
+24268,3,0,1,130,Golden Light Armor Gloves,306,100,14,0,4,1
+24269,3,0,1,135,Blackshatter Light Arm,306,100,14,0,0,1
+24270,3,0,1,135,Blackshatter Light Arm,306,100,14,0,1,1
+24271,3,0,1,135,Blackshatter Light Arm,306,100,14,0,2,1
+24272,3,0,1,135,Blackshatter Light Arm,306,100,14,0,3,1
+24273,3,0,1,135,Blackshatter Light Arm,306,100,14,0,4,1
+24349,3,0,1,130,Spirit's Magick Gloves,306,100,15,0,0,1
+24350,3,0,1,130,Spirit's Magick Gloves,306,100,15,0,1,1
+24351,3,0,1,130,Spirit's Magick Gloves,306,100,15,0,2,1
+24352,3,0,1,130,Spirit's Magick Gloves,306,100,15,0,3,1
+24353,3,0,1,130,Spirit's Magick Gloves,306,100,15,0,4,1
+24354,3,0,1,130,Fire King's Magick Gloves,306,100,15,0,0,1
+24355,3,0,1,130,Fire King's Magick Gloves,306,100,15,0,1,1
+24356,3,0,1,130,Fire King's Magick Gloves,306,100,15,0,2,1
+24357,3,0,1,130,Fire King's Magick Gloves,306,100,15,0,3,1
+24358,3,0,1,130,Fire King's Magick Gloves,306,100,15,0,4,1
+24359,3,0,1,130,White Wing's Magick Gloves,306,100,15,0,0,1
+24360,3,0,1,130,White Wing's Magick Gloves,306,100,15,0,1,1
+24361,3,0,1,130,White Wing's Magick Gloves,306,100,15,0,2,1
+24362,3,0,1,130,White Wing's Magick Gloves,306,100,15,0,3,1
+24363,3,0,1,130,White Wing's Magick Gloves,306,100,15,0,4,1
+24364,3,0,1,130,Golden Magick Gloves,306,100,15,0,0,1
+24365,3,0,1,130,Golden Magick Gloves,306,100,15,0,1,1
+24366,3,0,1,130,Golden Magick Gloves,306,100,15,0,2,1
+24367,3,0,1,130,Golden Magick Gloves,306,100,15,0,3,1
+24368,3,0,1,130,Golden Magick Gloves,306,100,15,0,4,1
+24369,3,0,1,135,Blackshatter Magic Arm,306,100,15,0,0,1
+24370,3,0,1,135,Blackshatter Magic Arm,306,100,15,0,1,1
+24371,3,0,1,135,Blackshatter Magic Arm,306,100,15,0,2,1
+24372,3,0,1,135,Blackshatter Magic Arm,306,100,15,0,3,1
+24373,3,0,1,135,Blackshatter Magic Arm,306,100,15,0,4,1
+24449,3,0,1,130,Spirit's Magick Combat Arms,306,100,17,0,0,1
+24450,3,0,1,130,Spirit's Magick Combat Arms,306,100,17,0,1,1
+24451,3,0,1,130,Spirit's Magick Combat Arms,306,100,17,0,2,1
+24452,3,0,1,130,Spirit's Magick Combat Arms,306,100,17,0,3,1
+24453,3,0,1,130,Spirit's Magick Combat Arms,306,100,17,0,4,1
+24454,3,0,1,130,Fire King's Magick Combat Arms,306,100,17,0,0,1
+24455,3,0,1,130,Fire King's Magick Combat Arms,306,100,17,0,1,1
+24456,3,0,1,130,Fire King's Magick Combat Arms,306,100,17,0,2,1
+24457,3,0,1,130,Fire King's Magick Combat Arms,306,100,17,0,3,1
+24458,3,0,1,130,Fire King's Magick Combat Arms,306,100,17,0,4,1
+24459,3,0,1,130,White Wings' Combat Arms,306,100,17,0,0,1
+24460,3,0,1,130,White Wings' Combat Arms,306,100,17,0,1,1
+24461,3,0,1,130,White Wings' Combat Arms,306,100,17,0,2,1
+24462,3,0,1,130,White Wings' Combat Arms,306,100,17,0,3,1
+24463,3,0,1,130,White Wings' Combat Arms,306,100,17,0,4,1
+24464,3,0,1,130,Golden Magick Battle Arm,306,100,17,0,0,1
+24465,3,0,1,130,Golden Magick Battle Arm,306,100,17,0,1,1
+24466,3,0,1,130,Golden Magick Battle Arm,306,100,17,0,2,1
+24467,3,0,1,130,Golden Magick Battle Arm,306,100,17,0,3,1
+24468,3,0,1,130,Golden Magick Battle Arm,306,100,17,0,4,1
+24469,3,0,1,135,Blackshatter Magic Arm,306,100,17,0,0,1
+24470,3,0,1,135,Blackshatter Magic Arm,306,100,17,0,1,1
+24471,3,0,1,135,Blackshatter Magic Arm,306,100,17,0,2,1
+24472,3,0,1,135,Blackshatter Magic Arm,306,100,17,0,3,1
+24473,3,0,1,135,Blackshatter Magic Arm,306,100,17,0,4,1
 24616,3,0,1,12,Valkyrian Arms,306,1,0,0,4,1
 24925,3,10000,1,1,Winter Gloves (Deep Red),306,1,0,0,0,1
 24936,3,10000,1,1,God of War's Hammer,306,1,0,0,4,1
@@ -17015,66 +17015,66 @@
 25226,3,10000,1,1,Holy Seal's Generous Hands,306,1,0,0,4,1
 25230,3,10000,1,1,Tricksters' Generous Arms,306,1,0,0,4,1
 25234,3,10000,1,1,Hero's Generous Arms,306,1,0,0,4,1
-25246,3,14400,1,12,Savage Courage Assault Cutter,306,105,12,0,0,1
-25247,3,14400,1,12,Savage Courage Assault Cutter,306,105,12,0,1,1
-25248,3,14400,1,12,Savage Courage Assault Cutter,306,105,12,0,2,1
-25249,3,14400,1,12,Savage Courage Assault Cutter,306,105,12,0,3,1
-25250,3,14400,1,12,Savage Courage Assault Cutter,306,105,12,0,4,1
-25266,3,14400,1,1,Solitary Assault Gauntlets,306,110,12,0,0,1
-25267,3,14400,1,1,Solitary Assault Gauntlets,306,110,12,0,1,1
-25268,3,14400,1,1,Solitary Assault Gauntlets,306,110,12,0,2,1
-25269,3,14400,1,1,Solitary Assault Gauntlets,306,110,12,0,3,1
-25270,3,14400,1,1,Solitary Assault Gauntlets,306,110,12,0,4,1
-25286,3,14400,1,6,Hero's Assault Gauntlets,306,115,12,0,0,1
-25287,3,14400,1,6,Hero's Assault Gauntlets,306,115,12,0,1,1
-25288,3,14400,1,6,Hero's Assault Gauntlets,306,115,12,0,2,1
-25289,3,14400,1,6,Hero's Assault Gauntlets,306,115,12,0,3,1
-25290,3,14400,1,6,Hero's Assault Gauntlets,306,115,12,0,4,1
-25306,3,14400,1,12,Savage Courage Snipe Arm,306,105,14,0,0,1
-25307,3,14400,1,12,Savage Courage Snipe Arm,306,105,14,0,1,1
-25308,3,14400,1,12,Savage Courage Snipe Arm,306,105,14,0,2,1
-25309,3,14400,1,12,Savage Courage Snipe Arm,306,105,14,0,3,1
-25310,3,14400,1,12,Savage Courage Snipe Arm,306,105,14,0,4,1
-25326,3,14400,1,1,Solitary's Snipe Gloves,306,110,14,0,0,1
-25327,3,14400,1,1,Solitary's Snipe Gloves,306,110,14,0,1,1
-25328,3,14400,1,1,Solitary's Snipe Gloves,306,110,14,0,2,1
-25329,3,14400,1,1,Solitary's Snipe Gloves,306,110,14,0,3,1
-25330,3,14400,1,1,Solitary's Snipe Gloves,306,110,14,0,4,1
-25346,3,14400,1,6,Hero's Snipe Gloves,306,115,14,0,0,1
-25347,3,14400,1,6,Hero's Snipe Gloves,306,115,14,0,1,1
-25348,3,14400,1,6,Hero's Snipe Gloves,306,115,14,0,2,1
-25349,3,14400,1,6,Hero's Snipe Gloves,306,115,14,0,3,1
-25350,3,14400,1,6,Hero's Snipe Gloves,306,115,14,0,4,1
-25366,3,14400,1,12,Savage Courage Magic Glove,306,105,15,0,0,1
-25367,3,14400,1,12,Savage Courage Magic Glove,306,105,15,0,1,1
-25368,3,14400,1,12,Savage Courage Magic Glove,306,105,15,0,2,1
-25369,3,14400,1,12,Savage Courage Magic Glove,306,105,15,0,3,1
-25370,3,14400,1,12,Savage Courage Magic Glove,306,105,15,0,4,1
-25386,3,14400,1,1,Solitary Magic Bracer,306,110,15,0,0,1
-25387,3,14400,1,1,Solitary Magic Bracer,306,110,15,0,1,1
-25388,3,14400,1,1,Solitary Magic Bracer,306,110,15,0,2,1
-25389,3,14400,1,1,Solitary Magic Bracer,306,110,15,0,3,1
-25390,3,14400,1,1,Solitary Magic Bracer,306,110,15,0,4,1
-25406,3,14400,1,6,Hero's Magic Claw,306,115,15,0,0,1
-25407,3,14400,1,6,Hero's Magic Claw,306,115,15,0,1,1
-25408,3,14400,1,6,Hero's Magic Claw,306,115,15,0,2,1
-25409,3,14400,1,6,Hero's Magic Claw,306,115,15,0,3,1
-25410,3,14400,1,6,Hero's Magic Claw,306,115,15,0,4,1
-25426,3,14400,1,12,Savage Courage Ranger Arm,306,105,17,0,0,1
-25427,3,14400,1,12,Savage Courage Ranger Arm,306,105,17,0,1,1
-25428,3,14400,1,12,Savage Courage Ranger Arm,306,105,17,0,2,1
-25429,3,14400,1,12,Savage Courage Ranger Arm,306,105,17,0,3,1
-25430,3,14400,1,12,Savage Courage Ranger Arm,306,105,17,0,4,1
-25446,3,14400,1,1,Solitary Ranger's Arms,306,110,17,0,0,1
-25447,3,14400,1,1,Solitary Ranger's Arms,306,110,17,0,1,1
-25448,3,14400,1,1,Solitary Ranger's Arms,306,110,17,0,2,1
-25449,3,14400,1,1,Solitary Ranger's Arms,306,110,17,0,3,1
-25450,3,14400,1,1,Solitary Ranger's Arms,306,110,17,0,4,1
-25466,3,14400,1,6,Hero's Ranger Bangle,306,115,17,0,0,1
-25467,3,14400,1,6,Hero's Ranger Bangle,306,115,17,0,1,1
-25468,3,14400,1,6,Hero's Ranger Bangle,306,115,17,0,2,1
-25469,3,14400,1,6,Hero's Ranger Bangle,306,115,17,0,3,1
-25470,3,14400,1,6,Hero's Ranger Bangle,306,115,17,0,4,1
+25246,3,14400,1,140,Savage Courage Assault Cutter,306,105,12,0,0,1
+25247,3,14400,1,140,Savage Courage Assault Cutter,306,105,12,0,1,1
+25248,3,14400,1,140,Savage Courage Assault Cutter,306,105,12,0,2,1
+25249,3,14400,1,140,Savage Courage Assault Cutter,306,105,12,0,3,1
+25250,3,14400,1,140,Savage Courage Assault Cutter,306,105,12,0,4,1
+25266,3,14400,1,145,Solitary Assault Gauntlets,306,110,12,0,0,1
+25267,3,14400,1,145,Solitary Assault Gauntlets,306,110,12,0,1,1
+25268,3,14400,1,145,Solitary Assault Gauntlets,306,110,12,0,2,1
+25269,3,14400,1,145,Solitary Assault Gauntlets,306,110,12,0,3,1
+25270,3,14400,1,145,Solitary Assault Gauntlets,306,110,12,0,4,1
+25286,3,14400,1,150,Hero's Assault Gauntlets,306,115,12,0,0,1
+25287,3,14400,1,150,Hero's Assault Gauntlets,306,115,12,0,1,1
+25288,3,14400,1,150,Hero's Assault Gauntlets,306,115,12,0,2,1
+25289,3,14400,1,150,Hero's Assault Gauntlets,306,115,12,0,3,1
+25290,3,14400,1,150,Hero's Assault Gauntlets,306,115,12,0,4,1
+25306,3,14400,1,140,Savage Courage Snipe Arm,306,105,14,0,0,1
+25307,3,14400,1,140,Savage Courage Snipe Arm,306,105,14,0,1,1
+25308,3,14400,1,140,Savage Courage Snipe Arm,306,105,14,0,2,1
+25309,3,14400,1,140,Savage Courage Snipe Arm,306,105,14,0,3,1
+25310,3,14400,1,140,Savage Courage Snipe Arm,306,105,14,0,4,1
+25326,3,14400,1,145,Solitary's Snipe Gloves,306,110,14,0,0,1
+25327,3,14400,1,145,Solitary's Snipe Gloves,306,110,14,0,1,1
+25328,3,14400,1,145,Solitary's Snipe Gloves,306,110,14,0,2,1
+25329,3,14400,1,145,Solitary's Snipe Gloves,306,110,14,0,3,1
+25330,3,14400,1,145,Solitary's Snipe Gloves,306,110,14,0,4,1
+25346,3,14400,1,150,Hero's Snipe Gloves,306,115,14,0,0,1
+25347,3,14400,1,150,Hero's Snipe Gloves,306,115,14,0,1,1
+25348,3,14400,1,150,Hero's Snipe Gloves,306,115,14,0,2,1
+25349,3,14400,1,150,Hero's Snipe Gloves,306,115,14,0,3,1
+25350,3,14400,1,150,Hero's Snipe Gloves,306,115,14,0,4,1
+25366,3,14400,1,140,Savage Courage Magic Glove,306,105,15,0,0,1
+25367,3,14400,1,140,Savage Courage Magic Glove,306,105,15,0,1,1
+25368,3,14400,1,140,Savage Courage Magic Glove,306,105,15,0,2,1
+25369,3,14400,1,140,Savage Courage Magic Glove,306,105,15,0,3,1
+25370,3,14400,1,140,Savage Courage Magic Glove,306,105,15,0,4,1
+25386,3,14400,1,145,Solitary Magic Bracer,306,110,15,0,0,1
+25387,3,14400,1,145,Solitary Magic Bracer,306,110,15,0,1,1
+25388,3,14400,1,145,Solitary Magic Bracer,306,110,15,0,2,1
+25389,3,14400,1,145,Solitary Magic Bracer,306,110,15,0,3,1
+25390,3,14400,1,145,Solitary Magic Bracer,306,110,15,0,4,1
+25406,3,14400,1,150,Hero's Magic Claw,306,115,15,0,0,1
+25407,3,14400,1,150,Hero's Magic Claw,306,115,15,0,1,1
+25408,3,14400,1,150,Hero's Magic Claw,306,115,15,0,2,1
+25409,3,14400,1,150,Hero's Magic Claw,306,115,15,0,3,1
+25410,3,14400,1,150,Hero's Magic Claw,306,115,15,0,4,1
+25426,3,14400,1,140,Savage Courage Ranger Arm,306,105,17,0,0,1
+25427,3,14400,1,140,Savage Courage Ranger Arm,306,105,17,0,1,1
+25428,3,14400,1,140,Savage Courage Ranger Arm,306,105,17,0,2,1
+25429,3,14400,1,140,Savage Courage Ranger Arm,306,105,17,0,3,1
+25430,3,14400,1,140,Savage Courage Ranger Arm,306,105,17,0,4,1
+25446,3,14400,1,145,Solitary Ranger's Arms,306,110,17,0,0,1
+25447,3,14400,1,145,Solitary Ranger's Arms,306,110,17,0,1,1
+25448,3,14400,1,145,Solitary Ranger's Arms,306,110,17,0,2,1
+25449,3,14400,1,145,Solitary Ranger's Arms,306,110,17,0,3,1
+25450,3,14400,1,145,Solitary Ranger's Arms,306,110,17,0,4,1
+25466,3,14400,1,150,Hero's Ranger Bangle,306,115,17,0,0,1
+25467,3,14400,1,150,Hero's Ranger Bangle,306,115,17,0,1,1
+25468,3,14400,1,150,Hero's Ranger Bangle,306,115,17,0,2,1
+25469,3,14400,1,150,Hero's Ranger Bangle,306,115,17,0,3,1
+25470,3,14400,1,150,Hero's Ranger Bangle,306,115,17,0,4,1
 25532,3,10000,1,1,Holy Seal's Trust Gloves,306,1,0,0,4,1
 25536,3,10000,1,1,Holy Seal's Bliss Glove,306,1,0,0,4,1
 25540,3,10000,1,1,Holy Seal's Grandiose Arms,306,1,0,0,4,1
@@ -17249,11 +17249,11 @@
 3220,3,3700,1,9,Sunset Cuisses,307,45,12,0,2,1
 4243,3,3700,1,9,Sunset Cuisses,307,45,12,0,3,1
 5266,3,3700,1,9,Sunset Cuisses,307,45,12,0,4,1
-586,3,9189,1,3,Faith Sabatons,307,70,12,0,0,1
-2198,3,9189,1,3,Faith Sabatons,307,70,12,0,1,1
-3221,3,9189,1,3,Faith Sabatons,307,70,12,0,2,1
-4244,3,9189,1,3,Faith Sabatons,307,70,12,0,3,1
-5267,3,9189,1,3,Faith Sabatons,307,70,12,0,4,1
+586,3,9189,1,35,Faith Sabatons,307,70,12,0,0,1
+2198,3,9189,1,35,Faith Sabatons,307,70,12,0,1,1
+3221,3,9189,1,35,Faith Sabatons,307,70,12,0,2,1
+4244,3,9189,1,35,Faith Sabatons,307,70,12,0,3,1
+5267,3,9189,1,35,Faith Sabatons,307,70,12,0,4,1
 587,3,4420,1,10,Silver Sabatons,307,49,12,0,0,1
 2199,3,4420,1,10,Silver Sabatons,307,49,12,0,1,1
 3222,3,4420,1,10,Silver Sabatons,307,49,12,0,2,1
@@ -17379,11 +17379,11 @@
 3327,3,3700,1,9,Leader Leg Guards,307,45,14,0,2,1
 4350,3,3700,1,9,Leader Leg Guards,307,45,14,0,3,1
 5373,3,3700,1,9,Leader Leg Guards,307,45,14,0,4,1
-693,3,9189,1,3,Faith Cuisses,307,70,14,0,0,1
-2305,3,9189,1,3,Faith Cuisses,307,70,14,0,1,1
-3328,3,9189,1,3,Faith Cuisses,307,70,14,0,2,1
-4351,3,9189,1,3,Faith Cuisses,307,70,14,0,3,1
-5374,3,9189,1,3,Faith Cuisses,307,70,14,0,4,1
+693,3,9189,1,35,Faith Cuisses,307,70,14,0,0,1
+2305,3,9189,1,35,Faith Cuisses,307,70,14,0,1,1
+3328,3,9189,1,35,Faith Cuisses,307,70,14,0,2,1
+4351,3,9189,1,35,Faith Cuisses,307,70,14,0,3,1
+5374,3,9189,1,35,Faith Cuisses,307,70,14,0,4,1
 694,3,4230,1,10,Fur Cuisses,307,46,14,0,0,1
 2306,3,4230,1,10,Fur Cuisses,307,46,14,0,1,1
 3329,3,4230,1,10,Fur Cuisses,307,46,14,0,2,1
@@ -17429,11 +17429,11 @@
 3337,3,7200,1,12,Rubedo Cuisses,307,60,3,0,2,1
 4360,3,7200,1,12,Rubedo Cuisses,307,60,3,0,3,1
 5383,3,7200,1,12,Rubedo Cuisses,307,60,3,0,4,1
-703,3,7923,1,4,Liberation Greaves,307,65,14,0,0,1
-2315,3,7923,1,4,Liberation Greaves,307,65,14,0,1,1
-3338,3,7923,1,4,Liberation Greaves,307,65,14,0,2,1
-4361,3,7923,1,4,Liberation Greaves,307,65,14,0,3,1
-5384,3,7923,1,4,Liberation Greaves,307,65,14,0,4,1
+703,3,7923,1,20,Liberation Greaves,307,65,14,0,0,1
+2315,3,7923,1,20,Liberation Greaves,307,65,14,0,1,1
+3338,3,7923,1,20,Liberation Greaves,307,65,14,0,2,1
+4361,3,7923,1,20,Liberation Greaves,307,65,14,0,3,1
+5384,3,7923,1,20,Liberation Greaves,307,65,14,0,4,1
 704,3,6270,1,12,Land Kankar,307,58,14,0,0,1
 2316,3,6270,1,12,Land Kankar,307,58,14,0,1,1
 3339,3,6270,1,12,Land Kankar,307,58,14,0,2,1
@@ -17509,11 +17509,11 @@
 3432,3,3700,1,9,Demon's Greaves,307,45,15,0,2,1
 4455,3,3700,1,9,Demon's Greaves,307,45,15,0,3,1
 5478,3,3700,1,9,Demon's Greaves,307,45,15,0,4,1
-798,3,9189,1,3,Faith Greaves,307,70,15,0,0,1
-2410,3,9189,1,3,Faith Greaves,307,70,15,0,1,1
-3433,3,9189,1,3,Faith Greaves,307,70,15,0,2,1
-4456,3,9189,1,3,Faith Greaves,307,70,15,0,3,1
-5479,3,9189,1,3,Faith Greaves,307,70,15,0,4,1
+798,3,9189,1,35,Faith Greaves,307,70,15,0,0,1
+2410,3,9189,1,35,Faith Greaves,307,70,15,0,1,1
+3433,3,9189,1,35,Faith Greaves,307,70,15,0,2,1
+4456,3,9189,1,35,Faith Greaves,307,70,15,0,3,1
+5479,3,9189,1,35,Faith Greaves,307,70,15,0,4,1
 799,3,4420,1,11,Pleats of Revival,307,52,15,0,0,1
 2411,3,4420,1,11,Pleats of Revival,307,52,15,0,1,1
 3434,3,4420,1,11,Pleats of Revival,307,52,15,0,2,1
@@ -17649,11 +17649,11 @@
 3539,3,3700,1,9,Bounty Boots,307,45,17,0,2,1
 4562,3,3700,1,9,Bounty Boots,307,45,17,0,3,1
 5585,3,3700,1,9,Bounty Boots,307,45,17,0,4,1
-905,3,9189,1,3,Genius Legs,307,70,17,0,0,1
-2517,3,9189,1,3,Genius Legs,307,70,17,0,1,1
-3540,3,9189,1,3,Genius Legs,307,70,17,0,2,1
-4563,3,9189,1,3,Genius Legs,307,70,17,0,3,1
-5586,3,9189,1,3,Genius Legs,307,70,17,0,4,1
+905,3,9189,1,35,Genius Legs,307,70,17,0,0,1
+2517,3,9189,1,35,Genius Legs,307,70,17,0,1,1
+3540,3,9189,1,35,Genius Legs,307,70,17,0,2,1
+4563,3,9189,1,35,Genius Legs,307,70,17,0,3,1
+5586,3,9189,1,35,Genius Legs,307,70,17,0,4,1
 906,3,4420,1,12,Maverick Boots,307,56,17,0,0,1
 2518,3,4420,1,12,Maverick Boots,307,56,17,0,1,1
 3541,3,4420,1,12,Maverick Boots,307,56,17,0,2,1
@@ -17699,11 +17699,11 @@
 3549,3,6270,1,12,Greaves of Sacred Protection,307,58,17,0,2,1
 4572,3,6270,1,12,Greaves of Sacred Protection,307,58,17,0,3,1
 5595,3,6270,1,12,Greaves of Sacred Protection,307,58,17,0,4,1
-915,3,7923,1,4,Heavenly Legs,307,65,17,0,0,1
-2527,3,7923,1,4,Heavenly Legs,307,65,17,0,1,1
-3550,3,7923,1,4,Heavenly Legs,307,65,17,0,2,1
-4573,3,7923,1,4,Heavenly Legs,307,65,17,0,3,1
-5596,3,7923,1,4,Heavenly Legs,307,65,17,0,4,1
+915,3,7923,1,20,Heavenly Legs,307,65,17,0,0,1
+2527,3,7923,1,20,Heavenly Legs,307,65,17,0,1,1
+3550,3,7923,1,20,Heavenly Legs,307,65,17,0,2,1
+4573,3,7923,1,20,Heavenly Legs,307,65,17,0,3,1
+5596,3,7923,1,20,Heavenly Legs,307,65,17,0,4,1
 961,3,250,1,4,Lively Bottoms,307,16,0,0,0,1
 2573,3,250,1,4,Lively Bottoms,307,16,0,0,1,1
 3596,3,250,1,4,Lively Bottoms,307,16,0,0,2,1
@@ -17923,8 +17923,8 @@
 10463,3,4000,1,12,Enforcer's Boots (Crimson),307,1,0,3,2,1
 10464,3,4000,1,12,Enforcer's Boots (Crimson),307,1,0,3,3,1
 10465,3,4000,1,12,Enforcer's Boots (Crimson),307,1,0,3,4,1
-10470,3,5000,1,9,Enforcer's Boots (Moonflower),307,55,0,3,4,1
-10475,3,5000,1,8,Enforcer's Boots (Dark Night),307,60,0,3,4,1
+10470,3,5000,1,25,Enforcer's Boots (Moonflower),307,55,0,3,4,1
+10475,3,5000,1,40,Enforcer's Boots (Dark Night),307,60,0,3,4,1
 10963,3,5000,1,12,Rathalos Greaves,307,30,13,3,0,1
 10964,3,5000,1,12,Rathalos Greaves,307,30,13,3,1,1
 10965,3,5000,1,12,Rathalos Greaves,307,30,13,3,2,1
@@ -17935,571 +17935,571 @@
 10970,3,5000,1,12,Rathian Greaves,307,30,16,3,2,1
 10971,3,5000,1,12,Rathian Greaves,307,30,16,3,3,1
 10972,3,5000,1,12,Rathian Greaves,307,30,16,3,4,1
-10973,3,5000,1,7,Silver Sol Greaves,307,55,13,3,0,1
-10974,3,5000,1,7,Silver Sol Greaves,307,55,13,3,1,1
-10975,3,5000,1,7,Silver Sol Greaves,307,55,13,3,2,1
-10976,3,5000,1,7,Silver Sol Greaves,307,55,13,3,3,1
-10977,3,5000,1,7,Silver Sol Greaves,307,55,13,3,4,1
-10978,3,5000,1,7,Gold Luna Greaves,307,55,16,3,0,1
-10979,3,5000,1,7,Gold Luna Greaves,307,55,16,3,1,1
-10980,3,5000,1,7,Gold Luna Greaves,307,55,16,3,2,1
-10981,3,5000,1,7,Gold Luna Greaves,307,55,16,3,3,1
-10982,3,5000,1,7,Gold Luna Greaves,307,55,16,3,4,1
+10973,3,5000,1,55,Silver Sol Greaves,307,55,13,3,0,1
+10974,3,5000,1,55,Silver Sol Greaves,307,55,13,3,1,1
+10975,3,5000,1,55,Silver Sol Greaves,307,55,13,3,2,1
+10976,3,5000,1,55,Silver Sol Greaves,307,55,13,3,3,1
+10977,3,5000,1,55,Silver Sol Greaves,307,55,13,3,4,1
+10978,3,5000,1,55,Gold Luna Greaves,307,55,16,3,0,1
+10979,3,5000,1,55,Gold Luna Greaves,307,55,16,3,1,1
+10980,3,5000,1,55,Gold Luna Greaves,307,55,16,3,2,1
+10981,3,5000,1,55,Gold Luna Greaves,307,55,16,3,3,1
+10982,3,5000,1,55,Gold Luna Greaves,307,55,16,3,4,1
 11753,3,6000,1,1,Invisible Boots,307,1,0,0,0,1
-12913,3,7923,1,4,Damascus Cuisses,307,65,12,0,0,1
-12914,3,7923,1,4,Damascus Cuisses,307,65,12,0,1,1
-12915,3,7923,1,4,Damascus Cuisses,307,65,12,0,2,1
-12916,3,7923,1,4,Damascus Cuisses,307,65,12,0,3,1
-12917,3,7923,1,4,Damascus Cuisses,307,65,12,0,4,1
-12918,3,7923,1,9,Immortal's Sabatons,307,65,12,0,0,1
-12919,3,7923,1,9,Immortal's Sabatons,307,65,12,0,1,1
-12920,3,7923,1,9,Immortal's Sabatons,307,65,12,0,2,1
-12921,3,7923,1,9,Immortal's Sabatons,307,65,12,0,3,1
-12922,3,7923,1,9,Immortal's Sabatons,307,65,12,0,4,1
-12923,3,7923,1,14,Enlightenment Greaves,307,65,12,0,0,1
-12924,3,7923,1,14,Enlightenment Greaves,307,65,12,0,1,1
-12925,3,7923,1,14,Enlightenment Greaves,307,65,12,0,2,1
-12926,3,7923,1,14,Enlightenment Greaves,307,65,12,0,3,1
-12927,3,7923,1,14,Enlightenment Greaves,307,65,12,0,4,1
-12928,3,8418,1,14,Barbarian Boots,307,67,12,0,0,1
-12929,3,8418,1,14,Barbarian Boots,307,67,12,0,1,1
-12930,3,8418,1,14,Barbarian Boots,307,67,12,0,2,1
-12931,3,8418,1,14,Barbarian Boots,307,67,12,0,3,1
-12932,3,8418,1,14,Barbarian Boots,307,67,12,0,4,1
-12933,3,9189,1,8,Alloy Greaves,307,70,12,0,0,1
-12934,3,9189,1,8,Alloy Greaves,307,70,12,0,1,1
-12935,3,9189,1,8,Alloy Greaves,307,70,12,0,2,1
-12936,3,9189,1,8,Alloy Greaves,307,70,12,0,3,1
-12937,3,9189,1,8,Alloy Greaves,307,70,12,0,4,1
-12938,3,9189,1,13,Predator Cuisses,307,70,12,0,0,1
-12939,3,9189,1,13,Predator Cuisses,307,70,12,0,1,1
-12940,3,9189,1,13,Predator Cuisses,307,70,12,0,2,1
-12941,3,9189,1,13,Predator Cuisses,307,70,12,0,3,1
-12942,3,9189,1,13,Predator Cuisses,307,70,12,0,4,1
-12943,3,7923,1,4,Serpent Sandals,307,65,15,0,0,1
-12944,3,7923,1,4,Serpent Sandals,307,65,15,0,1,1
-12945,3,7923,1,4,Serpent Sandals,307,65,15,0,2,1
-12946,3,7923,1,4,Serpent Sandals,307,65,15,0,3,1
-12947,3,7923,1,4,Serpent Sandals,307,65,15,0,4,1
-12948,3,7923,1,9,Anklets of Bravery,307,65,15,0,0,1
-12949,3,7923,1,9,Anklets of Bravery,307,65,15,0,1,1
-12950,3,7923,1,9,Anklets of Bravery,307,65,15,0,2,1
-12951,3,7923,1,9,Anklets of Bravery,307,65,15,0,3,1
-12952,3,7923,1,9,Anklets of Bravery,307,65,15,0,4,1
-12953,3,7923,1,14,Bishop Shoes,307,65,15,0,0,1
-12954,3,7923,1,14,Bishop Shoes,307,65,15,0,1,1
-12955,3,7923,1,14,Bishop Shoes,307,65,15,0,2,1
-12956,3,7923,1,14,Bishop Shoes,307,65,15,0,3,1
-12957,3,7923,1,14,Bishop Shoes,307,65,15,0,4,1
-12958,3,8418,1,14,Morality Shoes,307,67,15,0,0,1
-12959,3,8418,1,14,Morality Shoes,307,67,15,0,1,1
-12960,3,8418,1,14,Morality Shoes,307,67,15,0,2,1
-12961,3,8418,1,14,Morality Shoes,307,67,15,0,3,1
-12962,3,8418,1,14,Morality Shoes,307,67,15,0,4,1
-12963,3,9189,1,8,Libertas Shoes,307,70,15,0,0,1
-12964,3,9189,1,8,Libertas Shoes,307,70,15,0,1,1
-12965,3,9189,1,8,Libertas Shoes,307,70,15,0,2,1
-12966,3,9189,1,8,Libertas Shoes,307,70,15,0,3,1
-12967,3,9189,1,8,Libertas Shoes,307,70,15,0,4,1
-12968,3,9189,1,13,Carrion Greaves,307,70,15,0,0,1
-12969,3,9189,1,13,Carrion Greaves,307,70,15,0,1,1
-12970,3,9189,1,13,Carrion Greaves,307,70,15,0,2,1
-12971,3,9189,1,13,Carrion Greaves,307,70,15,0,3,1
-12972,3,9189,1,13,Carrion Greaves,307,70,15,0,4,1
+12913,3,7923,1,20,Damascus Cuisses,307,65,12,0,0,1
+12914,3,7923,1,20,Damascus Cuisses,307,65,12,0,1,1
+12915,3,7923,1,20,Damascus Cuisses,307,65,12,0,2,1
+12916,3,7923,1,20,Damascus Cuisses,307,65,12,0,3,1
+12917,3,7923,1,20,Damascus Cuisses,307,65,12,0,4,1
+12918,3,7923,1,25,Immortal's Sabatons,307,65,12,0,0,1
+12919,3,7923,1,25,Immortal's Sabatons,307,65,12,0,1,1
+12920,3,7923,1,25,Immortal's Sabatons,307,65,12,0,2,1
+12921,3,7923,1,25,Immortal's Sabatons,307,65,12,0,3,1
+12922,3,7923,1,25,Immortal's Sabatons,307,65,12,0,4,1
+12923,3,7923,1,30,Enlightenment Greaves,307,65,12,0,0,1
+12924,3,7923,1,30,Enlightenment Greaves,307,65,12,0,1,1
+12925,3,7923,1,30,Enlightenment Greaves,307,65,12,0,2,1
+12926,3,7923,1,30,Enlightenment Greaves,307,65,12,0,3,1
+12927,3,7923,1,30,Enlightenment Greaves,307,65,12,0,4,1
+12928,3,8418,1,30,Barbarian Boots,307,67,12,0,0,1
+12929,3,8418,1,30,Barbarian Boots,307,67,12,0,1,1
+12930,3,8418,1,30,Barbarian Boots,307,67,12,0,2,1
+12931,3,8418,1,30,Barbarian Boots,307,67,12,0,3,1
+12932,3,8418,1,30,Barbarian Boots,307,67,12,0,4,1
+12933,3,9189,1,40,Alloy Greaves,307,70,12,0,0,1
+12934,3,9189,1,40,Alloy Greaves,307,70,12,0,1,1
+12935,3,9189,1,40,Alloy Greaves,307,70,12,0,2,1
+12936,3,9189,1,40,Alloy Greaves,307,70,12,0,3,1
+12937,3,9189,1,40,Alloy Greaves,307,70,12,0,4,1
+12938,3,9189,1,45,Predator Cuisses,307,70,12,0,0,1
+12939,3,9189,1,45,Predator Cuisses,307,70,12,0,1,1
+12940,3,9189,1,45,Predator Cuisses,307,70,12,0,2,1
+12941,3,9189,1,45,Predator Cuisses,307,70,12,0,3,1
+12942,3,9189,1,45,Predator Cuisses,307,70,12,0,4,1
+12943,3,7923,1,20,Serpent Sandals,307,65,15,0,0,1
+12944,3,7923,1,20,Serpent Sandals,307,65,15,0,1,1
+12945,3,7923,1,20,Serpent Sandals,307,65,15,0,2,1
+12946,3,7923,1,20,Serpent Sandals,307,65,15,0,3,1
+12947,3,7923,1,20,Serpent Sandals,307,65,15,0,4,1
+12948,3,7923,1,25,Anklets of Bravery,307,65,15,0,0,1
+12949,3,7923,1,25,Anklets of Bravery,307,65,15,0,1,1
+12950,3,7923,1,25,Anklets of Bravery,307,65,15,0,2,1
+12951,3,7923,1,25,Anklets of Bravery,307,65,15,0,3,1
+12952,3,7923,1,25,Anklets of Bravery,307,65,15,0,4,1
+12953,3,7923,1,30,Bishop Shoes,307,65,15,0,0,1
+12954,3,7923,1,30,Bishop Shoes,307,65,15,0,1,1
+12955,3,7923,1,30,Bishop Shoes,307,65,15,0,2,1
+12956,3,7923,1,30,Bishop Shoes,307,65,15,0,3,1
+12957,3,7923,1,30,Bishop Shoes,307,65,15,0,4,1
+12958,3,8418,1,30,Morality Shoes,307,67,15,0,0,1
+12959,3,8418,1,30,Morality Shoes,307,67,15,0,1,1
+12960,3,8418,1,30,Morality Shoes,307,67,15,0,2,1
+12961,3,8418,1,30,Morality Shoes,307,67,15,0,3,1
+12962,3,8418,1,30,Morality Shoes,307,67,15,0,4,1
+12963,3,9189,1,40,Libertas Shoes,307,70,15,0,0,1
+12964,3,9189,1,40,Libertas Shoes,307,70,15,0,1,1
+12965,3,9189,1,40,Libertas Shoes,307,70,15,0,2,1
+12966,3,9189,1,40,Libertas Shoes,307,70,15,0,3,1
+12967,3,9189,1,40,Libertas Shoes,307,70,15,0,4,1
+12968,3,9189,1,45,Carrion Greaves,307,70,15,0,0,1
+12969,3,9189,1,45,Carrion Greaves,307,70,15,0,1,1
+12970,3,9189,1,45,Carrion Greaves,307,70,15,0,2,1
+12971,3,9189,1,45,Carrion Greaves,307,70,15,0,3,1
+12972,3,9189,1,45,Carrion Greaves,307,70,15,0,4,1
 12973,3,7209,1,15,Greaves of Gloom,307,62,17,0,0,1
 12974,3,7209,1,15,Greaves of Gloom,307,62,17,0,1,1
 12975,3,7209,1,15,Greaves of Gloom,307,62,17,0,2,1
 12976,3,7209,1,15,Greaves of Gloom,307,62,17,0,3,1
 12977,3,7209,1,15,Greaves of Gloom,307,62,17,0,4,1
-12978,3,7923,1,9,Over-Knee Boots of Wisemen,307,65,17,0,0,1
-12979,3,7923,1,9,Over-Knee Boots of Wisemen,307,65,17,0,1,1
-12980,3,7923,1,9,Over-Knee Boots of Wisemen,307,65,17,0,2,1
-12981,3,7923,1,9,Over-Knee Boots of Wisemen,307,65,17,0,3,1
-12982,3,7923,1,9,Over-Knee Boots of Wisemen,307,65,17,0,4,1
-12983,3,7923,1,14,Saint's Greaves,307,65,17,0,0,1
-12984,3,7923,1,14,Saint's Greaves,307,65,17,0,1,1
-12985,3,7923,1,14,Saint's Greaves,307,65,17,0,2,1
-12986,3,7923,1,14,Saint's Greaves,307,65,17,0,3,1
-12987,3,7923,1,14,Saint's Greaves,307,65,17,0,4,1
-12988,3,8418,1,14,Roaming Boots,307,67,17,0,0,1
-12989,3,8418,1,14,Roaming Boots,307,67,17,0,1,1
-12990,3,8418,1,14,Roaming Boots,307,67,17,0,2,1
-12991,3,8418,1,14,Roaming Boots,307,67,17,0,3,1
-12992,3,8418,1,14,Roaming Boots,307,67,17,0,4,1
-12993,3,9189,1,8,Greaves of Certainty,307,70,17,0,0,1
-12994,3,9189,1,8,Greaves of Certainty,307,70,17,0,1,1
-12995,3,9189,1,8,Greaves of Certainty,307,70,17,0,2,1
-12996,3,9189,1,8,Greaves of Certainty,307,70,17,0,3,1
-12997,3,9189,1,8,Greaves of Certainty,307,70,17,0,4,1
-12998,3,9189,1,13,Scholarly Cuisses,307,70,17,0,0,1
-12999,3,9189,1,13,Scholarly Cuisses,307,70,17,0,1,1
-13000,3,9189,1,13,Scholarly Cuisses,307,70,17,0,2,1
-13001,3,9189,1,13,Scholarly Cuisses,307,70,17,0,3,1
-13002,3,9189,1,13,Scholarly Cuisses,307,70,17,0,4,1
+12978,3,7923,1,25,Over-Knee Boots of Wisemen,307,65,17,0,0,1
+12979,3,7923,1,25,Over-Knee Boots of Wisemen,307,65,17,0,1,1
+12980,3,7923,1,25,Over-Knee Boots of Wisemen,307,65,17,0,2,1
+12981,3,7923,1,25,Over-Knee Boots of Wisemen,307,65,17,0,3,1
+12982,3,7923,1,25,Over-Knee Boots of Wisemen,307,65,17,0,4,1
+12983,3,7923,1,30,Saint's Greaves,307,65,17,0,0,1
+12984,3,7923,1,30,Saint's Greaves,307,65,17,0,1,1
+12985,3,7923,1,30,Saint's Greaves,307,65,17,0,2,1
+12986,3,7923,1,30,Saint's Greaves,307,65,17,0,3,1
+12987,3,7923,1,30,Saint's Greaves,307,65,17,0,4,1
+12988,3,8418,1,30,Roaming Boots,307,67,17,0,0,1
+12989,3,8418,1,30,Roaming Boots,307,67,17,0,1,1
+12990,3,8418,1,30,Roaming Boots,307,67,17,0,2,1
+12991,3,8418,1,30,Roaming Boots,307,67,17,0,3,1
+12992,3,8418,1,30,Roaming Boots,307,67,17,0,4,1
+12993,3,9189,1,40,Greaves of Certainty,307,70,17,0,0,1
+12994,3,9189,1,40,Greaves of Certainty,307,70,17,0,1,1
+12995,3,9189,1,40,Greaves of Certainty,307,70,17,0,2,1
+12996,3,9189,1,40,Greaves of Certainty,307,70,17,0,3,1
+12997,3,9189,1,40,Greaves of Certainty,307,70,17,0,4,1
+12998,3,9189,1,45,Scholarly Cuisses,307,70,17,0,0,1
+12999,3,9189,1,45,Scholarly Cuisses,307,70,17,0,1,1
+13000,3,9189,1,45,Scholarly Cuisses,307,70,17,0,2,1
+13001,3,9189,1,45,Scholarly Cuisses,307,70,17,0,3,1
+13002,3,9189,1,45,Scholarly Cuisses,307,70,17,0,4,1
 13003,3,7209,1,15,Enhanced Bottoms,307,62,14,0,0,1
 13004,3,7209,1,15,Enhanced Bottoms,307,62,14,0,1,1
 13005,3,7209,1,15,Enhanced Bottoms,307,62,14,0,2,1
 13006,3,7209,1,15,Enhanced Bottoms,307,62,14,0,3,1
 13007,3,7209,1,15,Enhanced Bottoms,307,62,14,0,4,1
-13008,3,7923,1,9,Stealthy Boots,307,65,14,0,0,1
-13009,3,7923,1,9,Stealthy Boots,307,65,14,0,1,1
-13010,3,7923,1,9,Stealthy Boots,307,65,14,0,2,1
-13011,3,7923,1,9,Stealthy Boots,307,65,14,0,3,1
-13012,3,7923,1,9,Stealthy Boots,307,65,14,0,4,1
-13013,3,7923,1,14,Paladin Greaves,307,65,14,0,0,1
-13014,3,7923,1,14,Paladin Greaves,307,65,14,0,1,1
-13015,3,7923,1,14,Paladin Greaves,307,65,14,0,2,1
-13016,3,7923,1,14,Paladin Greaves,307,65,14,0,3,1
-13017,3,7923,1,14,Paladin Greaves,307,65,14,0,4,1
-13018,3,8418,1,14,Sentinel Kilt,307,67,14,0,0,1
-13019,3,8418,1,14,Sentinel Kilt,307,67,14,0,1,1
-13020,3,8418,1,14,Sentinel Kilt,307,67,14,0,2,1
-13021,3,8418,1,14,Sentinel Kilt,307,67,14,0,3,1
-13022,3,8418,1,14,Sentinel Kilt,307,67,14,0,4,1
-13023,3,9189,1,8,Aquila Cuisses,307,70,14,0,0,1
-13024,3,9189,1,8,Aquila Cuisses,307,70,14,0,1,1
-13025,3,9189,1,8,Aquila Cuisses,307,70,14,0,2,1
-13026,3,9189,1,8,Aquila Cuisses,307,70,14,0,3,1
-13027,3,9189,1,8,Aquila Cuisses,307,70,14,0,4,1
-13028,3,9189,1,13,Mail of Concealment,307,70,14,0,0,1
-13029,3,9189,1,13,Mail of Concealment,307,70,14,0,1,1
-13030,3,9189,1,13,Mail of Concealment,307,70,14,0,2,1
-13031,3,9189,1,13,Mail of Concealment,307,70,14,0,3,1
-13032,3,9189,1,13,Mail of Concealment,307,70,14,0,4,1
+13008,3,7923,1,25,Stealthy Boots,307,65,14,0,0,1
+13009,3,7923,1,25,Stealthy Boots,307,65,14,0,1,1
+13010,3,7923,1,25,Stealthy Boots,307,65,14,0,2,1
+13011,3,7923,1,25,Stealthy Boots,307,65,14,0,3,1
+13012,3,7923,1,25,Stealthy Boots,307,65,14,0,4,1
+13013,3,7923,1,30,Paladin Greaves,307,65,14,0,0,1
+13014,3,7923,1,30,Paladin Greaves,307,65,14,0,1,1
+13015,3,7923,1,30,Paladin Greaves,307,65,14,0,2,1
+13016,3,7923,1,30,Paladin Greaves,307,65,14,0,3,1
+13017,3,7923,1,30,Paladin Greaves,307,65,14,0,4,1
+13018,3,8418,1,30,Sentinel Kilt,307,67,14,0,0,1
+13019,3,8418,1,30,Sentinel Kilt,307,67,14,0,1,1
+13020,3,8418,1,30,Sentinel Kilt,307,67,14,0,2,1
+13021,3,8418,1,30,Sentinel Kilt,307,67,14,0,3,1
+13022,3,8418,1,30,Sentinel Kilt,307,67,14,0,4,1
+13023,3,9189,1,40,Aquila Cuisses,307,70,14,0,0,1
+13024,3,9189,1,40,Aquila Cuisses,307,70,14,0,1,1
+13025,3,9189,1,40,Aquila Cuisses,307,70,14,0,2,1
+13026,3,9189,1,40,Aquila Cuisses,307,70,14,0,3,1
+13027,3,9189,1,40,Aquila Cuisses,307,70,14,0,4,1
+13028,3,9189,1,45,Mail of Concealment,307,70,14,0,0,1
+13029,3,9189,1,45,Mail of Concealment,307,70,14,0,1,1
+13030,3,9189,1,45,Mail of Concealment,307,70,14,0,2,1
+13031,3,9189,1,45,Mail of Concealment,307,70,14,0,3,1
+13032,3,9189,1,45,Mail of Concealment,307,70,14,0,4,1
 13063,3,999,1,12,Artisan's Boots,307,55,0,0,0,1
 13064,3,999,1,12,Artisan's Boots,307,55,0,0,1,1
 13065,3,999,1,12,Artisan's Boots,307,55,0,0,2,1
 13066,3,999,1,12,Artisan's Boots,307,55,0,0,3,1
 13067,3,999,1,12,Artisan's Boots,307,55,0,0,4,1
-13068,3,999,1,13,Foreign Waistguard,307,72,0,0,0,1
-13069,3,999,1,13,Foreign Waistguard,307,72,0,0,1,1
-13070,3,999,1,13,Foreign Waistguard,307,72,0,0,2,1
-13071,3,999,1,13,Foreign Waistguard,307,72,0,0,3,1
-13072,3,999,1,13,Foreign Waistguard,307,72,0,0,4,1
+13068,3,999,1,45,Foreign Waistguard,307,72,0,0,0,1
+13069,3,999,1,45,Foreign Waistguard,307,72,0,0,1,1
+13070,3,999,1,45,Foreign Waistguard,307,72,0,0,2,1
+13071,3,999,1,45,Foreign Waistguard,307,72,0,0,3,1
+13072,3,999,1,45,Foreign Waistguard,307,72,0,0,4,1
 13610,3,12500,1,11,Marquis Cuisses,307,1,0,3,0,1
 13611,3,12500,1,11,Marquis Cuisses,307,1,0,3,1,1
 13612,3,12500,1,11,Marquis Cuisses,307,1,0,3,2,1
 13613,3,12500,1,11,Marquis Cuisses,307,1,0,3,3,1
 13614,3,12500,1,11,Marquis Cuisses,307,1,0,3,4,1
-15359,3,12001,1,11,Finnegan's Boots,307,80,0,3,0,1
-15360,3,12001,1,11,Finnegan's Boots,307,80,0,3,1,1
-15361,3,12001,1,11,Finnegan's Boots,307,80,0,3,2,1
-15362,3,12001,1,11,Finnegan's Boots,307,80,0,3,3,1
-15363,3,12001,1,11,Finnegan's Boots,307,80,0,3,4,1
-15364,3,12001,1,11,Greedy Boots,307,80,0,3,0,1
-15365,3,12001,1,11,Greedy Boots,307,80,0,3,1,1
-15366,3,12001,1,11,Greedy Boots,307,80,0,3,2,1
-15367,3,12001,1,11,Greedy Boots,307,80,0,3,3,1
-15368,3,12001,1,11,Greedy Boots,307,80,0,3,4,1
-15369,3,5000,1,7,Duke Cuisses (Dark Night),307,70,0,3,4,1
-15374,3,5000,1,6,Duke Cuisses (Moonflower),307,75,0,3,4,1
-15379,3,10548,1,2,Executioner's Greaves,307,75,12,0,0,1
-15380,3,10548,1,2,Executioner's Greaves,307,75,12,0,1,1
-15381,3,10548,1,2,Executioner's Greaves,307,75,12,0,2,1
-15382,3,10548,1,2,Executioner's Greaves,307,75,12,0,3,1
-15383,3,10548,1,2,Executioner's Greaves,307,75,12,0,4,1
-15384,3,10548,1,7,Ancient Beast Sabatons,307,75,12,0,0,1
-15385,3,10548,1,7,Ancient Beast Sabatons,307,75,12,0,1,1
-15386,3,10548,1,7,Ancient Beast Sabatons,307,75,12,0,2,1
-15387,3,10548,1,7,Ancient Beast Sabatons,307,75,12,0,3,1
-15388,3,10548,1,7,Ancient Beast Sabatons,307,75,12,0,4,1
-15389,3,10548,1,12,Grip of Genocide,307,75,12,0,0,1
-15390,3,10548,1,12,Grip of Genocide,307,75,12,0,1,1
-15391,3,10548,1,12,Grip of Genocide,307,75,12,0,2,1
-15392,3,10548,1,12,Grip of Genocide,307,75,12,0,3,1
-15393,3,10548,1,12,Grip of Genocide,307,75,12,0,4,1
-15394,3,11118,1,12,Royal Guardsman's Sabatons,307,77,12,0,0,1
-15395,3,11118,1,12,Royal Guardsman's Sabatons,307,77,12,0,1,1
-15396,3,11118,1,12,Royal Guardsman's Sabatons,307,77,12,0,2,1
-15397,3,11118,1,12,Royal Guardsman's Sabatons,307,77,12,0,3,1
-15398,3,11118,1,12,Royal Guardsman's Sabatons,307,77,12,0,4,1
-15399,3,12001,1,1,Northern Sabatons,307,80,12,0,0,1
-15400,3,12001,1,1,Northern Sabatons,307,80,12,0,1,1
-15401,3,12001,1,1,Northern Sabatons,307,80,12,0,2,1
-15402,3,12001,1,1,Northern Sabatons,307,80,12,0,3,1
-15403,3,12001,1,1,Northern Sabatons,307,80,12,0,4,1
-15404,3,12001,1,6,Knight Greaves of Dawn,307,80,12,0,0,1
-15405,3,12001,1,6,Knight Greaves of Dawn,307,80,12,0,1,1
-15406,3,12001,1,6,Knight Greaves of Dawn,307,80,12,0,2,1
-15407,3,12001,1,6,Knight Greaves of Dawn,307,80,12,0,3,1
-15408,3,12001,1,6,Knight Greaves of Dawn,307,80,12,0,4,1
-15409,3,12001,1,11,Azure Cuisses,307,80,12,0,0,1
-15410,3,12001,1,11,Azure Cuisses,307,80,12,0,1,1
-15411,3,12001,1,11,Azure Cuisses,307,80,12,0,2,1
-15412,3,12001,1,11,Azure Cuisses,307,80,12,0,3,1
-15413,3,12001,1,11,Azure Cuisses,307,80,12,0,4,1
-15414,3,10548,1,2,Innocent Shoes,307,75,15,0,0,1
-15415,3,10548,1,2,Innocent Shoes,307,75,15,0,1,1
-15416,3,10548,1,2,Innocent Shoes,307,75,15,0,2,1
-15417,3,10548,1,2,Innocent Shoes,307,75,15,0,3,1
-15418,3,10548,1,2,Innocent Shoes,307,75,15,0,4,1
-15419,3,10548,1,7,Crimson Boots,307,75,15,0,0,1
-15420,3,10548,1,7,Crimson Boots,307,75,15,0,1,1
-15421,3,10548,1,7,Crimson Boots,307,75,15,0,2,1
-15422,3,10548,1,7,Crimson Boots,307,75,15,0,3,1
-15423,3,10548,1,7,Crimson Boots,307,75,15,0,4,1
-15424,3,10548,1,12,Enhanced Boots,307,75,15,0,0,1
-15425,3,10548,1,12,Enhanced Boots,307,75,15,0,1,1
-15426,3,10548,1,12,Enhanced Boots,307,75,15,0,2,1
-15427,3,10548,1,12,Enhanced Boots,307,75,15,0,3,1
-15428,3,10548,1,12,Enhanced Boots,307,75,15,0,4,1
-15429,3,11118,1,12,Medium Boots,307,77,15,0,0,1
-15430,3,11118,1,12,Medium Boots,307,77,15,0,1,1
-15431,3,11118,1,12,Medium Boots,307,77,15,0,2,1
-15432,3,11118,1,12,Medium Boots,307,77,15,0,3,1
-15433,3,11118,1,12,Medium Boots,307,77,15,0,4,1
-15434,3,12001,1,1,Garrisoner's Shoes,307,80,15,0,0,1
-15435,3,12001,1,1,Garrisoner's Shoes,307,80,15,0,1,1
-15436,3,12001,1,1,Garrisoner's Shoes,307,80,15,0,2,1
-15437,3,12001,1,1,Garrisoner's Shoes,307,80,15,0,3,1
-15438,3,12001,1,1,Garrisoner's Shoes,307,80,15,0,4,1
-15439,3,12001,1,6,Ginkgo-dyed Footwear,307,80,15,0,0,1
-15440,3,12001,1,6,Ginkgo-dyed Footwear,307,80,15,0,1,1
-15441,3,12001,1,6,Ginkgo-dyed Footwear,307,80,15,0,2,1
-15442,3,12001,1,6,Ginkgo-dyed Footwear,307,80,15,0,3,1
-15443,3,12001,1,6,Ginkgo-dyed Footwear,307,80,15,0,4,1
-15444,3,12001,1,11,Azure Bottoms,307,80,15,0,0,1
-15445,3,12001,1,11,Azure Bottoms,307,80,15,0,1,1
-15446,3,12001,1,11,Azure Bottoms,307,80,15,0,2,1
-15447,3,12001,1,11,Azure Bottoms,307,80,15,0,3,1
-15448,3,12001,1,11,Azure Bottoms,307,80,15,0,4,1
-15449,3,10548,1,2,Continent Legs,307,75,17,0,0,1
-15450,3,10548,1,2,Continent Legs,307,75,17,0,1,1
-15451,3,10548,1,2,Continent Legs,307,75,17,0,2,1
-15452,3,10548,1,2,Continent Legs,307,75,17,0,3,1
-15453,3,10548,1,2,Continent Legs,307,75,17,0,4,1
-15454,3,10548,1,7,Greaves of Keen Insight,307,75,17,0,0,1
-15455,3,10548,1,7,Greaves of Keen Insight,307,75,17,0,1,1
-15456,3,10548,1,7,Greaves of Keen Insight,307,75,17,0,2,1
-15457,3,10548,1,7,Greaves of Keen Insight,307,75,17,0,3,1
-15458,3,10548,1,7,Greaves of Keen Insight,307,75,17,0,4,1
-15459,3,10548,1,12,Fortress Base,307,75,17,0,0,1
-15460,3,10548,1,12,Fortress Base,307,75,17,0,1,1
-15461,3,10548,1,12,Fortress Base,307,75,17,0,2,1
-15462,3,10548,1,12,Fortress Base,307,75,17,0,3,1
-15463,3,10548,1,12,Fortress Base,307,75,17,0,4,1
-15464,3,11118,1,12,Boots of Benevolence,307,77,17,0,0,1
-15465,3,11118,1,12,Boots of Benevolence,307,77,17,0,1,1
-15466,3,11118,1,12,Boots of Benevolence,307,77,17,0,2,1
-15467,3,11118,1,12,Boots of Benevolence,307,77,17,0,3,1
-15468,3,11118,1,12,Boots of Benevolence,307,77,17,0,4,1
-15469,3,12001,1,1,Monochrome Greaves,307,80,17,0,0,1
-15470,3,12001,1,1,Monochrome Greaves,307,80,17,0,1,1
-15471,3,12001,1,1,Monochrome Greaves,307,80,17,0,2,1
-15472,3,12001,1,1,Monochrome Greaves,307,80,17,0,3,1
-15473,3,12001,1,1,Monochrome Greaves,307,80,17,0,4,1
-15474,3,12001,1,6,Dark Red Greaves,307,80,17,0,0,1
-15475,3,12001,1,6,Dark Red Greaves,307,80,17,0,1,1
-15476,3,12001,1,6,Dark Red Greaves,307,80,17,0,2,1
-15477,3,12001,1,6,Dark Red Greaves,307,80,17,0,3,1
-15478,3,12001,1,6,Dark Red Greaves,307,80,17,0,4,1
-15479,3,12001,1,11,Azure Greaves,307,80,17,0,0,1
-15480,3,12001,1,11,Azure Greaves,307,80,17,0,1,1
-15481,3,12001,1,11,Azure Greaves,307,80,17,0,2,1
-15482,3,12001,1,11,Azure Greaves,307,80,17,0,3,1
-15483,3,12001,1,11,Azure Greaves,307,80,17,0,4,1
-15484,3,10548,1,2,Mountaineer Shoes,307,75,14,0,0,1
-15485,3,10548,1,2,Mountaineer Shoes,307,75,14,0,1,1
-15486,3,10548,1,2,Mountaineer Shoes,307,75,14,0,2,1
-15487,3,10548,1,2,Mountaineer Shoes,307,75,14,0,3,1
-15488,3,10548,1,2,Mountaineer Shoes,307,75,14,0,4,1
-15489,3,10548,1,7,Ocean's Legs,307,75,14,0,0,1
-15490,3,10548,1,7,Ocean's Legs,307,75,14,0,1,1
-15491,3,10548,1,7,Ocean's Legs,307,75,14,0,2,1
-15492,3,10548,1,7,Ocean's Legs,307,75,14,0,3,1
-15493,3,10548,1,7,Ocean's Legs,307,75,14,0,4,1
-15494,3,10548,1,12,Forest Cuisses,307,75,14,0,0,1
-15495,3,10548,1,12,Forest Cuisses,307,75,14,0,1,1
-15496,3,10548,1,12,Forest Cuisses,307,75,14,0,2,1
-15497,3,10548,1,12,Forest Cuisses,307,75,14,0,3,1
-15498,3,10548,1,12,Forest Cuisses,307,75,14,0,4,1
-15499,3,11118,1,12,Black Panther Leg Guards,307,77,14,0,0,1
-15500,3,11118,1,12,Black Panther Leg Guards,307,77,14,0,1,1
-15501,3,11118,1,12,Black Panther Leg Guards,307,77,14,0,2,1
-15502,3,11118,1,12,Black Panther Leg Guards,307,77,14,0,3,1
-15503,3,11118,1,12,Black Panther Leg Guards,307,77,14,0,4,1
-15504,3,12001,1,1,Patrician Legs,307,80,14,0,0,1
-15505,3,12001,1,1,Patrician Legs,307,80,14,0,1,1
-15506,3,12001,1,1,Patrician Legs,307,80,14,0,2,1
-15507,3,12001,1,1,Patrician Legs,307,80,14,0,3,1
-15508,3,12001,1,1,Patrician Legs,307,80,14,0,4,1
-15509,3,12001,1,6,Chausses of Evening Mist,307,80,14,0,0,1
-15510,3,12001,1,6,Chausses of Evening Mist,307,80,14,0,1,1
-15511,3,12001,1,6,Chausses of Evening Mist,307,80,14,0,2,1
-15512,3,12001,1,6,Chausses of Evening Mist,307,80,14,0,3,1
-15513,3,12001,1,6,Chausses of Evening Mist,307,80,14,0,4,1
-15514,3,12001,1,11,Azure Boots,307,80,14,0,0,1
-15515,3,12001,1,11,Azure Boots,307,80,14,0,1,1
-15516,3,12001,1,11,Azure Boots,307,80,14,0,2,1
-15517,3,12001,1,11,Azure Boots,307,80,14,0,3,1
-15518,3,12001,1,11,Azure Boots,307,80,14,0,4,1
+15359,3,12001,1,75,Finnegan's Boots,307,80,0,3,0,1
+15360,3,12001,1,75,Finnegan's Boots,307,80,0,3,1,1
+15361,3,12001,1,75,Finnegan's Boots,307,80,0,3,2,1
+15362,3,12001,1,75,Finnegan's Boots,307,80,0,3,3,1
+15363,3,12001,1,75,Finnegan's Boots,307,80,0,3,4,1
+15364,3,12001,1,75,Greedy Boots,307,80,0,3,0,1
+15365,3,12001,1,75,Greedy Boots,307,80,0,3,1,1
+15366,3,12001,1,75,Greedy Boots,307,80,0,3,2,1
+15367,3,12001,1,75,Greedy Boots,307,80,0,3,3,1
+15368,3,12001,1,75,Greedy Boots,307,80,0,3,4,1
+15369,3,5000,1,55,Duke Cuisses (Dark Night),307,70,0,3,4,1
+15374,3,5000,1,70,Duke Cuisses (Moonflower),307,75,0,3,4,1
+15379,3,10548,1,50,Executioner's Greaves,307,75,12,0,0,1
+15380,3,10548,1,50,Executioner's Greaves,307,75,12,0,1,1
+15381,3,10548,1,50,Executioner's Greaves,307,75,12,0,2,1
+15382,3,10548,1,50,Executioner's Greaves,307,75,12,0,3,1
+15383,3,10548,1,50,Executioner's Greaves,307,75,12,0,4,1
+15384,3,10548,1,55,Ancient Beast Sabatons,307,75,12,0,0,1
+15385,3,10548,1,55,Ancient Beast Sabatons,307,75,12,0,1,1
+15386,3,10548,1,55,Ancient Beast Sabatons,307,75,12,0,2,1
+15387,3,10548,1,55,Ancient Beast Sabatons,307,75,12,0,3,1
+15388,3,10548,1,55,Ancient Beast Sabatons,307,75,12,0,4,1
+15389,3,10548,1,60,Grip of Genocide,307,75,12,0,0,1
+15390,3,10548,1,60,Grip of Genocide,307,75,12,0,1,1
+15391,3,10548,1,60,Grip of Genocide,307,75,12,0,2,1
+15392,3,10548,1,60,Grip of Genocide,307,75,12,0,3,1
+15393,3,10548,1,60,Grip of Genocide,307,75,12,0,4,1
+15394,3,11118,1,60,Royal Guardsman's Sabatons,307,77,12,0,0,1
+15395,3,11118,1,60,Royal Guardsman's Sabatons,307,77,12,0,1,1
+15396,3,11118,1,60,Royal Guardsman's Sabatons,307,77,12,0,2,1
+15397,3,11118,1,60,Royal Guardsman's Sabatons,307,77,12,0,3,1
+15398,3,11118,1,60,Royal Guardsman's Sabatons,307,77,12,0,4,1
+15399,3,12001,1,65,Northern Sabatons,307,80,12,0,0,1
+15400,3,12001,1,65,Northern Sabatons,307,80,12,0,1,1
+15401,3,12001,1,65,Northern Sabatons,307,80,12,0,2,1
+15402,3,12001,1,65,Northern Sabatons,307,80,12,0,3,1
+15403,3,12001,1,65,Northern Sabatons,307,80,12,0,4,1
+15404,3,12001,1,70,Knight Greaves of Dawn,307,80,12,0,0,1
+15405,3,12001,1,70,Knight Greaves of Dawn,307,80,12,0,1,1
+15406,3,12001,1,70,Knight Greaves of Dawn,307,80,12,0,2,1
+15407,3,12001,1,70,Knight Greaves of Dawn,307,80,12,0,3,1
+15408,3,12001,1,70,Knight Greaves of Dawn,307,80,12,0,4,1
+15409,3,12001,1,75,Azure Cuisses,307,80,12,0,0,1
+15410,3,12001,1,75,Azure Cuisses,307,80,12,0,1,1
+15411,3,12001,1,75,Azure Cuisses,307,80,12,0,2,1
+15412,3,12001,1,75,Azure Cuisses,307,80,12,0,3,1
+15413,3,12001,1,75,Azure Cuisses,307,80,12,0,4,1
+15414,3,10548,1,50,Innocent Shoes,307,75,15,0,0,1
+15415,3,10548,1,50,Innocent Shoes,307,75,15,0,1,1
+15416,3,10548,1,50,Innocent Shoes,307,75,15,0,2,1
+15417,3,10548,1,50,Innocent Shoes,307,75,15,0,3,1
+15418,3,10548,1,50,Innocent Shoes,307,75,15,0,4,1
+15419,3,10548,1,55,Crimson Boots,307,75,15,0,0,1
+15420,3,10548,1,55,Crimson Boots,307,75,15,0,1,1
+15421,3,10548,1,55,Crimson Boots,307,75,15,0,2,1
+15422,3,10548,1,55,Crimson Boots,307,75,15,0,3,1
+15423,3,10548,1,55,Crimson Boots,307,75,15,0,4,1
+15424,3,10548,1,60,Enhanced Boots,307,75,15,0,0,1
+15425,3,10548,1,60,Enhanced Boots,307,75,15,0,1,1
+15426,3,10548,1,60,Enhanced Boots,307,75,15,0,2,1
+15427,3,10548,1,60,Enhanced Boots,307,75,15,0,3,1
+15428,3,10548,1,60,Enhanced Boots,307,75,15,0,4,1
+15429,3,11118,1,60,Medium Boots,307,77,15,0,0,1
+15430,3,11118,1,60,Medium Boots,307,77,15,0,1,1
+15431,3,11118,1,60,Medium Boots,307,77,15,0,2,1
+15432,3,11118,1,60,Medium Boots,307,77,15,0,3,1
+15433,3,11118,1,60,Medium Boots,307,77,15,0,4,1
+15434,3,12001,1,65,Garrisoner's Shoes,307,80,15,0,0,1
+15435,3,12001,1,65,Garrisoner's Shoes,307,80,15,0,1,1
+15436,3,12001,1,65,Garrisoner's Shoes,307,80,15,0,2,1
+15437,3,12001,1,65,Garrisoner's Shoes,307,80,15,0,3,1
+15438,3,12001,1,65,Garrisoner's Shoes,307,80,15,0,4,1
+15439,3,12001,1,70,Ginkgo-dyed Footwear,307,80,15,0,0,1
+15440,3,12001,1,70,Ginkgo-dyed Footwear,307,80,15,0,1,1
+15441,3,12001,1,70,Ginkgo-dyed Footwear,307,80,15,0,2,1
+15442,3,12001,1,70,Ginkgo-dyed Footwear,307,80,15,0,3,1
+15443,3,12001,1,70,Ginkgo-dyed Footwear,307,80,15,0,4,1
+15444,3,12001,1,75,Azure Bottoms,307,80,15,0,0,1
+15445,3,12001,1,75,Azure Bottoms,307,80,15,0,1,1
+15446,3,12001,1,75,Azure Bottoms,307,80,15,0,2,1
+15447,3,12001,1,75,Azure Bottoms,307,80,15,0,3,1
+15448,3,12001,1,75,Azure Bottoms,307,80,15,0,4,1
+15449,3,10548,1,50,Continent Legs,307,75,17,0,0,1
+15450,3,10548,1,50,Continent Legs,307,75,17,0,1,1
+15451,3,10548,1,50,Continent Legs,307,75,17,0,2,1
+15452,3,10548,1,50,Continent Legs,307,75,17,0,3,1
+15453,3,10548,1,50,Continent Legs,307,75,17,0,4,1
+15454,3,10548,1,55,Greaves of Keen Insight,307,75,17,0,0,1
+15455,3,10548,1,55,Greaves of Keen Insight,307,75,17,0,1,1
+15456,3,10548,1,55,Greaves of Keen Insight,307,75,17,0,2,1
+15457,3,10548,1,55,Greaves of Keen Insight,307,75,17,0,3,1
+15458,3,10548,1,55,Greaves of Keen Insight,307,75,17,0,4,1
+15459,3,10548,1,60,Fortress Base,307,75,17,0,0,1
+15460,3,10548,1,60,Fortress Base,307,75,17,0,1,1
+15461,3,10548,1,60,Fortress Base,307,75,17,0,2,1
+15462,3,10548,1,60,Fortress Base,307,75,17,0,3,1
+15463,3,10548,1,60,Fortress Base,307,75,17,0,4,1
+15464,3,11118,1,60,Boots of Benevolence,307,77,17,0,0,1
+15465,3,11118,1,60,Boots of Benevolence,307,77,17,0,1,1
+15466,3,11118,1,60,Boots of Benevolence,307,77,17,0,2,1
+15467,3,11118,1,60,Boots of Benevolence,307,77,17,0,3,1
+15468,3,11118,1,60,Boots of Benevolence,307,77,17,0,4,1
+15469,3,12001,1,65,Monochrome Greaves,307,80,17,0,0,1
+15470,3,12001,1,65,Monochrome Greaves,307,80,17,0,1,1
+15471,3,12001,1,65,Monochrome Greaves,307,80,17,0,2,1
+15472,3,12001,1,65,Monochrome Greaves,307,80,17,0,3,1
+15473,3,12001,1,65,Monochrome Greaves,307,80,17,0,4,1
+15474,3,12001,1,70,Dark Red Greaves,307,80,17,0,0,1
+15475,3,12001,1,70,Dark Red Greaves,307,80,17,0,1,1
+15476,3,12001,1,70,Dark Red Greaves,307,80,17,0,2,1
+15477,3,12001,1,70,Dark Red Greaves,307,80,17,0,3,1
+15478,3,12001,1,70,Dark Red Greaves,307,80,17,0,4,1
+15479,3,12001,1,75,Azure Greaves,307,80,17,0,0,1
+15480,3,12001,1,75,Azure Greaves,307,80,17,0,1,1
+15481,3,12001,1,75,Azure Greaves,307,80,17,0,2,1
+15482,3,12001,1,75,Azure Greaves,307,80,17,0,3,1
+15483,3,12001,1,75,Azure Greaves,307,80,17,0,4,1
+15484,3,10548,1,50,Mountaineer Shoes,307,75,14,0,0,1
+15485,3,10548,1,50,Mountaineer Shoes,307,75,14,0,1,1
+15486,3,10548,1,50,Mountaineer Shoes,307,75,14,0,2,1
+15487,3,10548,1,50,Mountaineer Shoes,307,75,14,0,3,1
+15488,3,10548,1,50,Mountaineer Shoes,307,75,14,0,4,1
+15489,3,10548,1,55,Ocean's Legs,307,75,14,0,0,1
+15490,3,10548,1,55,Ocean's Legs,307,75,14,0,1,1
+15491,3,10548,1,55,Ocean's Legs,307,75,14,0,2,1
+15492,3,10548,1,55,Ocean's Legs,307,75,14,0,3,1
+15493,3,10548,1,55,Ocean's Legs,307,75,14,0,4,1
+15494,3,10548,1,60,Forest Cuisses,307,75,14,0,0,1
+15495,3,10548,1,60,Forest Cuisses,307,75,14,0,1,1
+15496,3,10548,1,60,Forest Cuisses,307,75,14,0,2,1
+15497,3,10548,1,60,Forest Cuisses,307,75,14,0,3,1
+15498,3,10548,1,60,Forest Cuisses,307,75,14,0,4,1
+15499,3,11118,1,60,Black Panther Leg Guards,307,77,14,0,0,1
+15500,3,11118,1,60,Black Panther Leg Guards,307,77,14,0,1,1
+15501,3,11118,1,60,Black Panther Leg Guards,307,77,14,0,2,1
+15502,3,11118,1,60,Black Panther Leg Guards,307,77,14,0,3,1
+15503,3,11118,1,60,Black Panther Leg Guards,307,77,14,0,4,1
+15504,3,12001,1,65,Patrician Legs,307,80,14,0,0,1
+15505,3,12001,1,65,Patrician Legs,307,80,14,0,1,1
+15506,3,12001,1,65,Patrician Legs,307,80,14,0,2,1
+15507,3,12001,1,65,Patrician Legs,307,80,14,0,3,1
+15508,3,12001,1,65,Patrician Legs,307,80,14,0,4,1
+15509,3,12001,1,70,Chausses of Evening Mist,307,80,14,0,0,1
+15510,3,12001,1,70,Chausses of Evening Mist,307,80,14,0,1,1
+15511,3,12001,1,70,Chausses of Evening Mist,307,80,14,0,2,1
+15512,3,12001,1,70,Chausses of Evening Mist,307,80,14,0,3,1
+15513,3,12001,1,70,Chausses of Evening Mist,307,80,14,0,4,1
+15514,3,12001,1,75,Azure Boots,307,80,14,0,0,1
+15515,3,12001,1,75,Azure Boots,307,80,14,0,1,1
+15516,3,12001,1,75,Azure Boots,307,80,14,0,2,1
+15517,3,12001,1,75,Azure Boots,307,80,14,0,3,1
+15518,3,12001,1,75,Azure Boots,307,80,14,0,4,1
 16496,3,100,1,1,Dragoon Boots (Decoration),307,1,0,0,4,1
 16497,3,100,1,1,Wyrm's Scheme (Decoration),307,1,0,0,4,1
 16498,3,100,1,1,Ddraig Crura (Decoration),307,1,0,0,4,1
 16499,3,100,1,1,Drachen-Pein (Decoration),307,1,0,0,4,1
-17751,3,12020,1,0,Brigand Sabatons,307,80,12,0,0,1
-17752,3,12020,1,0,Brigand Sabatons,307,80,12,0,1,1
-17753,3,12020,1,0,Brigand Sabatons,307,80,12,0,2,1
-17754,3,12020,1,0,Brigand Sabatons,307,80,12,0,3,1
-17755,3,12020,1,0,Brigand Sabatons,307,80,12,0,4,1
-17756,3,12886,1,5,Gelmez Greaves,307,83,12,0,0,1
-17757,3,12886,1,5,Gelmez Greaves,307,83,12,0,1,1
-17758,3,12886,1,5,Gelmez Greaves,307,83,12,0,2,1
-17759,3,12886,1,5,Gelmez Greaves,307,83,12,0,3,1
-17760,3,12886,1,5,Gelmez Greaves,307,83,12,0,4,1
-17761,3,13463,1,10,Acrean Greaves,307,85,12,0,0,1
-17762,3,13463,1,10,Acrean Greaves,307,85,12,0,1,1
-17763,3,13463,1,10,Acrean Greaves,307,85,12,0,2,1
-17764,3,13463,1,10,Acrean Greaves,307,85,12,0,3,1
-17765,3,13463,1,10,Acrean Greaves,307,85,12,0,4,1
-17766,3,12020,1,0,Modestly Greaves,307,80,15,0,0,1
-17767,3,12020,1,0,Modestly Greaves,307,80,15,0,1,1
-17768,3,12020,1,0,Modestly Greaves,307,80,15,0,2,1
-17769,3,12020,1,0,Modestly Greaves,307,80,15,0,3,1
-17770,3,12020,1,0,Modestly Greaves,307,80,15,0,4,1
-17771,3,12886,1,5,Duarev Shoes,307,83,15,0,0,1
-17772,3,12886,1,5,Duarev Shoes,307,83,15,0,1,1
-17773,3,12886,1,5,Duarev Shoes,307,83,15,0,2,1
-17774,3,12886,1,5,Duarev Shoes,307,83,15,0,3,1
-17775,3,12886,1,5,Duarev Shoes,307,83,15,0,4,1
-17776,3,13463,1,10,Acrean Boots,307,85,15,0,0,1
-17777,3,13463,1,10,Acrean Boots,307,85,15,0,1,1
-17778,3,13463,1,10,Acrean Boots,307,85,15,0,2,1
-17779,3,13463,1,10,Acrean Boots,307,85,15,0,3,1
-17780,3,13463,1,10,Acrean Boots,307,85,15,0,4,1
-17781,3,12020,1,0,Brass Greaves,307,80,17,0,0,1
-17782,3,12020,1,0,Brass Greaves,307,80,17,0,1,1
-17783,3,12020,1,0,Brass Greaves,307,80,17,0,2,1
-17784,3,12020,1,0,Brass Greaves,307,80,17,0,3,1
-17785,3,12020,1,0,Brass Greaves,307,80,17,0,4,1
-17786,3,12886,1,5,Sizjak Greaves,307,83,17,0,0,1
-17787,3,12886,1,5,Sizjak Greaves,307,83,17,0,1,1
-17788,3,12886,1,5,Sizjak Greaves,307,83,17,0,2,1
-17789,3,12886,1,5,Sizjak Greaves,307,83,17,0,3,1
-17790,3,12886,1,5,Sizjak Greaves,307,83,17,0,4,1
-17791,3,13463,1,10,Acrean Bottoms,307,85,17,0,0,1
-17792,3,13463,1,10,Acrean Bottoms,307,85,17,0,1,1
-17793,3,13463,1,10,Acrean Bottoms,307,85,17,0,2,1
-17794,3,13463,1,10,Acrean Bottoms,307,85,17,0,3,1
-17795,3,13463,1,10,Acrean Bottoms,307,85,17,0,4,1
-17796,3,12020,1,0,Colored Boots of Warm Winds,307,80,14,0,0,1
-17797,3,12020,1,0,Colored Boots of Warm Winds,307,80,14,0,1,1
-17798,3,12020,1,0,Colored Boots of Warm Winds,307,80,14,0,2,1
-17799,3,12020,1,0,Colored Boots of Warm Winds,307,80,14,0,3,1
-17800,3,12020,1,0,Colored Boots of Warm Winds,307,80,14,0,4,1
-17801,3,12886,1,5,Shahabad Boots,307,83,14,0,0,1
-17802,3,12886,1,5,Shahabad Boots,307,83,14,0,1,1
-17803,3,12886,1,5,Shahabad Boots,307,83,14,0,2,1
-17804,3,12886,1,5,Shahabad Boots,307,83,14,0,3,1
-17805,3,12886,1,5,Shahabad Boots,307,83,14,0,4,1
-17806,3,13463,1,10,Acrean Cuisses,307,85,14,0,0,1
-17807,3,13463,1,10,Acrean Cuisses,307,85,14,0,1,1
-17808,3,13463,1,10,Acrean Cuisses,307,85,14,0,2,1
-17809,3,13463,1,10,Acrean Cuisses,307,85,14,0,3,1
-17810,3,13463,1,10,Acrean Cuisses,307,85,14,0,4,1
-18379,3,13463,1,10,Courage Sabatons,307,85,12,0,0,1
-18380,3,13463,1,10,Courage Sabatons,307,85,12,0,1,1
-18381,3,13463,1,10,Courage Sabatons,307,85,12,0,2,1
-18382,3,13463,1,10,Courage Sabatons,307,85,12,0,3,1
-18383,3,13463,1,10,Courage Sabatons,307,85,12,0,4,1
-18384,3,14402,1,15,Emine Cuisses,307,88,12,0,0,1
-18385,3,14402,1,15,Emine Cuisses,307,88,12,0,1,1
-18386,3,14402,1,15,Emine Cuisses,307,88,12,0,2,1
-18387,3,14402,1,15,Emine Cuisses,307,88,12,0,3,1
-18388,3,14402,1,15,Emine Cuisses,307,88,12,0,4,1
-18389,3,14958,1,4,Dools Cuisses,307,90,12,0,0,1
-18390,3,14958,1,4,Dools Cuisses,307,90,12,0,1,1
-18391,3,14958,1,4,Dools Cuisses,307,90,12,0,2,1
-18392,3,14958,1,4,Dools Cuisses,307,90,12,0,3,1
-18393,3,14958,1,4,Dools Cuisses,307,90,12,0,4,1
-18394,3,13463,1,10,Magnus Boots,307,85,15,0,0,1
-18395,3,13463,1,10,Magnus Boots,307,85,15,0,1,1
-18396,3,13463,1,10,Magnus Boots,307,85,15,0,2,1
-18397,3,13463,1,10,Magnus Boots,307,85,15,0,3,1
-18398,3,13463,1,10,Magnus Boots,307,85,15,0,4,1
-18399,3,14402,1,15,Anklets of Hope,307,88,15,0,0,1
-18400,3,14402,1,15,Anklets of Hope,307,88,15,0,1,1
-18401,3,14402,1,15,Anklets of Hope,307,88,15,0,2,1
-18402,3,14402,1,15,Anklets of Hope,307,88,15,0,3,1
-18403,3,14402,1,15,Anklets of Hope,307,88,15,0,4,1
-18404,3,14958,1,4,Dools High Boots,307,90,15,0,0,1
-18405,3,14958,1,4,Dools High Boots,307,90,15,0,1,1
-18406,3,14958,1,4,Dools High Boots,307,90,15,0,2,1
-18407,3,14958,1,4,Dools High Boots,307,90,15,0,3,1
-18408,3,14958,1,4,Dools High Boots,307,90,15,0,4,1
-18409,3,13463,1,10,Kelsus Greaves,307,85,17,0,0,1
-18410,3,13463,1,10,Kelsus Greaves,307,85,17,0,1,1
-18411,3,13463,1,10,Kelsus Greaves,307,85,17,0,2,1
-18412,3,13463,1,10,Kelsus Greaves,307,85,17,0,3,1
-18413,3,13463,1,10,Kelsus Greaves,307,85,17,0,4,1
-18414,3,14402,1,15,Kier Boots,307,88,17,0,0,1
-18415,3,14402,1,15,Kier Boots,307,88,17,0,1,1
-18416,3,14402,1,15,Kier Boots,307,88,17,0,2,1
-18417,3,14402,1,15,Kier Boots,307,88,17,0,3,1
-18418,3,14402,1,15,Kier Boots,307,88,17,0,4,1
-18419,3,14958,1,4,Dools Legs,307,90,17,0,0,1
-18420,3,14958,1,4,Dools Legs,307,90,17,0,1,1
-18421,3,14958,1,4,Dools Legs,307,90,17,0,2,1
-18422,3,14958,1,4,Dools Legs,307,90,17,0,3,1
-18423,3,14958,1,4,Dools Legs,307,90,17,0,4,1
-18424,3,13463,1,10,Aura Poleyn,307,85,14,0,0,1
-18425,3,13463,1,10,Aura Poleyn,307,85,14,0,1,1
-18426,3,13463,1,10,Aura Poleyn,307,85,14,0,2,1
-18427,3,13463,1,10,Aura Poleyn,307,85,14,0,3,1
-18428,3,13463,1,10,Aura Poleyn,307,85,14,0,4,1
-18429,3,14402,1,15,Niloufar Bottoms,307,88,14,0,0,1
-18430,3,14402,1,15,Niloufar Bottoms,307,88,14,0,1,1
-18431,3,14402,1,15,Niloufar Bottoms,307,88,14,0,2,1
-18432,3,14402,1,15,Niloufar Bottoms,307,88,14,0,3,1
-18433,3,14402,1,15,Niloufar Bottoms,307,88,14,0,4,1
-18434,3,14958,1,4,Dools Greaves,307,90,14,0,0,1
-18435,3,14958,1,4,Dools Greaves,307,90,14,0,1,1
-18436,3,14958,1,4,Dools Greaves,307,90,14,0,2,1
-18437,3,14958,1,4,Dools Greaves,307,90,14,0,3,1
-18438,3,14958,1,4,Dools Greaves,307,90,14,0,4,1
+17751,3,12020,1,80,Brigand Sabatons,307,80,12,0,0,1
+17752,3,12020,1,80,Brigand Sabatons,307,80,12,0,1,1
+17753,3,12020,1,80,Brigand Sabatons,307,80,12,0,2,1
+17754,3,12020,1,80,Brigand Sabatons,307,80,12,0,3,1
+17755,3,12020,1,80,Brigand Sabatons,307,80,12,0,4,1
+17756,3,12886,1,85,Gelmez Greaves,307,83,12,0,0,1
+17757,3,12886,1,85,Gelmez Greaves,307,83,12,0,1,1
+17758,3,12886,1,85,Gelmez Greaves,307,83,12,0,2,1
+17759,3,12886,1,85,Gelmez Greaves,307,83,12,0,3,1
+17760,3,12886,1,85,Gelmez Greaves,307,83,12,0,4,1
+17761,3,13463,1,90,Acrean Greaves,307,85,12,0,0,1
+17762,3,13463,1,90,Acrean Greaves,307,85,12,0,1,1
+17763,3,13463,1,90,Acrean Greaves,307,85,12,0,2,1
+17764,3,13463,1,90,Acrean Greaves,307,85,12,0,3,1
+17765,3,13463,1,90,Acrean Greaves,307,85,12,0,4,1
+17766,3,12020,1,80,Modestly Greaves,307,80,15,0,0,1
+17767,3,12020,1,80,Modestly Greaves,307,80,15,0,1,1
+17768,3,12020,1,80,Modestly Greaves,307,80,15,0,2,1
+17769,3,12020,1,80,Modestly Greaves,307,80,15,0,3,1
+17770,3,12020,1,80,Modestly Greaves,307,80,15,0,4,1
+17771,3,12886,1,85,Duarev Shoes,307,83,15,0,0,1
+17772,3,12886,1,85,Duarev Shoes,307,83,15,0,1,1
+17773,3,12886,1,85,Duarev Shoes,307,83,15,0,2,1
+17774,3,12886,1,85,Duarev Shoes,307,83,15,0,3,1
+17775,3,12886,1,85,Duarev Shoes,307,83,15,0,4,1
+17776,3,13463,1,90,Acrean Boots,307,85,15,0,0,1
+17777,3,13463,1,90,Acrean Boots,307,85,15,0,1,1
+17778,3,13463,1,90,Acrean Boots,307,85,15,0,2,1
+17779,3,13463,1,90,Acrean Boots,307,85,15,0,3,1
+17780,3,13463,1,90,Acrean Boots,307,85,15,0,4,1
+17781,3,12020,1,80,Brass Greaves,307,80,17,0,0,1
+17782,3,12020,1,80,Brass Greaves,307,80,17,0,1,1
+17783,3,12020,1,80,Brass Greaves,307,80,17,0,2,1
+17784,3,12020,1,80,Brass Greaves,307,80,17,0,3,1
+17785,3,12020,1,80,Brass Greaves,307,80,17,0,4,1
+17786,3,12886,1,85,Sizjak Greaves,307,83,17,0,0,1
+17787,3,12886,1,85,Sizjak Greaves,307,83,17,0,1,1
+17788,3,12886,1,85,Sizjak Greaves,307,83,17,0,2,1
+17789,3,12886,1,85,Sizjak Greaves,307,83,17,0,3,1
+17790,3,12886,1,85,Sizjak Greaves,307,83,17,0,4,1
+17791,3,13463,1,90,Acrean Bottoms,307,85,17,0,0,1
+17792,3,13463,1,90,Acrean Bottoms,307,85,17,0,1,1
+17793,3,13463,1,90,Acrean Bottoms,307,85,17,0,2,1
+17794,3,13463,1,90,Acrean Bottoms,307,85,17,0,3,1
+17795,3,13463,1,90,Acrean Bottoms,307,85,17,0,4,1
+17796,3,12020,1,80,Colored Boots of Warm Winds,307,80,14,0,0,1
+17797,3,12020,1,80,Colored Boots of Warm Winds,307,80,14,0,1,1
+17798,3,12020,1,80,Colored Boots of Warm Winds,307,80,14,0,2,1
+17799,3,12020,1,80,Colored Boots of Warm Winds,307,80,14,0,3,1
+17800,3,12020,1,80,Colored Boots of Warm Winds,307,80,14,0,4,1
+17801,3,12886,1,85,Shahabad Boots,307,83,14,0,0,1
+17802,3,12886,1,85,Shahabad Boots,307,83,14,0,1,1
+17803,3,12886,1,85,Shahabad Boots,307,83,14,0,2,1
+17804,3,12886,1,85,Shahabad Boots,307,83,14,0,3,1
+17805,3,12886,1,85,Shahabad Boots,307,83,14,0,4,1
+17806,3,13463,1,90,Acrean Cuisses,307,85,14,0,0,1
+17807,3,13463,1,90,Acrean Cuisses,307,85,14,0,1,1
+17808,3,13463,1,90,Acrean Cuisses,307,85,14,0,2,1
+17809,3,13463,1,90,Acrean Cuisses,307,85,14,0,3,1
+17810,3,13463,1,90,Acrean Cuisses,307,85,14,0,4,1
+18379,3,13463,1,90,Courage Sabatons,307,85,12,0,0,1
+18380,3,13463,1,90,Courage Sabatons,307,85,12,0,1,1
+18381,3,13463,1,90,Courage Sabatons,307,85,12,0,2,1
+18382,3,13463,1,90,Courage Sabatons,307,85,12,0,3,1
+18383,3,13463,1,90,Courage Sabatons,307,85,12,0,4,1
+18384,3,14402,1,95,Emine Cuisses,307,88,12,0,0,1
+18385,3,14402,1,95,Emine Cuisses,307,88,12,0,1,1
+18386,3,14402,1,95,Emine Cuisses,307,88,12,0,2,1
+18387,3,14402,1,95,Emine Cuisses,307,88,12,0,3,1
+18388,3,14402,1,95,Emine Cuisses,307,88,12,0,4,1
+18389,3,14958,1,100,Dools Cuisses,307,90,12,0,0,1
+18390,3,14958,1,100,Dools Cuisses,307,90,12,0,1,1
+18391,3,14958,1,100,Dools Cuisses,307,90,12,0,2,1
+18392,3,14958,1,100,Dools Cuisses,307,90,12,0,3,1
+18393,3,14958,1,100,Dools Cuisses,307,90,12,0,4,1
+18394,3,13463,1,90,Magnus Boots,307,85,15,0,0,1
+18395,3,13463,1,90,Magnus Boots,307,85,15,0,1,1
+18396,3,13463,1,90,Magnus Boots,307,85,15,0,2,1
+18397,3,13463,1,90,Magnus Boots,307,85,15,0,3,1
+18398,3,13463,1,90,Magnus Boots,307,85,15,0,4,1
+18399,3,14402,1,95,Anklets of Hope,307,88,15,0,0,1
+18400,3,14402,1,95,Anklets of Hope,307,88,15,0,1,1
+18401,3,14402,1,95,Anklets of Hope,307,88,15,0,2,1
+18402,3,14402,1,95,Anklets of Hope,307,88,15,0,3,1
+18403,3,14402,1,95,Anklets of Hope,307,88,15,0,4,1
+18404,3,14958,1,100,Dools High Boots,307,90,15,0,0,1
+18405,3,14958,1,100,Dools High Boots,307,90,15,0,1,1
+18406,3,14958,1,100,Dools High Boots,307,90,15,0,2,1
+18407,3,14958,1,100,Dools High Boots,307,90,15,0,3,1
+18408,3,14958,1,100,Dools High Boots,307,90,15,0,4,1
+18409,3,13463,1,90,Kelsus Greaves,307,85,17,0,0,1
+18410,3,13463,1,90,Kelsus Greaves,307,85,17,0,1,1
+18411,3,13463,1,90,Kelsus Greaves,307,85,17,0,2,1
+18412,3,13463,1,90,Kelsus Greaves,307,85,17,0,3,1
+18413,3,13463,1,90,Kelsus Greaves,307,85,17,0,4,1
+18414,3,14402,1,95,Kier Boots,307,88,17,0,0,1
+18415,3,14402,1,95,Kier Boots,307,88,17,0,1,1
+18416,3,14402,1,95,Kier Boots,307,88,17,0,2,1
+18417,3,14402,1,95,Kier Boots,307,88,17,0,3,1
+18418,3,14402,1,95,Kier Boots,307,88,17,0,4,1
+18419,3,14958,1,100,Dools Legs,307,90,17,0,0,1
+18420,3,14958,1,100,Dools Legs,307,90,17,0,1,1
+18421,3,14958,1,100,Dools Legs,307,90,17,0,2,1
+18422,3,14958,1,100,Dools Legs,307,90,17,0,3,1
+18423,3,14958,1,100,Dools Legs,307,90,17,0,4,1
+18424,3,13463,1,90,Aura Poleyn,307,85,14,0,0,1
+18425,3,13463,1,90,Aura Poleyn,307,85,14,0,1,1
+18426,3,13463,1,90,Aura Poleyn,307,85,14,0,2,1
+18427,3,13463,1,90,Aura Poleyn,307,85,14,0,3,1
+18428,3,13463,1,90,Aura Poleyn,307,85,14,0,4,1
+18429,3,14402,1,95,Niloufar Bottoms,307,88,14,0,0,1
+18430,3,14402,1,95,Niloufar Bottoms,307,88,14,0,1,1
+18431,3,14402,1,95,Niloufar Bottoms,307,88,14,0,2,1
+18432,3,14402,1,95,Niloufar Bottoms,307,88,14,0,3,1
+18433,3,14402,1,95,Niloufar Bottoms,307,88,14,0,4,1
+18434,3,14958,1,100,Dools Greaves,307,90,14,0,0,1
+18435,3,14958,1,100,Dools Greaves,307,90,14,0,1,1
+18436,3,14958,1,100,Dools Greaves,307,90,14,0,2,1
+18437,3,14958,1,100,Dools Greaves,307,90,14,0,3,1
+18438,3,14958,1,100,Dools Greaves,307,90,14,0,4,1
 18500,3,100,1,1,Volcanic High Boots,307,75,0,0,4,1
-18584,3,15000,1,13,Black Venom Boots,307,1,0,3,0,1
-18585,3,15000,1,2,Black Venom Boots,307,1,0,3,1,1
-18586,3,15000,1,7,Black Venom Boots,307,1,0,3,2,1
-18587,3,15000,1,12,Black Venom Boots,307,1,0,3,3,1
-18588,3,15000,1,6,Black Venom Boots,307,1,0,3,4,1
-19251,3,0,1,10,Armor of the First King,307,80,0,3,0,1
-19252,3,0,1,4,Armor of the First King,307,80,0,3,1,1
-19253,3,0,1,9,Armor of the First King,307,80,0,3,2,1
-19254,3,0,1,14,Armor of the First King,307,80,0,3,3,1
-19255,3,0,1,8,Armor of the First King,307,80,0,3,4,1
-19457,3,10000,1,0,Boundless Tempest Cuisses,307,1,0,3,4,1
-19461,3,10000,1,3,Boundless Tempest Boots,307,1,0,3,4,1
-20479,3,15100,1,4,Maddest Greaves,307,90,12,0,0,1
-20480,3,15100,1,4,Maddest Greaves,307,90,12,0,1,1
-20481,3,15100,1,4,Maddest Greaves,307,90,12,0,2,1
-20482,3,15100,1,4,Maddest Greaves,307,90,12,0,3,1
-20483,3,15100,1,4,Maddest Greaves,307,90,12,0,4,1
-20484,3,15855,1,9,Corail Cuisses,307,93,12,0,0,1
-20485,3,15855,1,9,Corail Cuisses,307,93,12,0,1,1
-20486,3,15855,1,9,Corail Cuisses,307,93,12,0,2,1
-20487,3,15855,1,9,Corail Cuisses,307,93,12,0,3,1
-20488,3,15855,1,9,Corail Cuisses,307,93,12,0,4,1
-20489,3,16610,1,14,Mehizaf Poleyn,307,95,12,0,0,1
-20490,3,16610,1,14,Mehizaf Poleyn,307,95,12,0,1,1
-20491,3,16610,1,14,Mehizaf Poleyn,307,95,12,0,2,1
-20492,3,16610,1,14,Mehizaf Poleyn,307,95,12,0,3,1
-20493,3,16610,1,14,Mehizaf Poleyn,307,95,12,0,4,1
-20807,3,16610,1,14,Courage Boots,307,95,12,0,0,1
-20808,3,16610,1,14,Courage Boots,307,95,12,0,1,1
-20809,3,16610,1,14,Courage Boots,307,95,12,0,2,1
-20810,3,16610,1,14,Courage Boots,307,95,12,0,3,1
-20811,3,16610,1,14,Courage Boots,307,95,12,0,4,1
-20812,3,17365,1,3,Confidence Greaves,307,98,12,0,0,1
-20813,3,17365,1,3,Confidence Greaves,307,98,12,0,1,1
-20814,3,17365,1,3,Confidence Greaves,307,98,12,0,2,1
-20815,3,17365,1,3,Confidence Greaves,307,98,12,0,3,1
-20816,3,17365,1,3,Confidence Greaves,307,98,12,0,4,1
-20817,3,18120,1,8,Ambition Legs,307,100,12,0,0,1
-20818,3,18120,1,8,Ambition Legs,307,100,12,0,1,1
-20819,3,18120,1,8,Ambition Legs,307,100,12,0,2,1
-20820,3,18120,1,8,Ambition Legs,307,100,12,0,3,1
-20821,3,18120,1,8,Ambition Legs,307,100,12,0,4,1
-20539,3,15100,1,4,Capable Boots,307,90,14,0,0,1
-20540,3,15100,1,4,Capable Boots,307,90,14,0,1,1
-20541,3,15100,1,4,Capable Boots,307,90,14,0,2,1
-20542,3,15100,1,4,Capable Boots,307,90,14,0,3,1
-20543,3,15100,1,4,Capable Boots,307,90,14,0,4,1
-20544,3,15855,1,9,Cuivre Legs,307,93,14,0,0,1
-20545,3,15855,1,9,Cuivre Legs,307,93,14,0,1,1
-20546,3,15855,1,9,Cuivre Legs,307,93,14,0,2,1
-20547,3,15855,1,9,Cuivre Legs,307,93,14,0,3,1
-20548,3,15855,1,9,Cuivre Legs,307,93,14,0,4,1
-20549,3,16610,1,14,Mehizaf Banded,307,95,14,0,0,1
-20550,3,16610,1,14,Mehizaf Banded,307,95,14,0,1,1
-20551,3,16610,1,14,Mehizaf Banded,307,95,14,0,2,1
-20552,3,16610,1,14,Mehizaf Banded,307,95,14,0,3,1
-20553,3,16610,1,14,Mehizaf Banded,307,95,14,0,4,1
-20867,3,16610,1,14,Hardy Bottoms,307,95,14,0,0,1
-20868,3,16610,1,14,Hardy Bottoms,307,95,14,0,1,1
-20869,3,16610,1,14,Hardy Bottoms,307,95,14,0,2,1
-20870,3,16610,1,14,Hardy Bottoms,307,95,14,0,3,1
-20871,3,16610,1,14,Hardy Bottoms,307,95,14,0,4,1
-20872,3,17365,1,3,Taciturne Cuisses,307,98,14,0,0,1
-20873,3,17365,1,3,Taciturne Cuisses,307,98,14,0,1,1
-20874,3,17365,1,3,Taciturne Cuisses,307,98,14,0,2,1
-20875,3,17365,1,3,Taciturne Cuisses,307,98,14,0,3,1
-20876,3,17365,1,3,Taciturne Cuisses,307,98,14,0,4,1
-20877,3,18120,1,8,Mission Greaves,307,100,14,0,0,1
-20878,3,18120,1,8,Mission Greaves,307,100,14,0,1,1
-20879,3,18120,1,8,Mission Greaves,307,100,14,0,2,1
-20880,3,18120,1,8,Mission Greaves,307,100,14,0,3,1
-20881,3,18120,1,8,Mission Greaves,307,100,14,0,4,1
-20599,3,15100,1,4,Waistcloth of Sacrament,307,90,15,0,0,1
-20600,3,15100,1,4,Waistcloth of Sacrament,307,90,15,0,1,1
-20601,3,15100,1,4,Waistcloth of Sacrament,307,90,15,0,2,1
-20602,3,15100,1,4,Waistcloth of Sacrament,307,90,15,0,3,1
-20603,3,15100,1,4,Waistcloth of Sacrament,307,90,15,0,4,1
-20604,3,15855,1,9,June Bottoms,307,93,15,0,0,1
-20605,3,15855,1,9,June Bottoms,307,93,15,0,1,1
-20606,3,15855,1,9,June Bottoms,307,93,15,0,2,1
-20607,3,15855,1,9,June Bottoms,307,93,15,0,3,1
-20608,3,15855,1,9,June Bottoms,307,93,15,0,4,1
-20609,3,16610,1,14,Mehizaf Boots,307,95,15,0,0,1
-20610,3,16610,1,14,Mehizaf Boots,307,95,15,0,1,1
-20611,3,16610,1,14,Mehizaf Boots,307,95,15,0,2,1
-20612,3,16610,1,14,Mehizaf Boots,307,95,15,0,3,1
-20613,3,16610,1,14,Mehizaf Boots,307,95,15,0,4,1
-20927,3,16610,1,14,Miséricorde Shoes,307,95,15,0,0,1
-20928,3,16610,1,14,Miséricorde Shoes,307,95,15,0,1,1
-20929,3,16610,1,14,Miséricorde Shoes,307,95,15,0,2,1
-20930,3,16610,1,14,Miséricorde Shoes,307,95,15,0,3,1
-20931,3,16610,1,14,Miséricorde Shoes,307,95,15,0,4,1
-20932,3,17365,1,3,Charité Boots,307,98,15,0,0,1
-20933,3,17365,1,3,Charité Boots,307,98,15,0,1,1
-20934,3,17365,1,3,Charité Boots,307,98,15,0,2,1
-20935,3,17365,1,3,Charité Boots,307,98,15,0,3,1
-20936,3,17365,1,3,Charité Boots,307,98,15,0,4,1
-20937,3,18120,1,8,Redoutable Boots,307,100,15,0,0,1
-20938,3,18120,1,8,Redoutable Boots,307,100,15,0,1,1
-20939,3,18120,1,8,Redoutable Boots,307,100,15,0,2,1
-20940,3,18120,1,8,Redoutable Boots,307,100,15,0,3,1
-20941,3,18120,1,8,Redoutable Boots,307,100,15,0,4,1
-20659,3,15100,1,4,Pundit Greaves,307,90,17,0,0,1
-20660,3,15100,1,4,Pundit Greaves,307,90,17,0,1,1
-20661,3,15100,1,4,Pundit Greaves,307,90,17,0,2,1
-20662,3,15100,1,4,Pundit Greaves,307,90,17,0,3,1
-20663,3,15100,1,4,Pundit Greaves,307,90,17,0,4,1
-20664,3,15855,1,9,Briller Poleyn,307,93,17,0,0,1
-20665,3,15855,1,9,Briller Poleyn,307,93,17,0,1,1
-20666,3,15855,1,9,Briller Poleyn,307,93,17,0,2,1
-20667,3,15855,1,9,Briller Poleyn,307,93,17,0,3,1
-20668,3,15855,1,9,Briller Poleyn,307,93,17,0,4,1
-20669,3,16610,1,14,Mehizaf Cuirass,307,95,17,0,0,1
-20670,3,16610,1,14,Mehizaf Cuirass,307,95,17,0,1,1
-20671,3,16610,1,14,Mehizaf Cuirass,307,95,17,0,2,1
-20672,3,16610,1,14,Mehizaf Cuirass,307,95,17,0,3,1
-20673,3,16610,1,14,Mehizaf Cuirass,307,95,17,0,4,1
-20987,3,16610,1,14,Positivité Greaves,307,95,17,0,0,1
-20988,3,16610,1,14,Positivité Greaves,307,95,17,0,1,1
-20989,3,16610,1,14,Positivité Greaves,307,95,17,0,2,1
-20990,3,16610,1,14,Positivité Greaves,307,95,17,0,3,1
-20991,3,16610,1,14,Positivité Greaves,307,95,17,0,4,1
-20992,3,17365,1,3,Solidarité Bottoms,307,98,17,0,0,1
-20993,3,17365,1,3,Solidarité Bottoms,307,98,17,0,1,1
-20994,3,17365,1,3,Solidarité Bottoms,307,98,17,0,2,1
-20995,3,17365,1,3,Solidarité Bottoms,307,98,17,0,3,1
-20996,3,17365,1,3,Solidarité Bottoms,307,98,17,0,4,1
-20997,3,18120,1,8,Ideal Legs,307,100,17,0,0,1
-20998,3,18120,1,8,Ideal Legs,307,100,17,0,1,1
-20999,3,18120,1,8,Ideal Legs,307,100,17,0,2,1
-21000,3,18120,1,8,Ideal Legs,307,100,17,0,3,1
-21001,3,18120,1,8,Ideal Legs,307,100,17,0,4,1
+18584,3,15000,1,45,Black Venom Boots,307,1,0,3,0,1
+18585,3,15000,1,50,Black Venom Boots,307,1,0,3,1,1
+18586,3,15000,1,55,Black Venom Boots,307,1,0,3,2,1
+18587,3,15000,1,60,Black Venom Boots,307,1,0,3,3,1
+18588,3,15000,1,70,Black Venom Boots,307,1,0,3,4,1
+19251,3,0,1,90,Armor of the First King,307,80,0,3,0,1
+19252,3,0,1,100,Armor of the First King,307,80,0,3,1,1
+19253,3,0,1,105,Armor of the First King,307,80,0,3,2,1
+19254,3,0,1,110,Armor of the First King,307,80,0,3,3,1
+19255,3,0,1,120,Armor of the First King,307,80,0,3,4,1
+19457,3,10000,1,80,Boundless Tempest Cuisses,307,1,0,3,4,1
+19461,3,10000,1,83,Boundless Tempest Boots,307,1,0,3,4,1
+20479,3,15100,1,100,Maddest Greaves,307,90,12,0,0,1
+20480,3,15100,1,100,Maddest Greaves,307,90,12,0,1,1
+20481,3,15100,1,100,Maddest Greaves,307,90,12,0,2,1
+20482,3,15100,1,100,Maddest Greaves,307,90,12,0,3,1
+20483,3,15100,1,100,Maddest Greaves,307,90,12,0,4,1
+20484,3,15855,1,105,Corail Cuisses,307,93,12,0,0,1
+20485,3,15855,1,105,Corail Cuisses,307,93,12,0,1,1
+20486,3,15855,1,105,Corail Cuisses,307,93,12,0,2,1
+20487,3,15855,1,105,Corail Cuisses,307,93,12,0,3,1
+20488,3,15855,1,105,Corail Cuisses,307,93,12,0,4,1
+20489,3,16610,1,110,Mehizaf Poleyn,307,95,12,0,0,1
+20490,3,16610,1,110,Mehizaf Poleyn,307,95,12,0,1,1
+20491,3,16610,1,110,Mehizaf Poleyn,307,95,12,0,2,1
+20492,3,16610,1,110,Mehizaf Poleyn,307,95,12,0,3,1
+20493,3,16610,1,110,Mehizaf Poleyn,307,95,12,0,4,1
+20807,3,16610,1,110,Courage Boots,307,95,12,0,0,1
+20808,3,16610,1,110,Courage Boots,307,95,12,0,1,1
+20809,3,16610,1,110,Courage Boots,307,95,12,0,2,1
+20810,3,16610,1,110,Courage Boots,307,95,12,0,3,1
+20811,3,16610,1,110,Courage Boots,307,95,12,0,4,1
+20812,3,17365,1,115,Confidence Greaves,307,98,12,0,0,1
+20813,3,17365,1,115,Confidence Greaves,307,98,12,0,1,1
+20814,3,17365,1,115,Confidence Greaves,307,98,12,0,2,1
+20815,3,17365,1,115,Confidence Greaves,307,98,12,0,3,1
+20816,3,17365,1,115,Confidence Greaves,307,98,12,0,4,1
+20817,3,18120,1,120,Ambition Legs,307,100,12,0,0,1
+20818,3,18120,1,120,Ambition Legs,307,100,12,0,1,1
+20819,3,18120,1,120,Ambition Legs,307,100,12,0,2,1
+20820,3,18120,1,120,Ambition Legs,307,100,12,0,3,1
+20821,3,18120,1,120,Ambition Legs,307,100,12,0,4,1
+20539,3,15100,1,100,Capable Boots,307,90,14,0,0,1
+20540,3,15100,1,100,Capable Boots,307,90,14,0,1,1
+20541,3,15100,1,100,Capable Boots,307,90,14,0,2,1
+20542,3,15100,1,100,Capable Boots,307,90,14,0,3,1
+20543,3,15100,1,100,Capable Boots,307,90,14,0,4,1
+20544,3,15855,1,105,Cuivre Legs,307,93,14,0,0,1
+20545,3,15855,1,105,Cuivre Legs,307,93,14,0,1,1
+20546,3,15855,1,105,Cuivre Legs,307,93,14,0,2,1
+20547,3,15855,1,105,Cuivre Legs,307,93,14,0,3,1
+20548,3,15855,1,105,Cuivre Legs,307,93,14,0,4,1
+20549,3,16610,1,110,Mehizaf Banded,307,95,14,0,0,1
+20550,3,16610,1,110,Mehizaf Banded,307,95,14,0,1,1
+20551,3,16610,1,110,Mehizaf Banded,307,95,14,0,2,1
+20552,3,16610,1,110,Mehizaf Banded,307,95,14,0,3,1
+20553,3,16610,1,110,Mehizaf Banded,307,95,14,0,4,1
+20867,3,16610,1,110,Hardy Bottoms,307,95,14,0,0,1
+20868,3,16610,1,110,Hardy Bottoms,307,95,14,0,1,1
+20869,3,16610,1,110,Hardy Bottoms,307,95,14,0,2,1
+20870,3,16610,1,110,Hardy Bottoms,307,95,14,0,3,1
+20871,3,16610,1,110,Hardy Bottoms,307,95,14,0,4,1
+20872,3,17365,1,115,Taciturne Cuisses,307,98,14,0,0,1
+20873,3,17365,1,115,Taciturne Cuisses,307,98,14,0,1,1
+20874,3,17365,1,115,Taciturne Cuisses,307,98,14,0,2,1
+20875,3,17365,1,115,Taciturne Cuisses,307,98,14,0,3,1
+20876,3,17365,1,115,Taciturne Cuisses,307,98,14,0,4,1
+20877,3,18120,1,120,Mission Greaves,307,100,14,0,0,1
+20878,3,18120,1,120,Mission Greaves,307,100,14,0,1,1
+20879,3,18120,1,120,Mission Greaves,307,100,14,0,2,1
+20880,3,18120,1,120,Mission Greaves,307,100,14,0,3,1
+20881,3,18120,1,120,Mission Greaves,307,100,14,0,4,1
+20599,3,15100,1,100,Waistcloth of Sacrament,307,90,15,0,0,1
+20600,3,15100,1,100,Waistcloth of Sacrament,307,90,15,0,1,1
+20601,3,15100,1,100,Waistcloth of Sacrament,307,90,15,0,2,1
+20602,3,15100,1,100,Waistcloth of Sacrament,307,90,15,0,3,1
+20603,3,15100,1,100,Waistcloth of Sacrament,307,90,15,0,4,1
+20604,3,15855,1,105,June Bottoms,307,93,15,0,0,1
+20605,3,15855,1,105,June Bottoms,307,93,15,0,1,1
+20606,3,15855,1,105,June Bottoms,307,93,15,0,2,1
+20607,3,15855,1,105,June Bottoms,307,93,15,0,3,1
+20608,3,15855,1,105,June Bottoms,307,93,15,0,4,1
+20609,3,16610,1,110,Mehizaf Boots,307,95,15,0,0,1
+20610,3,16610,1,110,Mehizaf Boots,307,95,15,0,1,1
+20611,3,16610,1,110,Mehizaf Boots,307,95,15,0,2,1
+20612,3,16610,1,110,Mehizaf Boots,307,95,15,0,3,1
+20613,3,16610,1,110,Mehizaf Boots,307,95,15,0,4,1
+20927,3,16610,1,110,Miséricorde Shoes,307,95,15,0,0,1
+20928,3,16610,1,110,Miséricorde Shoes,307,95,15,0,1,1
+20929,3,16610,1,110,Miséricorde Shoes,307,95,15,0,2,1
+20930,3,16610,1,110,Miséricorde Shoes,307,95,15,0,3,1
+20931,3,16610,1,110,Miséricorde Shoes,307,95,15,0,4,1
+20932,3,17365,1,115,Charité Boots,307,98,15,0,0,1
+20933,3,17365,1,115,Charité Boots,307,98,15,0,1,1
+20934,3,17365,1,115,Charité Boots,307,98,15,0,2,1
+20935,3,17365,1,115,Charité Boots,307,98,15,0,3,1
+20936,3,17365,1,115,Charité Boots,307,98,15,0,4,1
+20937,3,18120,1,120,Redoutable Boots,307,100,15,0,0,1
+20938,3,18120,1,120,Redoutable Boots,307,100,15,0,1,1
+20939,3,18120,1,120,Redoutable Boots,307,100,15,0,2,1
+20940,3,18120,1,120,Redoutable Boots,307,100,15,0,3,1
+20941,3,18120,1,120,Redoutable Boots,307,100,15,0,4,1
+20659,3,15100,1,100,Pundit Greaves,307,90,17,0,0,1
+20660,3,15100,1,100,Pundit Greaves,307,90,17,0,1,1
+20661,3,15100,1,100,Pundit Greaves,307,90,17,0,2,1
+20662,3,15100,1,100,Pundit Greaves,307,90,17,0,3,1
+20663,3,15100,1,100,Pundit Greaves,307,90,17,0,4,1
+20664,3,15855,1,105,Briller Poleyn,307,93,17,0,0,1
+20665,3,15855,1,105,Briller Poleyn,307,93,17,0,1,1
+20666,3,15855,1,105,Briller Poleyn,307,93,17,0,2,1
+20667,3,15855,1,105,Briller Poleyn,307,93,17,0,3,1
+20668,3,15855,1,105,Briller Poleyn,307,93,17,0,4,1
+20669,3,16610,1,110,Mehizaf Cuirass,307,95,17,0,0,1
+20670,3,16610,1,110,Mehizaf Cuirass,307,95,17,0,1,1
+20671,3,16610,1,110,Mehizaf Cuirass,307,95,17,0,2,1
+20672,3,16610,1,110,Mehizaf Cuirass,307,95,17,0,3,1
+20673,3,16610,1,110,Mehizaf Cuirass,307,95,17,0,4,1
+20987,3,16610,1,110,Positivité Greaves,307,95,17,0,0,1
+20988,3,16610,1,110,Positivité Greaves,307,95,17,0,1,1
+20989,3,16610,1,110,Positivité Greaves,307,95,17,0,2,1
+20990,3,16610,1,110,Positivité Greaves,307,95,17,0,3,1
+20991,3,16610,1,110,Positivité Greaves,307,95,17,0,4,1
+20992,3,17365,1,115,Solidarité Bottoms,307,98,17,0,0,1
+20993,3,17365,1,115,Solidarité Bottoms,307,98,17,0,1,1
+20994,3,17365,1,115,Solidarité Bottoms,307,98,17,0,2,1
+20995,3,17365,1,115,Solidarité Bottoms,307,98,17,0,3,1
+20996,3,17365,1,115,Solidarité Bottoms,307,98,17,0,4,1
+20997,3,18120,1,120,Ideal Legs,307,100,17,0,0,1
+20998,3,18120,1,120,Ideal Legs,307,100,17,0,1,1
+20999,3,18120,1,120,Ideal Legs,307,100,17,0,2,1
+21000,3,18120,1,120,Ideal Legs,307,100,17,0,3,1
+21001,3,18120,1,120,Ideal Legs,307,100,17,0,4,1
 20696,3,100,1,1,War God's Full Armor,307,1,0,0,4,1
 21032,3,100,1,1,Refined Legs,307,1,0,0,4,1
 21037,3,100,1,1,Noble Legs,307,1,0,0,4,1
-21115,3,10000,1,12,Maestro Cuisses,307,1,0,3,4,1
-20754,3,10000,1,10,Crimson Leather Boots,307,90,0,3,4,1
-21097,3,10000,1,4,White Smoke Leather Boots,307,95,0,3,4,1
+21115,3,10000,1,92,Maestro Cuisses,307,1,0,3,4,1
+20754,3,10000,1,106,Crimson Leather Boots,307,90,0,3,4,1
+21097,3,10000,1,116,White Smoke Leather Boots,307,95,0,3,4,1
 20761,3,10000,1,7,Midsummer Surf Pants (Red),307,1,0,0,0,2
-21164,3,10000,1,15,Virtuoso Cuisses,307,1,0,3,4,1
-21172,3,10000,1,12,Lord Knight Leather Boots,307,90,0,3,4,1
-21180,3,10000,1,6,Selenite Leather Boots,307,95,0,3,4,1
+21164,3,10000,1,95,Virtuoso Cuisses,307,1,0,3,4,1
+21172,3,10000,1,108,Lord Knight Leather Boots,307,90,0,3,4,1
+21180,3,10000,1,118,Selenite Leather Boots,307,95,0,3,4,1
 21339,3,10000,1,7,Midsummer Surf Pants (Yellow),307,1,0,0,0,2
 21340,3,10000,1,7,Midsummer Surf Pants (Blue),307,1,0,0,0,2
 21341,3,10000,1,7,Midsummer Surf Pants (Purple),307,1,0,0,0,2
@@ -18507,180 +18507,180 @@
 21343,3,10000,1,7,Midsummer Surf Pants (Black),307,1,0,0,0,2
 21399,3,500,1,12,Cursed Cuisses,307,1,0,0,0,1
 21403,3,500,1,12,Chaos Legs,307,1,0,0,0,1
-21701,3,10000,1,11,Winter Boots (White),307,1,0,0,4,1
-21702,3,10000,1,11,Winter Boots (Black),307,1,0,0,4,1
-21703,3,10000,1,11,Winter Boots (Brown),307,1,0,0,4,1
+21701,3,10000,1,75,Winter Boots (White),307,1,0,0,4,1
+21702,3,10000,1,75,Winter Boots (Black),307,1,0,0,4,1
+21703,3,10000,1,75,Winter Boots (Brown),307,1,0,0,4,1
 23458,3,100,1,1,Reindeer's Mouton Boots (Brown),307,1,0,0,4,1
 23459,3,100,1,1,Reindeer's Mouton Boots (White),307,1,0,0,4,1
-24174,3,0,1,2,Spirit's Heavy Armored Leg Gear,307,100,12,0,0,1
-24175,3,0,1,2,Spirit's Heavy Armored Leg Gear,307,100,12,0,1,1
-24176,3,0,1,2,Spirit's Heavy Armored Leg Gear,307,100,12,0,2,1
-24177,3,0,1,2,Spirit's Heavy Armored Leg Gear,307,100,12,0,3,1
-24178,3,0,1,2,Spirit's Heavy Armored Leg Gear,307,100,12,0,4,1
-24179,3,0,1,2,Fire King's Heavy Armored Leg Gear,307,100,12,0,0,1
-24180,3,0,1,2,Fire King's Heavy Armored Leg Gear,307,100,12,0,1,1
-24181,3,0,1,2,Fire King's Heavy Armored Leg Gear,307,100,12,0,2,1
-24182,3,0,1,2,Fire King's Heavy Armored Leg Gear,307,100,12,0,3,1
-24183,3,0,1,2,Fire King's Heavy Armored Leg Gear,307,100,12,0,4,1
-24184,3,0,1,2,White Wings' Heavy Armored Leg Gear,307,100,12,0,0,1
-24185,3,0,1,2,White Wings' Heavy Armored Leg Gear,307,100,12,0,1,1
-24186,3,0,1,2,White Wings' Heavy Armored Leg Gear,307,100,12,0,2,1
-24187,3,0,1,2,White Wings' Heavy Armored Leg Gear,307,100,12,0,3,1
-24188,3,0,1,2,White Wings' Heavy Armored Leg Gear,307,100,12,0,4,1
-24189,3,0,1,2,Golden Heavy Leg Armor,307,100,12,0,0,1
-24190,3,0,1,2,Golden Heavy Leg Armor,307,100,12,0,1,1
-24191,3,0,1,2,Golden Heavy Leg Armor,307,100,12,0,2,1
-24192,3,0,1,2,Golden Heavy Leg Armor,307,100,12,0,3,1
-24193,3,0,1,2,Golden Heavy Leg Armor,307,100,12,0,4,1
-24194,3,0,1,7,Blackshatter Heavy Armor Leg,307,100,12,0,0,1
-24195,3,0,1,7,Blackshatter Heavy Armor Leg,307,100,12,0,1,1
-24196,3,0,1,7,Blackshatter Heavy Armor Leg,307,100,12,0,2,1
-24197,3,0,1,7,Blackshatter Heavy Armor Leg,307,100,12,0,3,1
-24198,3,0,1,7,Blackshatter Heavy Armor Leg,307,100,12,0,4,1
-24274,3,0,1,2,Spirit Light Armored Leg Gear,307,100,14,0,0,1
-24275,3,0,1,2,Spirit Light Armored Leg Gear,307,100,14,0,1,1
-24276,3,0,1,2,Spirit Light Armored Leg Gear,307,100,14,0,2,1
-24277,3,0,1,2,Spirit Light Armored Leg Gear,307,100,14,0,3,1
-24278,3,0,1,2,Spirit Light Armored Leg Gear,307,100,14,0,4,1
-24279,3,0,1,2,Fire King's Armored Leg Gear,307,100,14,0,0,1
-24280,3,0,1,2,Fire King's Armored Leg Gear,307,100,14,0,1,1
-24281,3,0,1,2,Fire King's Armored Leg Gear,307,100,14,0,2,1
-24282,3,0,1,2,Fire King's Armored Leg Gear,307,100,14,0,3,1
-24283,3,0,1,2,Fire King's Armored Leg Gear,307,100,14,0,4,1
-24284,3,0,1,2,White Wings' Light Armored Leg Gear,307,100,14,0,0,1
-24285,3,0,1,2,White Wings' Light Armored Leg Gear,307,100,14,0,1,1
-24286,3,0,1,2,White Wings' Light Armored Leg Gear,307,100,14,0,2,1
-24287,3,0,1,2,White Wings' Light Armored Leg Gear,307,100,14,0,3,1
-24288,3,0,1,2,White Wings' Light Armored Leg Gear,307,100,14,0,4,1
-24289,3,0,1,2,Golden Light Armor Legs,307,100,14,0,0,1
-24290,3,0,1,2,Golden Light Armor Legs,307,100,14,0,1,1
-24291,3,0,1,2,Golden Light Armor Legs,307,100,14,0,2,1
-24292,3,0,1,2,Golden Light Armor Legs,307,100,14,0,3,1
-24293,3,0,1,2,Golden Light Armor Legs,307,100,14,0,4,1
-24294,3,0,1,7,Blackshatter light armor leg,307,100,14,0,0,1
-24295,3,0,1,7,Blackshatter light armor leg,307,100,14,0,1,1
-24296,3,0,1,7,Blackshatter light armor leg,307,100,14,0,2,1
-24297,3,0,1,7,Blackshatter light armor leg,307,100,14,0,3,1
-24298,3,0,1,7,Blackshatter light armor leg,307,100,14,0,4,1
-24374,3,0,1,2,Spirit's Magick Boots,307,100,15,0,0,1
-24375,3,0,1,2,Spirit's Magick Boots,307,100,15,0,1,1
-24376,3,0,1,2,Spirit's Magick Boots,307,100,15,0,2,1
-24377,3,0,1,2,Spirit's Magick Boots,307,100,15,0,3,1
-24378,3,0,1,2,Spirit's Magick Boots,307,100,15,0,4,1
-24379,3,0,1,2,Fire King's Magick Boots,307,100,15,0,0,1
-24380,3,0,1,2,Fire King's Magick Boots,307,100,15,0,1,1
-24381,3,0,1,2,Fire King's Magick Boots,307,100,15,0,2,1
-24382,3,0,1,2,Fire King's Magick Boots,307,100,15,0,3,1
-24383,3,0,1,2,Fire King's Magick Boots,307,100,15,0,4,1
-24384,3,0,1,2,White Wings's Magick Boots,307,100,15,0,0,1
-24385,3,0,1,2,White Wings's Magick Boots,307,100,15,0,1,1
-24386,3,0,1,2,White Wings's Magick Boots,307,100,15,0,2,1
-24387,3,0,1,2,White Wings's Magick Boots,307,100,15,0,3,1
-24388,3,0,1,2,White Wings's Magick Boots,307,100,15,0,4,1
-24389,3,0,1,2,Golden Magick Boots,307,100,15,0,0,1
-24390,3,0,1,2,Golden Magick Boots,307,100,15,0,1,1
-24391,3,0,1,2,Golden Magick Boots,307,100,15,0,2,1
-24392,3,0,1,2,Golden Magick Boots,307,100,15,0,3,1
-24393,3,0,1,2,Golden Magick Boots,307,100,15,0,4,1
-24394,3,0,1,7,Blackshatter Magic Boots,307,100,15,0,0,1
-24395,3,0,1,7,Blackshatter Magic Boots,307,100,15,0,1,1
-24396,3,0,1,7,Blackshatter Magic Boots,307,100,15,0,2,1
-24397,3,0,1,7,Blackshatter Magic Boots,307,100,15,0,3,1
-24398,3,0,1,7,Blackshatter Magic Boots,307,100,15,0,4,1
-24474,3,0,1,2,Spirit's Magick Combat Legs,307,100,17,0,0,1
-24475,3,0,1,2,Spirit's Magick Combat Legs,307,100,17,0,1,1
-24476,3,0,1,2,Spirit's Magick Combat Legs,307,100,17,0,2,1
-24477,3,0,1,2,Spirit's Magick Combat Legs,307,100,17,0,3,1
-24478,3,0,1,2,Spirit's Magick Combat Legs,307,100,17,0,4,1
-24479,3,0,1,2,Fire King's Magick Combat Legs,307,100,17,0,0,1
-24480,3,0,1,2,Fire King's Magick Combat Legs,307,100,17,0,1,1
-24481,3,0,1,2,Fire King's Magick Combat Legs,307,100,17,0,2,1
-24482,3,0,1,2,Fire King's Magick Combat Legs,307,100,17,0,3,1
-24483,3,0,1,2,Fire King's Magick Combat Legs,307,100,17,0,4,1
-24484,3,0,1,2,White Wings' Combat Legs,307,100,17,0,0,1
-24485,3,0,1,2,White Wings' Combat Legs,307,100,17,0,1,1
-24486,3,0,1,2,White Wings' Combat Legs,307,100,17,0,2,1
-24487,3,0,1,2,White Wings' Combat Legs,307,100,17,0,3,1
-24488,3,0,1,2,White Wings' Combat Legs,307,100,17,0,4,1
-24489,3,0,1,2,Golden Magick Battle Boots,307,100,17,0,0,1
-24490,3,0,1,2,Golden Magick Battle Boots,307,100,17,0,1,1
-24491,3,0,1,2,Golden Magick Battle Boots,307,100,17,0,2,1
-24492,3,0,1,2,Golden Magick Battle Boots,307,100,17,0,3,1
-24493,3,0,1,2,Golden Magick Battle Boots,307,100,17,0,4,1
-24494,3,0,1,7,Blackshatter Magic Leg,307,100,17,0,0,1
-24495,3,0,1,7,Blackshatter Magic Leg,307,100,17,0,1,1
-24496,3,0,1,7,Blackshatter Magic Leg,307,100,17,0,2,1
-24497,3,0,1,7,Blackshatter Magic Leg,307,100,17,0,3,1
-24498,3,0,1,7,Blackshatter Magic Leg,307,100,17,0,4,1
+24174,3,0,1,130,Spirit's Heavy Armored Leg Gear,307,100,12,0,0,1
+24175,3,0,1,130,Spirit's Heavy Armored Leg Gear,307,100,12,0,1,1
+24176,3,0,1,130,Spirit's Heavy Armored Leg Gear,307,100,12,0,2,1
+24177,3,0,1,130,Spirit's Heavy Armored Leg Gear,307,100,12,0,3,1
+24178,3,0,1,130,Spirit's Heavy Armored Leg Gear,307,100,12,0,4,1
+24179,3,0,1,130,Fire King's Heavy Armored Leg Gear,307,100,12,0,0,1
+24180,3,0,1,130,Fire King's Heavy Armored Leg Gear,307,100,12,0,1,1
+24181,3,0,1,130,Fire King's Heavy Armored Leg Gear,307,100,12,0,2,1
+24182,3,0,1,130,Fire King's Heavy Armored Leg Gear,307,100,12,0,3,1
+24183,3,0,1,130,Fire King's Heavy Armored Leg Gear,307,100,12,0,4,1
+24184,3,0,1,130,White Wings' Heavy Armored Leg Gear,307,100,12,0,0,1
+24185,3,0,1,130,White Wings' Heavy Armored Leg Gear,307,100,12,0,1,1
+24186,3,0,1,130,White Wings' Heavy Armored Leg Gear,307,100,12,0,2,1
+24187,3,0,1,130,White Wings' Heavy Armored Leg Gear,307,100,12,0,3,1
+24188,3,0,1,130,White Wings' Heavy Armored Leg Gear,307,100,12,0,4,1
+24189,3,0,1,130,Golden Heavy Leg Armor,307,100,12,0,0,1
+24190,3,0,1,130,Golden Heavy Leg Armor,307,100,12,0,1,1
+24191,3,0,1,130,Golden Heavy Leg Armor,307,100,12,0,2,1
+24192,3,0,1,130,Golden Heavy Leg Armor,307,100,12,0,3,1
+24193,3,0,1,130,Golden Heavy Leg Armor,307,100,12,0,4,1
+24194,3,0,1,135,Blackshatter Heavy Armor Leg,307,100,12,0,0,1
+24195,3,0,1,135,Blackshatter Heavy Armor Leg,307,100,12,0,1,1
+24196,3,0,1,135,Blackshatter Heavy Armor Leg,307,100,12,0,2,1
+24197,3,0,1,135,Blackshatter Heavy Armor Leg,307,100,12,0,3,1
+24198,3,0,1,135,Blackshatter Heavy Armor Leg,307,100,12,0,4,1
+24274,3,0,1,130,Spirit Light Armored Leg Gear,307,100,14,0,0,1
+24275,3,0,1,130,Spirit Light Armored Leg Gear,307,100,14,0,1,1
+24276,3,0,1,130,Spirit Light Armored Leg Gear,307,100,14,0,2,1
+24277,3,0,1,130,Spirit Light Armored Leg Gear,307,100,14,0,3,1
+24278,3,0,1,130,Spirit Light Armored Leg Gear,307,100,14,0,4,1
+24279,3,0,1,130,Fire King's Armored Leg Gear,307,100,14,0,0,1
+24280,3,0,1,130,Fire King's Armored Leg Gear,307,100,14,0,1,1
+24281,3,0,1,130,Fire King's Armored Leg Gear,307,100,14,0,2,1
+24282,3,0,1,130,Fire King's Armored Leg Gear,307,100,14,0,3,1
+24283,3,0,1,130,Fire King's Armored Leg Gear,307,100,14,0,4,1
+24284,3,0,1,130,White Wings' Light Armored Leg Gear,307,100,14,0,0,1
+24285,3,0,1,130,White Wings' Light Armored Leg Gear,307,100,14,0,1,1
+24286,3,0,1,130,White Wings' Light Armored Leg Gear,307,100,14,0,2,1
+24287,3,0,1,130,White Wings' Light Armored Leg Gear,307,100,14,0,3,1
+24288,3,0,1,130,White Wings' Light Armored Leg Gear,307,100,14,0,4,1
+24289,3,0,1,130,Golden Light Armor Legs,307,100,14,0,0,1
+24290,3,0,1,130,Golden Light Armor Legs,307,100,14,0,1,1
+24291,3,0,1,130,Golden Light Armor Legs,307,100,14,0,2,1
+24292,3,0,1,130,Golden Light Armor Legs,307,100,14,0,3,1
+24293,3,0,1,130,Golden Light Armor Legs,307,100,14,0,4,1
+24294,3,0,1,135,Blackshatter light armor leg,307,100,14,0,0,1
+24295,3,0,1,135,Blackshatter light armor leg,307,100,14,0,1,1
+24296,3,0,1,135,Blackshatter light armor leg,307,100,14,0,2,1
+24297,3,0,1,135,Blackshatter light armor leg,307,100,14,0,3,1
+24298,3,0,1,135,Blackshatter light armor leg,307,100,14,0,4,1
+24374,3,0,1,130,Spirit's Magick Boots,307,100,15,0,0,1
+24375,3,0,1,130,Spirit's Magick Boots,307,100,15,0,1,1
+24376,3,0,1,130,Spirit's Magick Boots,307,100,15,0,2,1
+24377,3,0,1,130,Spirit's Magick Boots,307,100,15,0,3,1
+24378,3,0,1,130,Spirit's Magick Boots,307,100,15,0,4,1
+24379,3,0,1,130,Fire King's Magick Boots,307,100,15,0,0,1
+24380,3,0,1,130,Fire King's Magick Boots,307,100,15,0,1,1
+24381,3,0,1,130,Fire King's Magick Boots,307,100,15,0,2,1
+24382,3,0,1,130,Fire King's Magick Boots,307,100,15,0,3,1
+24383,3,0,1,130,Fire King's Magick Boots,307,100,15,0,4,1
+24384,3,0,1,130,White Wings's Magick Boots,307,100,15,0,0,1
+24385,3,0,1,130,White Wings's Magick Boots,307,100,15,0,1,1
+24386,3,0,1,130,White Wings's Magick Boots,307,100,15,0,2,1
+24387,3,0,1,130,White Wings's Magick Boots,307,100,15,0,3,1
+24388,3,0,1,130,White Wings's Magick Boots,307,100,15,0,4,1
+24389,3,0,1,130,Golden Magick Boots,307,100,15,0,0,1
+24390,3,0,1,130,Golden Magick Boots,307,100,15,0,1,1
+24391,3,0,1,130,Golden Magick Boots,307,100,15,0,2,1
+24392,3,0,1,130,Golden Magick Boots,307,100,15,0,3,1
+24393,3,0,1,130,Golden Magick Boots,307,100,15,0,4,1
+24394,3,0,1,135,Blackshatter Magic Boots,307,100,15,0,0,1
+24395,3,0,1,135,Blackshatter Magic Boots,307,100,15,0,1,1
+24396,3,0,1,135,Blackshatter Magic Boots,307,100,15,0,2,1
+24397,3,0,1,135,Blackshatter Magic Boots,307,100,15,0,3,1
+24398,3,0,1,135,Blackshatter Magic Boots,307,100,15,0,4,1
+24474,3,0,1,130,Spirit's Magick Combat Legs,307,100,17,0,0,1
+24475,3,0,1,130,Spirit's Magick Combat Legs,307,100,17,0,1,1
+24476,3,0,1,130,Spirit's Magick Combat Legs,307,100,17,0,2,1
+24477,3,0,1,130,Spirit's Magick Combat Legs,307,100,17,0,3,1
+24478,3,0,1,130,Spirit's Magick Combat Legs,307,100,17,0,4,1
+24479,3,0,1,130,Fire King's Magick Combat Legs,307,100,17,0,0,1
+24480,3,0,1,130,Fire King's Magick Combat Legs,307,100,17,0,1,1
+24481,3,0,1,130,Fire King's Magick Combat Legs,307,100,17,0,2,1
+24482,3,0,1,130,Fire King's Magick Combat Legs,307,100,17,0,3,1
+24483,3,0,1,130,Fire King's Magick Combat Legs,307,100,17,0,4,1
+24484,3,0,1,130,White Wings' Combat Legs,307,100,17,0,0,1
+24485,3,0,1,130,White Wings' Combat Legs,307,100,17,0,1,1
+24486,3,0,1,130,White Wings' Combat Legs,307,100,17,0,2,1
+24487,3,0,1,130,White Wings' Combat Legs,307,100,17,0,3,1
+24488,3,0,1,130,White Wings' Combat Legs,307,100,17,0,4,1
+24489,3,0,1,130,Golden Magick Battle Boots,307,100,17,0,0,1
+24490,3,0,1,130,Golden Magick Battle Boots,307,100,17,0,1,1
+24491,3,0,1,130,Golden Magick Battle Boots,307,100,17,0,2,1
+24492,3,0,1,130,Golden Magick Battle Boots,307,100,17,0,3,1
+24493,3,0,1,130,Golden Magick Battle Boots,307,100,17,0,4,1
+24494,3,0,1,135,Blackshatter Magic Leg,307,100,17,0,0,1
+24495,3,0,1,135,Blackshatter Magic Leg,307,100,17,0,1,1
+24496,3,0,1,135,Blackshatter Magic Leg,307,100,17,0,2,1
+24497,3,0,1,135,Blackshatter Magic Leg,307,100,17,0,3,1
+24498,3,0,1,135,Blackshatter Magic Leg,307,100,17,0,4,1
 24618,3,0,1,12,Valkyrian Legs,307,1,0,0,4,1
-24701,3,10000,1,2,Survivor Leather Boots,307,1,0,3,4,1
+24701,3,10000,1,130,Survivor Leather Boots,307,1,0,3,4,1
 24926,3,10000,1,1,Winter Boots (Deep Red),307,1,0,0,0,1
 24937,3,10000,1,1,God of War's Armor,307,1,0,0,4,1
 24941,3,10000,1,1,Spriggan Boots,307,1,0,0,4,1
-25016,3,10000,1,2,Combat Leather Boots,307,1,0,3,4,1
+25016,3,10000,1,130,Combat Leather Boots,307,1,0,3,4,1
 25227,3,10000,1,1,Holy Seal's Generous Greaves,307,1,0,0,4,1
 25231,3,10000,1,1,Tricksters' Generous Legs,307,1,0,0,4,1
 25235,3,10000,1,1,Hero's Generous Legs,307,1,0,0,4,1
-25251,3,18500,1,12,Savage Courage Assault Poleyn,307,105,12,0,0,1
-25252,3,18500,1,12,Savage Courage Assault Poleyn,307,105,12,0,1,1
-25253,3,18500,1,12,Savage Courage Assault Poleyn,307,105,12,0,2,1
-25254,3,18500,1,12,Savage Courage Assault Poleyn,307,105,12,0,3,1
-25255,3,18500,1,12,Savage Courage Assault Poleyn,307,105,12,0,4,1
-25271,3,18500,1,1,Solitary Assault Greaves,307,110,12,0,0,1
-25272,3,18500,1,1,Solitary Assault Greaves,307,110,12,0,1,1
-25273,3,18500,1,1,Solitary Assault Greaves,307,110,12,0,2,1
-25274,3,18500,1,1,Solitary Assault Greaves,307,110,12,0,3,1
-25275,3,18500,1,1,Solitary Assault Greaves,307,110,12,0,4,1
-25291,3,18500,1,6,Hero's Assault Cuirass,307,115,12,0,0,1
-25292,3,18500,1,6,Hero's Assault Cuirass,307,115,12,0,1,1
-25293,3,18500,1,6,Hero's Assault Cuirass,307,115,12,0,2,1
-25294,3,18500,1,6,Hero's Assault Cuirass,307,115,12,0,3,1
-25295,3,18500,1,6,Hero's Assault Cuirass,307,115,12,0,4,1
-25311,3,18500,1,12,Savage Courage Snipe Legs,307,105,14,0,0,1
-25312,3,18500,1,12,Savage Courage Snipe Legs,307,105,14,0,1,1
-25313,3,18500,1,12,Savage Courage Snipe Legs,307,105,14,0,2,1
-25314,3,18500,1,12,Savage Courage Snipe Legs,307,105,14,0,3,1
-25315,3,18500,1,12,Savage Courage Snipe Legs,307,105,14,0,4,1
-25331,3,18500,1,1,Solitary's Snipe Cuirass,307,110,14,0,0,1
-25332,3,18500,1,1,Solitary's Snipe Cuirass,307,110,14,0,1,1
-25333,3,18500,1,1,Solitary's Snipe Cuirass,307,110,14,0,2,1
-25334,3,18500,1,1,Solitary's Snipe Cuirass,307,110,14,0,3,1
-25335,3,18500,1,1,Solitary's Snipe Cuirass,307,110,14,0,4,1
-25351,3,18500,1,6,Hero's Snipe Bottom,307,115,14,0,0,1
-25352,3,18500,1,6,Hero's Snipe Bottom,307,115,14,0,1,1
-25353,3,18500,1,6,Hero's Snipe Bottom,307,115,14,0,2,1
-25354,3,18500,1,6,Hero's Snipe Bottom,307,115,14,0,3,1
-25355,3,18500,1,6,Hero's Snipe Bottom,307,115,14,0,4,1
-25371,3,18500,1,12,Savage Courage Magic high boots,307,105,15,0,0,1
-25372,3,18500,1,12,Savage Courage Magic high boots,307,105,15,0,1,1
-25373,3,18500,1,12,Savage Courage Magic high boots,307,105,15,0,2,1
-25374,3,18500,1,12,Savage Courage Magic high boots,307,105,15,0,3,1
-25375,3,18500,1,12,Savage Courage Magic high boots,307,105,15,0,4,1
-25391,3,18500,1,1,Solitary Magic Boots,307,110,15,0,0,1
-25392,3,18500,1,1,Solitary Magic Boots,307,110,15,0,1,1
-25393,3,18500,1,1,Solitary Magic Boots,307,110,15,0,2,1
-25394,3,18500,1,1,Solitary Magic Boots,307,110,15,0,3,1
-25395,3,18500,1,1,Solitary Magic Boots,307,110,15,0,4,1
-25411,3,18500,1,6,Hero's Magic Gloves,307,115,15,0,0,1
-25412,3,18500,1,6,Hero's Magic Gloves,307,115,15,0,1,1
-25413,3,18500,1,6,Hero's Magic Gloves,307,115,15,0,2,1
-25414,3,18500,1,6,Hero's Magic Gloves,307,115,15,0,3,1
-25415,3,18500,1,6,Hero's Magic Gloves,307,115,15,0,4,1
-25431,3,18500,1,12,Savage Courage Ranger Legs,307,105,17,0,0,1
-25432,3,18500,1,12,Savage Courage Ranger Legs,307,105,17,0,1,1
-25433,3,18500,1,12,Savage Courage Ranger Legs,307,105,17,0,2,1
-25434,3,18500,1,12,Savage Courage Ranger Legs,307,105,17,0,3,1
-25435,3,18500,1,12,Savage Courage Ranger Legs,307,105,17,0,4,1
-25451,3,18500,1,1,Solitary Ranger's Bottoms,307,110,17,0,0,1
-25452,3,18500,1,1,Solitary Ranger's Bottoms,307,110,17,0,1,1
-25453,3,18500,1,1,Solitary Ranger's Bottoms,307,110,17,0,2,1
-25454,3,18500,1,1,Solitary Ranger's Bottoms,307,110,17,0,3,1
-25455,3,18500,1,1,Solitary Ranger's Bottoms,307,110,17,0,4,1
-25471,3,18500,1,6,Heroes Ranger Cuirass,307,115,17,0,0,1
-25472,3,18500,1,6,Heroes Ranger Cuirass,307,115,17,0,1,1
-25473,3,18500,1,6,Heroes Ranger Cuirass,307,115,17,0,2,1
-25474,3,18500,1,6,Heroes Ranger Cuirass,307,115,17,0,3,1
-25475,3,18500,1,6,Heroes Ranger Cuirass,307,115,17,0,4,1
+25251,3,18500,1,140,Savage Courage Assault Poleyn,307,105,12,0,0,1
+25252,3,18500,1,140,Savage Courage Assault Poleyn,307,105,12,0,1,1
+25253,3,18500,1,140,Savage Courage Assault Poleyn,307,105,12,0,2,1
+25254,3,18500,1,140,Savage Courage Assault Poleyn,307,105,12,0,3,1
+25255,3,18500,1,140,Savage Courage Assault Poleyn,307,105,12,0,4,1
+25271,3,18500,1,145,Solitary Assault Greaves,307,110,12,0,0,1
+25272,3,18500,1,145,Solitary Assault Greaves,307,110,12,0,1,1
+25273,3,18500,1,145,Solitary Assault Greaves,307,110,12,0,2,1
+25274,3,18500,1,145,Solitary Assault Greaves,307,110,12,0,3,1
+25275,3,18500,1,145,Solitary Assault Greaves,307,110,12,0,4,1
+25291,3,18500,1,150,Hero's Assault Cuirass,307,115,12,0,0,1
+25292,3,18500,1,150,Hero's Assault Cuirass,307,115,12,0,1,1
+25293,3,18500,1,150,Hero's Assault Cuirass,307,115,12,0,2,1
+25294,3,18500,1,150,Hero's Assault Cuirass,307,115,12,0,3,1
+25295,3,18500,1,150,Hero's Assault Cuirass,307,115,12,0,4,1
+25311,3,18500,1,140,Savage Courage Snipe Legs,307,105,14,0,0,1
+25312,3,18500,1,140,Savage Courage Snipe Legs,307,105,14,0,1,1
+25313,3,18500,1,140,Savage Courage Snipe Legs,307,105,14,0,2,1
+25314,3,18500,1,140,Savage Courage Snipe Legs,307,105,14,0,3,1
+25315,3,18500,1,140,Savage Courage Snipe Legs,307,105,14,0,4,1
+25331,3,18500,1,145,Solitary's Snipe Cuirass,307,110,14,0,0,1
+25332,3,18500,1,145,Solitary's Snipe Cuirass,307,110,14,0,1,1
+25333,3,18500,1,145,Solitary's Snipe Cuirass,307,110,14,0,2,1
+25334,3,18500,1,145,Solitary's Snipe Cuirass,307,110,14,0,3,1
+25335,3,18500,1,145,Solitary's Snipe Cuirass,307,110,14,0,4,1
+25351,3,18500,1,150,Hero's Snipe Bottom,307,115,14,0,0,1
+25352,3,18500,1,150,Hero's Snipe Bottom,307,115,14,0,1,1
+25353,3,18500,1,150,Hero's Snipe Bottom,307,115,14,0,2,1
+25354,3,18500,1,150,Hero's Snipe Bottom,307,115,14,0,3,1
+25355,3,18500,1,150,Hero's Snipe Bottom,307,115,14,0,4,1
+25371,3,18500,1,140,Savage Courage Magic high boots,307,105,15,0,0,1
+25372,3,18500,1,140,Savage Courage Magic high boots,307,105,15,0,1,1
+25373,3,18500,1,140,Savage Courage Magic high boots,307,105,15,0,2,1
+25374,3,18500,1,140,Savage Courage Magic high boots,307,105,15,0,3,1
+25375,3,18500,1,140,Savage Courage Magic high boots,307,105,15,0,4,1
+25391,3,18500,1,145,Solitary Magic Boots,307,110,15,0,0,1
+25392,3,18500,1,145,Solitary Magic Boots,307,110,15,0,1,1
+25393,3,18500,1,145,Solitary Magic Boots,307,110,15,0,2,1
+25394,3,18500,1,145,Solitary Magic Boots,307,110,15,0,3,1
+25395,3,18500,1,145,Solitary Magic Boots,307,110,15,0,4,1
+25411,3,18500,1,150,Hero's Magic Gloves,307,115,15,0,0,1
+25412,3,18500,1,150,Hero's Magic Gloves,307,115,15,0,1,1
+25413,3,18500,1,150,Hero's Magic Gloves,307,115,15,0,2,1
+25414,3,18500,1,150,Hero's Magic Gloves,307,115,15,0,3,1
+25415,3,18500,1,150,Hero's Magic Gloves,307,115,15,0,4,1
+25431,3,18500,1,140,Savage Courage Ranger Legs,307,105,17,0,0,1
+25432,3,18500,1,140,Savage Courage Ranger Legs,307,105,17,0,1,1
+25433,3,18500,1,140,Savage Courage Ranger Legs,307,105,17,0,2,1
+25434,3,18500,1,140,Savage Courage Ranger Legs,307,105,17,0,3,1
+25435,3,18500,1,140,Savage Courage Ranger Legs,307,105,17,0,4,1
+25451,3,18500,1,145,Solitary Ranger's Bottoms,307,110,17,0,0,1
+25452,3,18500,1,145,Solitary Ranger's Bottoms,307,110,17,0,1,1
+25453,3,18500,1,145,Solitary Ranger's Bottoms,307,110,17,0,2,1
+25454,3,18500,1,145,Solitary Ranger's Bottoms,307,110,17,0,3,1
+25455,3,18500,1,145,Solitary Ranger's Bottoms,307,110,17,0,4,1
+25471,3,18500,1,150,Heroes Ranger Cuirass,307,115,17,0,0,1
+25472,3,18500,1,150,Heroes Ranger Cuirass,307,115,17,0,1,1
+25473,3,18500,1,150,Heroes Ranger Cuirass,307,115,17,0,2,1
+25474,3,18500,1,150,Heroes Ranger Cuirass,307,115,17,0,3,1
+25475,3,18500,1,150,Heroes Ranger Cuirass,307,115,17,0,4,1
 25533,3,10000,1,1,Holy Seal's Trust Greaves,307,1,0,0,4,1
 25537,3,10000,1,1,Holy Seal's Bliss Shoes,307,1,0,0,4,1
 25541,3,10000,1,1,Holy Seal's Grandiose Greaves,307,1,0,0,4,1
@@ -18966,49 +18966,49 @@
 10483,3,3000,1,12,Enforcer's Legwear (Crimson),308,1,0,0,2,1
 10484,3,3000,1,12,Enforcer's Legwear (Crimson),308,1,0,0,3,1
 10485,3,3000,1,12,Enforcer's Legwear (Crimson),308,1,0,0,4,1
-10490,3,5000,1,9,Enforcer's Legwear (Moonflower),308,55,0,0,4,1
-10495,3,5000,1,8,Enforcer's Legwear (Dark Night),308,60,0,0,4,1
+10490,3,5000,1,25,Enforcer's Legwear (Moonflower),308,55,0,0,4,1
+10495,3,5000,1,40,Enforcer's Legwear (Dark Night),308,60,0,0,4,1
 11754,3,6000,1,1,Invisible Underpants,308,1,0,0,0,1
 13113,3,1441,1,15,Traditional Underwear,308,62,0,0,0,1
 13114,3,1441,1,15,Traditional Underwear,308,62,0,0,1,1
 13115,3,1441,1,15,Traditional Underwear,308,62,0,0,2,1
 13116,3,1441,1,15,Traditional Underwear,308,62,0,0,3,1
 13117,3,1441,1,15,Traditional Underwear,308,62,0,0,4,1
-13118,3,1584,1,4,Dapper Hose,308,65,0,0,0,1
-13119,3,1584,1,4,Dapper Hose,308,65,0,0,1,1
-13120,3,1584,1,4,Dapper Hose,308,65,0,0,2,1
-13121,3,1584,1,4,Dapper Hose,308,65,0,0,3,1
-13122,3,1584,1,4,Dapper Hose,308,65,0,0,4,1
-13123,3,1584,1,9,Toughness Banded,308,65,0,0,0,1
-13124,3,1584,1,9,Toughness Banded,308,65,0,0,1,1
-13125,3,1584,1,9,Toughness Banded,308,65,0,0,2,1
-13126,3,1584,1,9,Toughness Banded,308,65,0,0,3,1
-13127,3,1584,1,9,Toughness Banded,308,65,0,0,4,1
-13128,3,1584,1,14,Moroni Hose,308,65,0,0,0,1
-13129,3,1584,1,14,Moroni Hose,308,65,0,0,1,1
-13130,3,1584,1,14,Moroni Hose,308,65,0,0,2,1
-13131,3,1584,1,14,Moroni Hose,308,65,0,0,3,1
-13132,3,1584,1,14,Moroni Hose,308,65,0,0,4,1
-13133,3,1683,1,14,Silky Stockings,308,67,0,0,0,1
-13134,3,1683,1,14,Silky Stockings,308,67,0,0,1,1
-13135,3,1683,1,14,Silky Stockings,308,67,0,0,2,1
-13136,3,1683,1,14,Silky Stockings,308,67,0,0,3,1
-13137,3,1683,1,14,Silky Stockings,308,67,0,0,4,1
-13138,3,1837,1,3,Fever Metal,308,70,0,0,0,1
-13139,3,1837,1,3,Fever Metal,308,70,0,0,1,1
-13140,3,1837,1,3,Fever Metal,308,70,0,0,2,1
-13141,3,1837,1,3,Fever Metal,308,70,0,0,3,1
-13142,3,1837,1,3,Fever Metal,308,70,0,0,4,1
-13143,3,1837,1,8,Imperial Hose,308,70,0,0,0,1
-13144,3,1837,1,8,Imperial Hose,308,70,0,0,1,1
-13145,3,1837,1,8,Imperial Hose,308,70,0,0,2,1
-13146,3,1837,1,8,Imperial Hose,308,70,0,0,3,1
-13147,3,1837,1,8,Imperial Hose,308,70,0,0,4,1
-13148,3,1837,1,13,Black Bandages,308,70,0,0,0,1
-13149,3,1837,1,13,Black Bandages,308,70,0,0,1,1
-13150,3,1837,1,13,Black Bandages,308,70,0,0,2,1
-13151,3,1837,1,13,Black Bandages,308,70,0,0,3,1
-13152,3,1837,1,13,Black Bandages,308,70,0,0,4,1
+13118,3,1584,1,20,Dapper Hose,308,65,0,0,0,1
+13119,3,1584,1,20,Dapper Hose,308,65,0,0,1,1
+13120,3,1584,1,20,Dapper Hose,308,65,0,0,2,1
+13121,3,1584,1,20,Dapper Hose,308,65,0,0,3,1
+13122,3,1584,1,20,Dapper Hose,308,65,0,0,4,1
+13123,3,1584,1,25,Toughness Banded,308,65,0,0,0,1
+13124,3,1584,1,25,Toughness Banded,308,65,0,0,1,1
+13125,3,1584,1,25,Toughness Banded,308,65,0,0,2,1
+13126,3,1584,1,25,Toughness Banded,308,65,0,0,3,1
+13127,3,1584,1,25,Toughness Banded,308,65,0,0,4,1
+13128,3,1584,1,30,Moroni Hose,308,65,0,0,0,1
+13129,3,1584,1,30,Moroni Hose,308,65,0,0,1,1
+13130,3,1584,1,30,Moroni Hose,308,65,0,0,2,1
+13131,3,1584,1,30,Moroni Hose,308,65,0,0,3,1
+13132,3,1584,1,30,Moroni Hose,308,65,0,0,4,1
+13133,3,1683,1,30,Silky Stockings,308,67,0,0,0,1
+13134,3,1683,1,30,Silky Stockings,308,67,0,0,1,1
+13135,3,1683,1,30,Silky Stockings,308,67,0,0,2,1
+13136,3,1683,1,30,Silky Stockings,308,67,0,0,3,1
+13137,3,1683,1,30,Silky Stockings,308,67,0,0,4,1
+13138,3,1837,1,35,Fever Metal,308,70,0,0,0,1
+13139,3,1837,1,35,Fever Metal,308,70,0,0,1,1
+13140,3,1837,1,35,Fever Metal,308,70,0,0,2,1
+13141,3,1837,1,35,Fever Metal,308,70,0,0,3,1
+13142,3,1837,1,35,Fever Metal,308,70,0,0,4,1
+13143,3,1837,1,40,Imperial Hose,308,70,0,0,0,1
+13144,3,1837,1,40,Imperial Hose,308,70,0,0,1,1
+13145,3,1837,1,40,Imperial Hose,308,70,0,0,2,1
+13146,3,1837,1,40,Imperial Hose,308,70,0,0,3,1
+13147,3,1837,1,40,Imperial Hose,308,70,0,0,4,1
+13148,3,1837,1,45,Black Bandages,308,70,0,0,0,1
+13149,3,1837,1,45,Black Bandages,308,70,0,0,1,1
+13150,3,1837,1,45,Black Bandages,308,70,0,0,2,1
+13151,3,1837,1,45,Black Bandages,308,70,0,0,3,1
+13152,3,1837,1,45,Black Bandages,308,70,0,0,4,1
 13615,3,2500,1,11,Marquis Legs,308,1,0,0,0,1
 13616,3,2500,1,11,Marquis Legs,308,1,0,0,1,1
 13617,3,2500,1,11,Marquis Legs,308,1,0,0,2,1
@@ -19020,94 +19020,94 @@
 14158,3,10000,1,7,Night Black Swimsuit (Bottom),308,1,0,0,0,1
 14160,3,10000,1,7,Silver Gray Swimsuit (Bottom),308,1,0,0,0,1
 14162,3,10000,1,7,Setting Sun Swimsuit (Bottom),308,1,0,0,0,1
-15519,3,1944,1,13,Questing Banded,308,72,0,0,0,1
-15520,3,1944,1,13,Questing Banded,308,72,0,0,1,1
-15521,3,1944,1,13,Questing Banded,308,72,0,0,2,1
-15522,3,1944,1,13,Questing Banded,308,72,0,0,3,1
-15523,3,1944,1,13,Questing Banded,308,72,0,0,4,1
-15524,3,2109,1,2,Hero's Hose,308,75,0,0,0,1
-15525,3,2109,1,2,Hero's Hose,308,75,0,0,1,1
-15526,3,2109,1,2,Hero's Hose,308,75,0,0,2,1
-15527,3,2109,1,2,Hero's Hose,308,75,0,0,3,1
-15528,3,2109,1,2,Hero's Hose,308,75,0,0,4,1
-15529,3,2109,1,7,Leaf Tied,308,75,0,0,0,1
-15530,3,2109,1,7,Leaf Tied,308,75,0,0,1,1
-15531,3,2109,1,7,Leaf Tied,308,75,0,0,2,1
-15532,3,2109,1,7,Leaf Tied,308,75,0,0,3,1
-15533,3,2109,1,7,Leaf Tied,308,75,0,0,4,1
-15534,3,2109,1,12,Phindymian Underwear,308,75,0,0,0,1
-15535,3,2109,1,12,Phindymian Underwear,308,75,0,0,1,1
-15536,3,2109,1,12,Phindymian Underwear,308,75,0,0,2,1
-15537,3,2109,1,12,Phindymian Underwear,308,75,0,0,3,1
-15538,3,2109,1,12,Phindymian Underwear,308,75,0,0,4,1
-15539,3,2223,1,12,Pallid Tights,308,77,0,0,0,1
-15540,3,2223,1,12,Pallid Tights,308,77,0,0,1,1
-15541,3,2223,1,12,Pallid Tights,308,77,0,0,2,1
-15542,3,2223,1,12,Pallid Tights,308,77,0,0,3,1
-15543,3,2223,1,12,Pallid Tights,308,77,0,0,4,1
-15544,3,2400,1,1,Dark Gray Bottoms,308,80,0,0,0,1
-15545,3,2400,1,1,Dark Gray Bottoms,308,80,0,0,1,1
-15546,3,2400,1,1,Dark Gray Bottoms,308,80,0,0,2,1
-15547,3,2400,1,1,Dark Gray Bottoms,308,80,0,0,3,1
-15548,3,2400,1,1,Dark Gray Bottoms,308,80,0,0,4,1
-15549,3,2400,1,6,Holy Legs,308,80,0,0,0,1
-15550,3,2400,1,6,Holy Legs,308,80,0,0,1,1
-15551,3,2400,1,6,Holy Legs,308,80,0,0,2,1
-15552,3,2400,1,6,Holy Legs,308,80,0,0,3,1
-15553,3,2400,1,6,Holy Legs,308,80,0,0,4,1
-15554,3,2400,1,11,Azure Hose,308,80,0,0,0,1
-15555,3,2400,1,11,Azure Hose,308,80,0,0,1,1
-15556,3,2400,1,11,Azure Hose,308,80,0,0,2,1
-15557,3,2400,1,11,Azure Hose,308,80,0,0,3,1
-15558,3,2400,1,11,Azure Hose,308,80,0,0,4,1
-15559,3,5000,1,7,Duke Legs (Dark Night),308,70,0,0,4,1
-15564,3,5000,1,6,Duke Legs (Moonflower),308,75,0,0,4,1
+15519,3,1944,1,45,Questing Banded,308,72,0,0,0,1
+15520,3,1944,1,45,Questing Banded,308,72,0,0,1,1
+15521,3,1944,1,45,Questing Banded,308,72,0,0,2,1
+15522,3,1944,1,45,Questing Banded,308,72,0,0,3,1
+15523,3,1944,1,45,Questing Banded,308,72,0,0,4,1
+15524,3,2109,1,50,Hero's Hose,308,75,0,0,0,1
+15525,3,2109,1,50,Hero's Hose,308,75,0,0,1,1
+15526,3,2109,1,50,Hero's Hose,308,75,0,0,2,1
+15527,3,2109,1,50,Hero's Hose,308,75,0,0,3,1
+15528,3,2109,1,50,Hero's Hose,308,75,0,0,4,1
+15529,3,2109,1,55,Leaf Tied,308,75,0,0,0,1
+15530,3,2109,1,55,Leaf Tied,308,75,0,0,1,1
+15531,3,2109,1,55,Leaf Tied,308,75,0,0,2,1
+15532,3,2109,1,55,Leaf Tied,308,75,0,0,3,1
+15533,3,2109,1,55,Leaf Tied,308,75,0,0,4,1
+15534,3,2109,1,60,Phindymian Underwear,308,75,0,0,0,1
+15535,3,2109,1,60,Phindymian Underwear,308,75,0,0,1,1
+15536,3,2109,1,60,Phindymian Underwear,308,75,0,0,2,1
+15537,3,2109,1,60,Phindymian Underwear,308,75,0,0,3,1
+15538,3,2109,1,60,Phindymian Underwear,308,75,0,0,4,1
+15539,3,2223,1,60,Pallid Tights,308,77,0,0,0,1
+15540,3,2223,1,60,Pallid Tights,308,77,0,0,1,1
+15541,3,2223,1,60,Pallid Tights,308,77,0,0,2,1
+15542,3,2223,1,60,Pallid Tights,308,77,0,0,3,1
+15543,3,2223,1,60,Pallid Tights,308,77,0,0,4,1
+15544,3,2400,1,65,Dark Gray Bottoms,308,80,0,0,0,1
+15545,3,2400,1,65,Dark Gray Bottoms,308,80,0,0,1,1
+15546,3,2400,1,65,Dark Gray Bottoms,308,80,0,0,2,1
+15547,3,2400,1,65,Dark Gray Bottoms,308,80,0,0,3,1
+15548,3,2400,1,65,Dark Gray Bottoms,308,80,0,0,4,1
+15549,3,2400,1,70,Holy Legs,308,80,0,0,0,1
+15550,3,2400,1,70,Holy Legs,308,80,0,0,1,1
+15551,3,2400,1,70,Holy Legs,308,80,0,0,2,1
+15552,3,2400,1,70,Holy Legs,308,80,0,0,3,1
+15553,3,2400,1,70,Holy Legs,308,80,0,0,4,1
+15554,3,2400,1,75,Azure Hose,308,80,0,0,0,1
+15555,3,2400,1,75,Azure Hose,308,80,0,0,1,1
+15556,3,2400,1,75,Azure Hose,308,80,0,0,2,1
+15557,3,2400,1,75,Azure Hose,308,80,0,0,3,1
+15558,3,2400,1,75,Azure Hose,308,80,0,0,4,1
+15559,3,5000,1,55,Duke Legs (Dark Night),308,70,0,0,4,1
+15564,3,5000,1,70,Duke Legs (Moonflower),308,75,0,0,4,1
 16791,3,100,1,1,Christmas Legs,308,1,0,0,4,1
 16798,3,100,1,1,Christmas Legs (White),308,1,0,0,4,1
-17826,3,2430,1,0,Arabesque Backs,308,80,0,0,0,1
-17827,3,2430,1,0,Arabesque Backs,308,80,0,0,1,1
-17828,3,2430,1,0,Arabesque Backs,308,80,0,0,2,1
-17829,3,2430,1,0,Arabesque Backs,308,80,0,0,3,1
-17830,3,2430,1,0,Arabesque Backs,308,80,0,0,4,1
-17831,3,2605,1,5,Biyabaan Tights,308,83,0,0,0,1
-17832,3,2605,1,5,Biyabaan Tights,308,83,0,0,1,1
-17833,3,2605,1,5,Biyabaan Tights,308,83,0,0,2,1
-17834,3,2605,1,5,Biyabaan Tights,308,83,0,0,3,1
-17835,3,2605,1,5,Biyabaan Tights,308,83,0,0,4,1
-17836,3,2721,1,10,Acrean Hose,308,85,0,0,0,1
-17837,3,2721,1,10,Acrean Hose,308,85,0,0,1,1
-17838,3,2721,1,10,Acrean Hose,308,85,0,0,2,1
-17839,3,2721,1,10,Acrean Hose,308,85,0,0,3,1
-17840,3,2721,1,10,Acrean Hose,308,85,0,0,4,1
+17826,3,2430,1,80,Arabesque Backs,308,80,0,0,0,1
+17827,3,2430,1,80,Arabesque Backs,308,80,0,0,1,1
+17828,3,2430,1,80,Arabesque Backs,308,80,0,0,2,1
+17829,3,2430,1,80,Arabesque Backs,308,80,0,0,3,1
+17830,3,2430,1,80,Arabesque Backs,308,80,0,0,4,1
+17831,3,2605,1,85,Biyabaan Tights,308,83,0,0,0,1
+17832,3,2605,1,85,Biyabaan Tights,308,83,0,0,1,1
+17833,3,2605,1,85,Biyabaan Tights,308,83,0,0,2,1
+17834,3,2605,1,85,Biyabaan Tights,308,83,0,0,3,1
+17835,3,2605,1,85,Biyabaan Tights,308,83,0,0,4,1
+17836,3,2721,1,90,Acrean Hose,308,85,0,0,0,1
+17837,3,2721,1,90,Acrean Hose,308,85,0,0,1,1
+17838,3,2721,1,90,Acrean Hose,308,85,0,0,2,1
+17839,3,2721,1,90,Acrean Hose,308,85,0,0,3,1
+17840,3,2721,1,90,Acrean Hose,308,85,0,0,4,1
 17955,3,5000,1,7,Alluring Swimsuit Bottom (Glittering Gold),308,1,0,0,0,1
-18454,3,2721,1,10,Asker Tights,308,85,0,0,0,1
-18455,3,2721,1,10,Asker Tights,308,85,0,0,1,1
-18456,3,2721,1,10,Asker Tights,308,85,0,0,2,1
-18457,3,2721,1,10,Asker Tights,308,85,0,0,3,1
-18458,3,2721,1,10,Asker Tights,308,85,0,0,4,1
-18459,3,2911,1,15,Krall Banded,308,88,0,0,0,1
-18460,3,2911,1,15,Krall Banded,308,88,0,0,1,1
-18461,3,2911,1,15,Krall Banded,308,88,0,0,2,1
-18462,3,2911,1,15,Krall Banded,308,88,0,0,3,1
-18463,3,2911,1,15,Krall Banded,308,88,0,0,4,1
-18464,3,3023,1,4,Casanance Hose,308,90,0,0,0,1
-18465,3,3023,1,4,Casanance Hose,308,90,0,0,1,1
-18466,3,3023,1,4,Casanance Hose,308,90,0,0,2,1
-18467,3,3023,1,4,Casanance Hose,308,90,0,0,3,1
-18468,3,3023,1,4,Casanance Hose,308,90,0,0,4,1
-18594,3,5000,1,13,Black Venom Legs,308,1,0,0,0,1
-18595,3,5000,1,2,Black Venom Legs,308,1,0,0,1,1
-18596,3,5000,1,7,Black Venom Legs,308,1,0,0,2,1
-18597,3,5000,1,12,Black Venom Legs,308,1,0,0,3,1
-18598,3,5000,1,6,Black Venom Legs,308,1,0,0,4,1
+18454,3,2721,1,90,Asker Tights,308,85,0,0,0,1
+18455,3,2721,1,90,Asker Tights,308,85,0,0,1,1
+18456,3,2721,1,90,Asker Tights,308,85,0,0,2,1
+18457,3,2721,1,90,Asker Tights,308,85,0,0,3,1
+18458,3,2721,1,90,Asker Tights,308,85,0,0,4,1
+18459,3,2911,1,95,Krall Banded,308,88,0,0,0,1
+18460,3,2911,1,95,Krall Banded,308,88,0,0,1,1
+18461,3,2911,1,95,Krall Banded,308,88,0,0,2,1
+18462,3,2911,1,95,Krall Banded,308,88,0,0,3,1
+18463,3,2911,1,95,Krall Banded,308,88,0,0,4,1
+18464,3,3023,1,100,Casanance Hose,308,90,0,0,0,1
+18465,3,3023,1,100,Casanance Hose,308,90,0,0,1,1
+18466,3,3023,1,100,Casanance Hose,308,90,0,0,2,1
+18467,3,3023,1,100,Casanance Hose,308,90,0,0,3,1
+18468,3,3023,1,100,Casanance Hose,308,90,0,0,4,1
+18594,3,5000,1,45,Black Venom Legs,308,1,0,0,0,1
+18595,3,5000,1,50,Black Venom Legs,308,1,0,0,1,1
+18596,3,5000,1,55,Black Venom Legs,308,1,0,0,2,1
+18597,3,5000,1,60,Black Venom Legs,308,1,0,0,3,1
+18598,3,5000,1,70,Black Venom Legs,308,1,0,0,4,1
 19141,3,10000,1,7,Alluring Swimsuit Bottom (Vivid Green),308,1,0,0,0,1
 19142,3,10000,1,7,Alluring Swimsuit Bottom (Indigo Blue),308,1,0,0,0,1
 19143,3,10000,1,7,Alluring Swimsuit Bottom (Bluish Purple),308,1,0,0,0,1
 19144,3,10000,1,7,Alluring Swimsuit Bottom (Night Black),308,1,0,0,0,1
 19145,3,10000,1,7,Alluring Swimsuit Bottom (Silver Gray),308,1,0,0,0,1
 19146,3,10000,1,7,Alluring Swimsuit Bottom (Setting Sun),308,1,0,0,0,1
-19458,3,10000,1,0,Boundless Tempest Bottoms,308,1,0,0,4,1
-19462,3,10000,1,3,Boundless Tempest Hose,308,1,0,0,4,1
+19458,3,10000,1,80,Boundless Tempest Bottoms,308,1,0,0,4,1
+19462,3,10000,1,83,Boundless Tempest Hose,308,1,0,0,4,1
 19502,3,15000,1,10,Magical Night Pumpkin Slacks,308,1,0,0,4,1
 19504,3,10000,1,10,Magical Night Witch Boots,308,1,0,0,4,1
 19562,3,10,1,15,Craig's Worn-out Pants,308,1,0,0,4,1
@@ -19117,59 +19117,59 @@
 19608,3,10000,1,7,Basic Shorts - Pink,308,1,0,0,0,1
 19611,3,10000,1,7,Cutie Shorts - Pink,308,1,0,0,0,1
 19612,3,10000,1,7,Cutie Shorts - Marine,308,1,0,0,0,1
-20713,3,3060,1,4,Rahatz Tied,308,90,0,0,0,1
-20714,3,3060,1,4,Rahatz Tied,308,90,0,0,1,1
-20715,3,3060,1,4,Rahatz Tied,308,90,0,0,2,1
-20716,3,3060,1,4,Rahatz Tied,308,90,0,0,3,1
-20717,3,3060,1,4,Rahatz Tied,308,90,0,0,4,1
-20718,3,3213,1,9,Kenneby's Pants,308,93,0,0,0,1
-20719,3,3213,1,9,Kenneby's Pants,308,93,0,0,1,1
-20720,3,3213,1,9,Kenneby's Pants,308,93,0,0,2,1
-20721,3,3213,1,9,Kenneby's Pants,308,93,0,0,3,1
-20722,3,3213,1,9,Kenneby's Pants,308,93,0,0,4,1
-20723,3,3366,1,14,Macera Hose,308,95,0,0,0,1
-20724,3,3366,1,14,Macera Hose,308,95,0,0,1,1
-20725,3,3366,1,14,Macera Hose,308,95,0,0,2,1
-20726,3,3366,1,14,Macera Hose,308,95,0,0,3,1
-20727,3,3366,1,14,Macera Hose,308,95,0,0,4,1
-21057,3,3366,1,14,Rébellion Pants,308,95,0,0,0,1
-21058,3,3366,1,14,Rébellion Pants,308,95,0,0,1,1
-21059,3,3366,1,14,Rébellion Pants,308,95,0,0,2,1
-21060,3,3366,1,14,Rébellion Pants,308,95,0,0,3,1
-21061,3,3366,1,14,Rébellion Pants,308,95,0,0,4,1
-21062,3,3519,1,3,Traître Hose,308,98,0,0,0,1
-21063,3,3519,1,3,Traître Hose,308,98,0,0,1,1
-21064,3,3519,1,3,Traître Hose,308,98,0,0,2,1
-21065,3,3519,1,3,Traître Hose,308,98,0,0,3,1
-21066,3,3519,1,3,Traître Hose,308,98,0,0,4,1
-21067,3,3672,1,8,Revanche Pants,308,100,0,0,0,1
-21068,3,3672,1,8,Revanche Pants,308,100,0,0,1,1
-21069,3,3672,1,8,Revanche Pants,308,100,0,0,2,1
-21070,3,3672,1,8,Revanche Pants,308,100,0,0,3,1
-21071,3,3672,1,8,Revanche Pants,308,100,0,0,4,1
-21116,3,10000,1,12,Maestro Legs,308,1,0,0,4,1
-20755,3,10000,1,10,Crimson Leather Bottom,308,90,0,0,4,1
-21098,3,10000,1,4,White Smoke Leather Bottoms,308,95,0,0,4,1
+20713,3,3060,1,100,Rahatz Tied,308,90,0,0,0,1
+20714,3,3060,1,100,Rahatz Tied,308,90,0,0,1,1
+20715,3,3060,1,100,Rahatz Tied,308,90,0,0,2,1
+20716,3,3060,1,100,Rahatz Tied,308,90,0,0,3,1
+20717,3,3060,1,100,Rahatz Tied,308,90,0,0,4,1
+20718,3,3213,1,105,Kenneby's Pants,308,93,0,0,0,1
+20719,3,3213,1,105,Kenneby's Pants,308,93,0,0,1,1
+20720,3,3213,1,105,Kenneby's Pants,308,93,0,0,2,1
+20721,3,3213,1,105,Kenneby's Pants,308,93,0,0,3,1
+20722,3,3213,1,105,Kenneby's Pants,308,93,0,0,4,1
+20723,3,3366,1,110,Macera Hose,308,95,0,0,0,1
+20724,3,3366,1,110,Macera Hose,308,95,0,0,1,1
+20725,3,3366,1,110,Macera Hose,308,95,0,0,2,1
+20726,3,3366,1,110,Macera Hose,308,95,0,0,3,1
+20727,3,3366,1,110,Macera Hose,308,95,0,0,4,1
+21057,3,3366,1,110,Rébellion Pants,308,95,0,0,0,1
+21058,3,3366,1,110,Rébellion Pants,308,95,0,0,1,1
+21059,3,3366,1,110,Rébellion Pants,308,95,0,0,2,1
+21060,3,3366,1,110,Rébellion Pants,308,95,0,0,3,1
+21061,3,3366,1,110,Rébellion Pants,308,95,0,0,4,1
+21062,3,3519,1,115,Traître Hose,308,98,0,0,0,1
+21063,3,3519,1,115,Traître Hose,308,98,0,0,1,1
+21064,3,3519,1,115,Traître Hose,308,98,0,0,2,1
+21065,3,3519,1,115,Traître Hose,308,98,0,0,3,1
+21066,3,3519,1,115,Traître Hose,308,98,0,0,4,1
+21067,3,3672,1,120,Revanche Pants,308,100,0,0,0,1
+21068,3,3672,1,120,Revanche Pants,308,100,0,0,1,1
+21069,3,3672,1,120,Revanche Pants,308,100,0,0,2,1
+21070,3,3672,1,120,Revanche Pants,308,100,0,0,3,1
+21071,3,3672,1,120,Revanche Pants,308,100,0,0,4,1
+21116,3,10000,1,92,Maestro Legs,308,1,0,0,4,1
+20755,3,10000,1,106,Crimson Leather Bottom,308,90,0,0,4,1
+21098,3,10000,1,116,White Smoke Leather Bottoms,308,95,0,0,4,1
 20437,3,10000,1,10,Magical Night Terror Slacks,308,1,0,0,4,1
 20439,3,10000,1,10,Magical Night Scream Boots,308,1,0,0,4,1
 20760,3,10000,1,7,Midsummer Glamorous Pants (Red),308,1,0,0,0,3
-21165,3,10000,1,15,Virtuoso Legs,308,1,0,0,4,1
-21173,3,10000,1,12,Lord Knight Leather Bottom,308,90,0,0,4,1
-21181,3,10000,1,6,Selenite Leather Bottoms,308,95,0,0,4,1
+21165,3,10000,1,95,Virtuoso Legs,308,1,0,0,4,1
+21173,3,10000,1,108,Lord Knight Leather Bottom,308,90,0,0,4,1
+21181,3,10000,1,118,Selenite Leather Bottoms,308,95,0,0,4,1
 21344,3,10000,1,7,Midsummer Glamorous Pants (Peach),308,1,0,0,0,3
 21345,3,10000,1,7,Midsummer Glamorous Pants (Blue),308,1,0,0,0,3
 21346,3,10000,1,7,Midsummer Glamorous Pants (Purple),308,1,0,0,0,3
 21347,3,10000,1,7,Midsummer Glamorous Pants (White),308,1,0,0,0,3
 21348,3,10000,1,7,Midsummer Glamorous Pants (Black),308,1,0,0,0,3
-21689,3,10000,1,11,Wooly Panties (White),308,1,0,0,4,1
-21690,3,10000,1,11,Wooly Panties (Black),308,1,0,0,4,1
-21691,3,10000,1,11,Wooly Panties (Brown),308,1,0,0,4,1
-21692,3,10000,1,11,Border Knee-high Socks (Peach),308,1,0,0,4,1
-21693,3,10000,1,11,Border Knee-high Socks (Black),308,1,0,0,4,1
-21694,3,10000,1,11,Border Knee-high Socks (Red),308,1,0,0,4,1
-21695,3,10000,1,11,Diamond Stockings (White),308,1,0,0,4,1
-21696,3,10000,1,11,Diamond Stockings (Black),308,1,0,0,4,1
-21697,3,10000,1,11,Diamond Stockings (Purple),308,1,0,0,4,1
+21689,3,10000,1,75,Wooly Panties (White),308,1,0,0,4,1
+21690,3,10000,1,75,Wooly Panties (Black),308,1,0,0,4,1
+21691,3,10000,1,75,Wooly Panties (Brown),308,1,0,0,4,1
+21692,3,10000,1,75,Border Knee-high Socks (Peach),308,1,0,0,4,1
+21693,3,10000,1,75,Border Knee-high Socks (Black),308,1,0,0,4,1
+21694,3,10000,1,75,Border Knee-high Socks (Red),308,1,0,0,4,1
+21695,3,10000,1,75,Diamond Stockings (White),308,1,0,0,4,1
+21696,3,10000,1,75,Diamond Stockings (Black),308,1,0,0,4,1
+21697,3,10000,1,75,Diamond Stockings (Purple),308,1,0,0,4,1
 23391,3,10000,1,1,Mischievous Parade Slacks,308,1,0,0,4,1
 23392,3,10000,1,1,Mischievous Moonlight Slacks,308,1,0,0,4,1
 23393,3,10000,1,1,Mischievous Party Tights,308,1,0,0,4,1
@@ -19179,32 +19179,32 @@
 23420,3,10000,1,1,Angel's Feather Tights (White),308,1,0,0,4,1
 23421,3,10000,1,1,Angel's Feather Tights (Black),308,1,0,0,4,1
 24617,3,0,1,12,Pleiades Pants,308,1,0,0,4,1
-24644,3,0,1,2,Spirit's Underpants,308,100,0,0,0,1
-24645,3,0,1,2,Spirit's Underpants,308,100,0,0,1,1
-24646,3,0,1,2,Spirit's Underpants,308,100,0,0,2,1
-24647,3,0,1,2,Spirit's Underpants,308,100,0,0,3,1
-24648,3,0,1,2,Spirit's Underpants,308,100,0,0,4,1
-24649,3,0,1,2,Fire King's Underpants,308,100,0,0,0,1
-24650,3,0,1,2,Fire King's Underpants,308,100,0,0,1,1
-24651,3,0,1,2,Fire King's Underpants,308,100,0,0,2,1
-24652,3,0,1,2,Fire King's Underpants,308,100,0,0,3,1
-24653,3,0,1,2,Fire King's Underpants,308,100,0,0,4,1
-24654,3,0,1,2,White Wings' Underpants,308,100,0,0,0,1
-24655,3,0,1,2,White Wings' Underpants,308,100,0,0,1,1
-24656,3,0,1,2,White Wings' Underpants,308,100,0,0,2,1
-24657,3,0,1,2,White Wings' Underpants,308,100,0,0,3,1
-24658,3,0,1,2,White Wings' Underpants,308,100,0,0,4,1
-24659,3,0,1,2,Golden Underpants,308,100,0,0,0,1
-24660,3,0,1,2,Golden Underpants,308,100,0,0,1,1
-24661,3,0,1,2,Golden Underpants,308,100,0,0,2,1
-24662,3,0,1,2,Golden Underpants,308,100,0,0,3,1
-24663,3,0,1,2,Golden Underpants,308,100,0,0,4,1
-24664,3,0,1,7,Blackshatter Underpants,308,100,0,0,0,1
-24665,3,0,1,7,Blackshatter Underpants,308,100,0,0,1,1
-24666,3,0,1,7,Blackshatter Underpants,308,100,0,0,2,1
-24667,3,0,1,7,Blackshatter Underpants,308,100,0,0,3,1
-24668,3,0,1,7,Blackshatter Underpants,308,100,0,0,4,1
-24703,3,10000,1,2,Survivor Leather Bottoms,308,1,0,0,4,1
+24644,3,0,1,130,Spirit's Underpants,308,100,0,0,0,1
+24645,3,0,1,130,Spirit's Underpants,308,100,0,0,1,1
+24646,3,0,1,130,Spirit's Underpants,308,100,0,0,2,1
+24647,3,0,1,130,Spirit's Underpants,308,100,0,0,3,1
+24648,3,0,1,130,Spirit's Underpants,308,100,0,0,4,1
+24649,3,0,1,130,Fire King's Underpants,308,100,0,0,0,1
+24650,3,0,1,130,Fire King's Underpants,308,100,0,0,1,1
+24651,3,0,1,130,Fire King's Underpants,308,100,0,0,2,1
+24652,3,0,1,130,Fire King's Underpants,308,100,0,0,3,1
+24653,3,0,1,130,Fire King's Underpants,308,100,0,0,4,1
+24654,3,0,1,130,White Wings' Underpants,308,100,0,0,0,1
+24655,3,0,1,130,White Wings' Underpants,308,100,0,0,1,1
+24656,3,0,1,130,White Wings' Underpants,308,100,0,0,2,1
+24657,3,0,1,130,White Wings' Underpants,308,100,0,0,3,1
+24658,3,0,1,130,White Wings' Underpants,308,100,0,0,4,1
+24659,3,0,1,130,Golden Underpants,308,100,0,0,0,1
+24660,3,0,1,130,Golden Underpants,308,100,0,0,1,1
+24661,3,0,1,130,Golden Underpants,308,100,0,0,2,1
+24662,3,0,1,130,Golden Underpants,308,100,0,0,3,1
+24663,3,0,1,130,Golden Underpants,308,100,0,0,4,1
+24664,3,0,1,135,Blackshatter Underpants,308,100,0,0,0,1
+24665,3,0,1,135,Blackshatter Underpants,308,100,0,0,1,1
+24666,3,0,1,135,Blackshatter Underpants,308,100,0,0,2,1
+24667,3,0,1,135,Blackshatter Underpants,308,100,0,0,3,1
+24668,3,0,1,135,Blackshatter Underpants,308,100,0,0,4,1
+24703,3,10000,1,130,Survivor Leather Bottoms,308,1,0,0,4,1
 24887,3,10000,1,1,Basic Shorts - Green,308,1,0,0,0,1
 24889,3,10000,1,1,Cutie Shorts - Yellow,308,1,0,0,0,1
 24898,3,10000,1,1,Southern Country Surf Pants (Red),308,1,0,0,0,2
@@ -19222,22 +19222,22 @@
 24928,3,10000,1,1,Wooly Panties (Deep Red),308,1,0,0,0,1
 24929,3,10000,1,1,Border Knee-high Socks (Deep Red),308,1,0,0,0,1
 24930,3,10000,1,1,Diamond Stockings (Deep Red),308,1,0,0,0,1
-25018,3,10000,1,2,Combat Leather Bottoms,308,1,0,0,4,1
-25481,3,4000,1,12,Holy Seal's Lively Hose,308,105,0,0,0,1
-25482,3,4000,1,12,Holy Seal's Lively Hose,308,105,0,0,1,1
-25483,3,4000,1,12,Holy Seal's Lively Hose,308,105,0,0,2,1
-25484,3,4000,1,12,Holy Seal's Lively Hose,308,105,0,0,3,1
-25485,3,4000,1,12,Holy Seal's Lively Hose,308,105,0,0,4,1
-25496,3,4000,1,1,Tricksters's Lively Pants,308,110,0,0,0,1
-25497,3,4000,1,1,Tricksters's Lively Pants,308,110,0,0,1,1
-25498,3,4000,1,1,Tricksters's Lively Pants,308,110,0,0,2,1
-25499,3,4000,1,1,Tricksters's Lively Pants,308,110,0,0,3,1
-25500,3,4000,1,1,Tricksters's Lively Pants,308,110,0,0,4,1
-25511,3,4000,1,6,Hero's Lively Underpants,308,115,0,0,0,1
-25512,3,4000,1,6,Hero's Lively Underpants,308,115,0,0,1,1
-25513,3,4000,1,6,Hero's Lively Underpants,308,115,0,0,2,1
-25514,3,4000,1,6,Hero's Lively Underpants,308,115,0,0,3,1
-25515,3,4000,1,6,Hero's Lively Underpants,308,115,0,0,4,1
+25018,3,10000,1,130,Combat Leather Bottoms,308,1,0,0,4,1
+25481,3,4000,1,140,Holy Seal's Lively Hose,308,105,0,0,0,1
+25482,3,4000,1,140,Holy Seal's Lively Hose,308,105,0,0,1,1
+25483,3,4000,1,140,Holy Seal's Lively Hose,308,105,0,0,2,1
+25484,3,4000,1,140,Holy Seal's Lively Hose,308,105,0,0,3,1
+25485,3,4000,1,140,Holy Seal's Lively Hose,308,105,0,0,4,1
+25496,3,4000,1,145,Tricksters's Lively Pants,308,110,0,0,0,1
+25497,3,4000,1,145,Tricksters's Lively Pants,308,110,0,0,1,1
+25498,3,4000,1,145,Tricksters's Lively Pants,308,110,0,0,2,1
+25499,3,4000,1,145,Tricksters's Lively Pants,308,110,0,0,3,1
+25500,3,4000,1,145,Tricksters's Lively Pants,308,110,0,0,4,1
+25511,3,4000,1,150,Hero's Lively Underpants,308,115,0,0,0,1
+25512,3,4000,1,150,Hero's Lively Underpants,308,115,0,0,1,1
+25513,3,4000,1,150,Hero's Lively Underpants,308,115,0,0,2,1
+25514,3,4000,1,150,Hero's Lively Underpants,308,115,0,0,3,1
+25515,3,4000,1,150,Hero's Lively Underpants,308,115,0,0,4,1
 486,3,0,1,7,Benefit Muffler,309,1,0,0,0,1
 2098,3,0,1,7,Benefit Muffler,309,1,0,0,1,1
 3121,3,0,1,7,Benefit Muffler,309,1,0,0,2,1
@@ -19564,52 +19564,52 @@
 11042,3,1000,1,1,Rookie Arisen's Tight Cloth,309,1,0,0,2,1
 11043,3,1000,1,1,Rookie Arisen's Tight Cloth,309,1,0,0,3,1
 11044,3,1000,1,1,Rookie Arisen's Tight Cloth,309,1,0,0,4,1
-11499,3,3840,1,11,Finnegan's Mantle,309,80,0,0,0,1
-11500,3,3840,1,11,Finnegan's Mantle,309,80,0,0,1,1
-11501,3,3840,1,11,Finnegan's Mantle,309,80,0,0,2,1
-11502,3,3840,1,11,Finnegan's Mantle,309,80,0,0,3,1
-11503,3,3840,1,11,Finnegan's Mantle,309,80,0,0,4,1
+11499,3,3840,1,75,Finnegan's Mantle,309,80,0,0,0,1
+11500,3,3840,1,75,Finnegan's Mantle,309,80,0,0,1,1
+11501,3,3840,1,75,Finnegan's Mantle,309,80,0,0,2,1
+11502,3,3840,1,75,Finnegan's Mantle,309,80,0,0,3,1
+11503,3,3840,1,75,Finnegan's Mantle,309,80,0,0,4,1
 11755,3,6000,1,1,Invisible Mantle,309,1,0,0,0,1
 13153,3,2307,1,15,Victor's Cloak,309,62,0,0,0,1
 13154,3,2307,1,15,Victor's Cloak,309,62,0,0,1,1
 13155,3,2307,1,15,Victor's Cloak,309,62,0,0,2,1
 13156,3,2307,1,15,Victor's Cloak,309,62,0,0,3,1
 13157,3,2307,1,15,Victor's Cloak,309,62,0,0,4,1
-13158,3,2535,1,4,Expecto Cloak,309,65,0,0,0,1
-13159,3,2535,1,4,Expecto Cloak,309,65,0,0,1,1
-13160,3,2535,1,4,Expecto Cloak,309,65,0,0,2,1
-13161,3,2535,1,4,Expecto Cloak,309,65,0,0,3,1
-13162,3,2535,1,4,Expecto Cloak,309,65,0,0,4,1
-13163,3,2535,1,9,Holy Embrace,309,65,0,0,0,1
-13164,3,2535,1,9,Holy Embrace,309,65,0,0,1,1
-13165,3,2535,1,9,Holy Embrace,309,65,0,0,2,1
-13166,3,2535,1,9,Holy Embrace,309,65,0,0,3,1
-13167,3,2535,1,9,Holy Embrace,309,65,0,0,4,1
-13168,3,2535,1,14,Benediction Mantle,309,65,0,0,0,1
-13169,3,2535,1,14,Benediction Mantle,309,65,0,0,1,1
-13170,3,2535,1,14,Benediction Mantle,309,65,0,0,2,1
-13171,3,2535,1,14,Benediction Mantle,309,65,0,0,3,1
-13172,3,2535,1,14,Benediction Mantle,309,65,0,0,4,1
-13173,3,2694,1,14,Beast Lord's Cape,309,67,0,0,0,1
-13174,3,2694,1,14,Beast Lord's Cape,309,67,0,0,1,1
-13175,3,2694,1,14,Beast Lord's Cape,309,67,0,0,2,1
-13176,3,2694,1,14,Beast Lord's Cape,309,67,0,0,3,1
-13177,3,2694,1,14,Beast Lord's Cape,309,67,0,0,4,1
-13178,3,2940,1,3,Sancto Cloak,309,70,0,0,0,1
-13179,3,2940,1,3,Sancto Cloak,309,70,0,0,1,1
-13180,3,2940,1,3,Sancto Cloak,309,70,0,0,2,1
-13181,3,2940,1,3,Sancto Cloak,309,70,0,0,3,1
-13182,3,2940,1,3,Sancto Cloak,309,70,0,0,4,1
-13183,3,2940,1,8,Imperial Cape,309,70,0,0,0,1
-13184,3,2940,1,8,Imperial Cape,309,70,0,0,1,1
-13185,3,2940,1,8,Imperial Cape,309,70,0,0,2,1
-13186,3,2940,1,8,Imperial Cape,309,70,0,0,3,1
-13187,3,2940,1,8,Imperial Cape,309,70,0,0,4,1
-13188,3,2940,1,13,Cryptid Mantle,309,70,0,0,0,1
-13189,3,2940,1,13,Cryptid Mantle,309,70,0,0,1,1
-13190,3,2940,1,13,Cryptid Mantle,309,70,0,0,2,1
-13191,3,2940,1,13,Cryptid Mantle,309,70,0,0,3,1
-13192,3,2940,1,13,Cryptid Mantle,309,70,0,0,4,1
+13158,3,2535,1,20,Expecto Cloak,309,65,0,0,0,1
+13159,3,2535,1,20,Expecto Cloak,309,65,0,0,1,1
+13160,3,2535,1,20,Expecto Cloak,309,65,0,0,2,1
+13161,3,2535,1,20,Expecto Cloak,309,65,0,0,3,1
+13162,3,2535,1,20,Expecto Cloak,309,65,0,0,4,1
+13163,3,2535,1,25,Holy Embrace,309,65,0,0,0,1
+13164,3,2535,1,25,Holy Embrace,309,65,0,0,1,1
+13165,3,2535,1,25,Holy Embrace,309,65,0,0,2,1
+13166,3,2535,1,25,Holy Embrace,309,65,0,0,3,1
+13167,3,2535,1,25,Holy Embrace,309,65,0,0,4,1
+13168,3,2535,1,30,Benediction Mantle,309,65,0,0,0,1
+13169,3,2535,1,30,Benediction Mantle,309,65,0,0,1,1
+13170,3,2535,1,30,Benediction Mantle,309,65,0,0,2,1
+13171,3,2535,1,30,Benediction Mantle,309,65,0,0,3,1
+13172,3,2535,1,30,Benediction Mantle,309,65,0,0,4,1
+13173,3,2694,1,30,Beast Lord's Cape,309,67,0,0,0,1
+13174,3,2694,1,30,Beast Lord's Cape,309,67,0,0,1,1
+13175,3,2694,1,30,Beast Lord's Cape,309,67,0,0,2,1
+13176,3,2694,1,30,Beast Lord's Cape,309,67,0,0,3,1
+13177,3,2694,1,30,Beast Lord's Cape,309,67,0,0,4,1
+13178,3,2940,1,35,Sancto Cloak,309,70,0,0,0,1
+13179,3,2940,1,35,Sancto Cloak,309,70,0,0,1,1
+13180,3,2940,1,35,Sancto Cloak,309,70,0,0,2,1
+13181,3,2940,1,35,Sancto Cloak,309,70,0,0,3,1
+13182,3,2940,1,35,Sancto Cloak,309,70,0,0,4,1
+13183,3,2940,1,40,Imperial Cape,309,70,0,0,0,1
+13184,3,2940,1,40,Imperial Cape,309,70,0,0,1,1
+13185,3,2940,1,40,Imperial Cape,309,70,0,0,2,1
+13186,3,2940,1,40,Imperial Cape,309,70,0,0,3,1
+13187,3,2940,1,40,Imperial Cape,309,70,0,0,4,1
+13188,3,2940,1,45,Cryptid Mantle,309,70,0,0,0,1
+13189,3,2940,1,45,Cryptid Mantle,309,70,0,0,1,1
+13190,3,2940,1,45,Cryptid Mantle,309,70,0,0,2,1
+13191,3,2940,1,45,Cryptid Mantle,309,70,0,0,3,1
+13192,3,2940,1,45,Cryptid Mantle,309,70,0,0,4,1
 13510,3,5555,1,12,Mantle of Domination,309,60,0,0,0,1
 13511,3,5555,1,12,Mantle of Domination,309,60,0,0,1,1
 13512,3,5555,1,12,Mantle of Domination,309,60,0,0,2,1
@@ -19643,210 +19643,210 @@
 13834,3,30000,1,10,Victor's Mantle (I),309,1,0,0,0,1
 13835,3,20000,1,10,Victor's Mantle (II),309,1,0,0,0,1
 13836,3,10000,1,10,Victor's Mantle (III),309,1,0,0,0,1
-15569,3,3111,1,13,Crimson Cloak,309,72,0,0,0,1
-15570,3,3111,1,13,Crimson Cloak,309,72,0,0,1,1
-15571,3,3111,1,13,Crimson Cloak,309,72,0,0,2,1
-15572,3,3111,1,13,Crimson Cloak,309,72,0,0,3,1
-15573,3,3111,1,13,Crimson Cloak,309,72,0,0,4,1
-15574,3,3375,1,2,Sea Eagle's Mantle,309,75,0,0,0,1
-15575,3,3375,1,2,Sea Eagle's Mantle,309,75,0,0,1,1
-15576,3,3375,1,2,Sea Eagle's Mantle,309,75,0,0,2,1
-15577,3,3375,1,2,Sea Eagle's Mantle,309,75,0,0,3,1
-15578,3,3375,1,2,Sea Eagle's Mantle,309,75,0,0,4,1
-15579,3,3375,1,7,Mantle of Military Rule,309,75,0,0,0,1
-15580,3,3375,1,7,Mantle of Military Rule,309,75,0,0,1,1
-15581,3,3375,1,7,Mantle of Military Rule,309,75,0,0,2,1
-15582,3,3375,1,7,Mantle of Military Rule,309,75,0,0,3,1
-15583,3,3375,1,7,Mantle of Military Rule,309,75,0,0,4,1
-15584,3,3375,1,12,Nigredo Mantle,309,75,0,0,0,1
-15585,3,3375,1,12,Nigredo Mantle,309,75,0,0,1,1
-15586,3,3375,1,12,Nigredo Mantle,309,75,0,0,2,1
-15587,3,3375,1,12,Nigredo Mantle,309,75,0,0,3,1
-15588,3,3375,1,12,Nigredo Mantle,309,75,0,0,4,1
-15589,3,3840,1,11,Greedy Mantle,309,80,0,0,0,1
-15590,3,3840,1,11,Greedy Mantle,309,80,0,0,1,1
-15591,3,3840,1,11,Greedy Mantle,309,80,0,0,2,1
-15592,3,3840,1,11,Greedy Mantle,309,80,0,0,3,1
-15593,3,3840,1,11,Greedy Mantle,309,80,0,0,4,1
-15594,3,3558,1,12,White Leather Cloak,309,77,0,0,0,1
-15595,3,3558,1,12,White Leather Cloak,309,77,0,0,1,1
-15596,3,3558,1,12,White Leather Cloak,309,77,0,0,2,1
-15597,3,3558,1,12,White Leather Cloak,309,77,0,0,3,1
-15598,3,3558,1,12,White Leather Cloak,309,77,0,0,4,1
-15599,3,3840,1,1,Bluish Purple Muffler,309,80,0,0,0,1
-15600,3,3840,1,1,Bluish Purple Muffler,309,80,0,0,1,1
-15601,3,3840,1,1,Bluish Purple Muffler,309,80,0,0,2,1
-15602,3,3840,1,1,Bluish Purple Muffler,309,80,0,0,3,1
-15603,3,3840,1,1,Bluish Purple Muffler,309,80,0,0,4,1
-15604,3,3840,1,6,Spirit Mantle,309,80,0,0,0,1
-15605,3,3840,1,6,Spirit Mantle,309,80,0,0,1,1
-15606,3,3840,1,6,Spirit Mantle,309,80,0,0,2,1
-15607,3,3840,1,6,Spirit Mantle,309,80,0,0,3,1
-15608,3,3840,1,6,Spirit Mantle,309,80,0,0,4,1
-15609,3,3840,1,11,Azure Mantle,309,80,0,0,0,1
-15610,3,3840,1,11,Azure Mantle,309,80,0,0,1,1
-15611,3,3840,1,11,Azure Mantle,309,80,0,0,2,1
-15612,3,3840,1,11,Azure Mantle,309,80,0,0,3,1
-15613,3,3840,1,11,Azure Mantle,309,80,0,0,4,1
+15569,3,3111,1,45,Crimson Cloak,309,72,0,0,0,1
+15570,3,3111,1,45,Crimson Cloak,309,72,0,0,1,1
+15571,3,3111,1,45,Crimson Cloak,309,72,0,0,2,1
+15572,3,3111,1,45,Crimson Cloak,309,72,0,0,3,1
+15573,3,3111,1,45,Crimson Cloak,309,72,0,0,4,1
+15574,3,3375,1,50,Sea Eagle's Mantle,309,75,0,0,0,1
+15575,3,3375,1,50,Sea Eagle's Mantle,309,75,0,0,1,1
+15576,3,3375,1,50,Sea Eagle's Mantle,309,75,0,0,2,1
+15577,3,3375,1,50,Sea Eagle's Mantle,309,75,0,0,3,1
+15578,3,3375,1,50,Sea Eagle's Mantle,309,75,0,0,4,1
+15579,3,3375,1,55,Mantle of Military Rule,309,75,0,0,0,1
+15580,3,3375,1,55,Mantle of Military Rule,309,75,0,0,1,1
+15581,3,3375,1,55,Mantle of Military Rule,309,75,0,0,2,1
+15582,3,3375,1,55,Mantle of Military Rule,309,75,0,0,3,1
+15583,3,3375,1,55,Mantle of Military Rule,309,75,0,0,4,1
+15584,3,3375,1,60,Nigredo Mantle,309,75,0,0,0,1
+15585,3,3375,1,60,Nigredo Mantle,309,75,0,0,1,1
+15586,3,3375,1,60,Nigredo Mantle,309,75,0,0,2,1
+15587,3,3375,1,60,Nigredo Mantle,309,75,0,0,3,1
+15588,3,3375,1,60,Nigredo Mantle,309,75,0,0,4,1
+15589,3,3840,1,75,Greedy Mantle,309,80,0,0,0,1
+15590,3,3840,1,75,Greedy Mantle,309,80,0,0,1,1
+15591,3,3840,1,75,Greedy Mantle,309,80,0,0,2,1
+15592,3,3840,1,75,Greedy Mantle,309,80,0,0,3,1
+15593,3,3840,1,75,Greedy Mantle,309,80,0,0,4,1
+15594,3,3558,1,60,White Leather Cloak,309,77,0,0,0,1
+15595,3,3558,1,60,White Leather Cloak,309,77,0,0,1,1
+15596,3,3558,1,60,White Leather Cloak,309,77,0,0,2,1
+15597,3,3558,1,60,White Leather Cloak,309,77,0,0,3,1
+15598,3,3558,1,60,White Leather Cloak,309,77,0,0,4,1
+15599,3,3840,1,65,Bluish Purple Muffler,309,80,0,0,0,1
+15600,3,3840,1,65,Bluish Purple Muffler,309,80,0,0,1,1
+15601,3,3840,1,65,Bluish Purple Muffler,309,80,0,0,2,1
+15602,3,3840,1,65,Bluish Purple Muffler,309,80,0,0,3,1
+15603,3,3840,1,65,Bluish Purple Muffler,309,80,0,0,4,1
+15604,3,3840,1,70,Spirit Mantle,309,80,0,0,0,1
+15605,3,3840,1,70,Spirit Mantle,309,80,0,0,1,1
+15606,3,3840,1,70,Spirit Mantle,309,80,0,0,2,1
+15607,3,3840,1,70,Spirit Mantle,309,80,0,0,3,1
+15608,3,3840,1,70,Spirit Mantle,309,80,0,0,4,1
+15609,3,3840,1,75,Azure Mantle,309,80,0,0,0,1
+15610,3,3840,1,75,Azure Mantle,309,80,0,0,1,1
+15611,3,3840,1,75,Azure Mantle,309,80,0,0,2,1
+15612,3,3840,1,75,Azure Mantle,309,80,0,0,3,1
+15613,3,3840,1,75,Azure Mantle,309,80,0,0,4,1
 16731,3,100,1,1,Fancy Dress: Imp's Mantle,309,1,0,0,4,1
 16732,3,100,1,1,Fancy Dress: Vampire's Mantle,309,1,0,0,4,1
 16792,3,100,1,1,Christmas Mantle,309,1,0,0,4,1
 16793,3,0,1,1,Present Sack (Supplied),309,1,0,0,0,1
 16794,3,100,1,1,Present Sack,309,1,0,0,4,1
 16799,3,100,1,1,Christmas Mantle (White),309,1,0,0,4,1
-17841,3,3868,1,0,Arabesque Stole,309,80,0,0,0,1
-17842,3,3868,1,0,Arabesque Stole,309,80,0,0,1,1
-17843,3,3868,1,0,Arabesque Stole,309,80,0,0,2,1
-17844,3,3868,1,0,Arabesque Stole,309,80,0,0,3,1
-17845,3,3868,1,0,Arabesque Stole,309,80,0,0,4,1
-17846,3,4147,1,5,Albasiyyah,309,83,0,0,0,1
-17847,3,4147,1,5,Albasiyyah,309,83,0,0,1,1
-17848,3,4147,1,5,Albasiyyah,309,83,0,0,2,1
-17849,3,4147,1,5,Albasiyyah,309,83,0,0,3,1
-17850,3,4147,1,5,Albasiyyah,309,83,0,0,4,1
-17851,3,4332,1,10,Acrean Cloak,309,85,0,0,0,1
-17852,3,4332,1,10,Acrean Cloak,309,85,0,0,1,1
-17853,3,4332,1,10,Acrean Cloak,309,85,0,0,2,1
-17854,3,4332,1,10,Acrean Cloak,309,85,0,0,3,1
-17855,3,4332,1,10,Acrean Cloak,309,85,0,0,4,1
-18469,3,4332,1,10,Desert Stole,309,85,0,0,0,1
-18470,3,4332,1,10,Desert Stole,309,85,0,0,1,1
-18471,3,4332,1,10,Desert Stole,309,85,0,0,2,1
-18472,3,4332,1,10,Desert Stole,309,85,0,0,3,1
-18473,3,4332,1,10,Desert Stole,309,85,0,0,4,1
-18474,3,4634,1,15,Oriental Mantle,309,88,0,0,0,1
-18475,3,4634,1,15,Oriental Mantle,309,88,0,0,1,1
-18476,3,4634,1,15,Oriental Mantle,309,88,0,0,2,1
-18477,3,4634,1,15,Oriental Mantle,309,88,0,0,3,1
-18478,3,4634,1,15,Oriental Mantle,309,88,0,0,4,1
-18479,3,4813,1,4,Eastern Shade,309,90,0,0,0,1
-18480,3,4813,1,4,Eastern Shade,309,90,0,0,1,1
-18481,3,4813,1,4,Eastern Shade,309,90,0,0,2,1
-18482,3,4813,1,4,Eastern Shade,309,90,0,0,3,1
-18483,3,4813,1,4,Eastern Shade,309,90,0,0,4,1
-18894,3,200,1,11,Mantle of Battle Supremacy,309,80,0,0,0,1
-18895,3,400,1,11,Mantle of Battle Supremacy,309,80,0,0,1,1
-18896,3,800,1,11,Mantle of Battle Supremacy,309,80,0,0,2,1
-18897,3,1600,1,11,Mantle of Battle Supremacy,309,80,0,0,3,1
-18898,3,30000,1,11,Mantle of Battle Supremacy,309,80,0,0,4,1
-18899,3,0,1,11,Magica Cloak,309,1,0,0,0,1
-19564,3,0,1,11,Magica Cloak,309,1,0,0,1,1
-19565,3,0,1,0,Magica Cloak,309,1,0,0,2,1
-19566,3,0,1,5,Magica Cloak,309,1,0,0,3,1
-19567,3,0,1,10,Magica Cloak,309,1,0,0,4,1
-19380,3,10000,1,10,Gloria Stole,309,85,0,0,4,1
-19381,3,10000,1,10,Ancient Mantle,309,1,0,0,4,1
-20728,3,4800,1,4,Scapular Mantle,309,90,0,0,0,1
-20729,3,4800,1,4,Scapular Mantle,309,90,0,0,1,1
-20730,3,4800,1,4,Scapular Mantle,309,90,0,0,2,1
-20731,3,4800,1,4,Scapular Mantle,309,90,0,0,3,1
-20732,3,4800,1,4,Scapular Mantle,309,90,0,0,4,1
-20733,3,5040,1,9,Suiere Mantle,309,93,0,0,0,1
-20734,3,5040,1,9,Suiere Mantle,309,93,0,0,1,1
-20735,3,5040,1,9,Suiere Mantle,309,93,0,0,2,1
-20736,3,5040,1,9,Suiere Mantle,309,93,0,0,3,1
-20737,3,5040,1,9,Suiere Mantle,309,93,0,0,4,1
-20738,3,5280,1,14,Bachelor's Mantle,309,95,0,0,0,1
-20739,3,5280,1,14,Bachelor's Mantle,309,95,0,0,1,1
-20740,3,5280,1,14,Bachelor's Mantle,309,95,0,0,2,1
-20741,3,5280,1,14,Bachelor's Mantle,309,95,0,0,3,1
-20742,3,5280,1,14,Bachelor's Mantle,309,95,0,0,4,1
-21072,3,5280,1,14,Rébellion Cloak,309,95,0,0,0,1
-21073,3,5280,1,14,Rébellion Cloak,309,95,0,0,1,1
-21074,3,5280,1,14,Rébellion Cloak,309,95,0,0,2,1
-21075,3,5280,1,14,Rébellion Cloak,309,95,0,0,3,1
-21076,3,5280,1,14,Rébellion Cloak,309,95,0,0,4,1
-21077,3,5520,1,3,Traître Mantle,309,98,0,0,0,1
-21078,3,5520,1,3,Traître Mantle,309,98,0,0,1,1
-21079,3,5520,1,3,Traître Mantle,309,98,0,0,2,1
-21080,3,5520,1,3,Traître Mantle,309,98,0,0,3,1
-21081,3,5520,1,3,Traître Mantle,309,98,0,0,4,1
-21082,3,5760,1,8,Revanche Mantle,309,100,0,0,0,1
-21083,3,5760,1,8,Revanche Mantle,309,100,0,0,1,1
-21084,3,5760,1,8,Revanche Mantle,309,100,0,0,2,1
-21085,3,5760,1,8,Revanche Mantle,309,100,0,0,3,1
-21086,3,5760,1,8,Revanche Mantle,309,100,0,0,4,1
+17841,3,3868,1,80,Arabesque Stole,309,80,0,0,0,1
+17842,3,3868,1,80,Arabesque Stole,309,80,0,0,1,1
+17843,3,3868,1,80,Arabesque Stole,309,80,0,0,2,1
+17844,3,3868,1,80,Arabesque Stole,309,80,0,0,3,1
+17845,3,3868,1,80,Arabesque Stole,309,80,0,0,4,1
+17846,3,4147,1,85,Albasiyyah,309,83,0,0,0,1
+17847,3,4147,1,85,Albasiyyah,309,83,0,0,1,1
+17848,3,4147,1,85,Albasiyyah,309,83,0,0,2,1
+17849,3,4147,1,85,Albasiyyah,309,83,0,0,3,1
+17850,3,4147,1,85,Albasiyyah,309,83,0,0,4,1
+17851,3,4332,1,90,Acrean Cloak,309,85,0,0,0,1
+17852,3,4332,1,90,Acrean Cloak,309,85,0,0,1,1
+17853,3,4332,1,90,Acrean Cloak,309,85,0,0,2,1
+17854,3,4332,1,90,Acrean Cloak,309,85,0,0,3,1
+17855,3,4332,1,90,Acrean Cloak,309,85,0,0,4,1
+18469,3,4332,1,90,Desert Stole,309,85,0,0,0,1
+18470,3,4332,1,90,Desert Stole,309,85,0,0,1,1
+18471,3,4332,1,90,Desert Stole,309,85,0,0,2,1
+18472,3,4332,1,90,Desert Stole,309,85,0,0,3,1
+18473,3,4332,1,90,Desert Stole,309,85,0,0,4,1
+18474,3,4634,1,95,Oriental Mantle,309,88,0,0,0,1
+18475,3,4634,1,95,Oriental Mantle,309,88,0,0,1,1
+18476,3,4634,1,95,Oriental Mantle,309,88,0,0,2,1
+18477,3,4634,1,95,Oriental Mantle,309,88,0,0,3,1
+18478,3,4634,1,95,Oriental Mantle,309,88,0,0,4,1
+18479,3,4813,1,100,Eastern Shade,309,90,0,0,0,1
+18480,3,4813,1,100,Eastern Shade,309,90,0,0,1,1
+18481,3,4813,1,100,Eastern Shade,309,90,0,0,2,1
+18482,3,4813,1,100,Eastern Shade,309,90,0,0,3,1
+18483,3,4813,1,100,Eastern Shade,309,90,0,0,4,1
+18894,3,200,1,75,Mantle of Battle Supremacy,309,80,0,0,0,1
+18895,3,400,1,75,Mantle of Battle Supremacy,309,80,0,0,1,1
+18896,3,800,1,75,Mantle of Battle Supremacy,309,80,0,0,2,1
+18897,3,1600,1,75,Mantle of Battle Supremacy,309,80,0,0,3,1
+18898,3,30000,1,75,Mantle of Battle Supremacy,309,80,0,0,4,1
+18899,3,0,1,75,Magica Cloak,309,1,0,0,0,1
+19564,3,0,1,75,Magica Cloak,309,1,0,0,1,1
+19565,3,0,1,80,Magica Cloak,309,1,0,0,2,1
+19566,3,0,1,85,Magica Cloak,309,1,0,0,3,1
+19567,3,0,1,90,Magica Cloak,309,1,0,0,4,1
+19380,3,10000,1,90,Gloria Stole,309,85,0,0,4,1
+19381,3,10000,1,90,Ancient Mantle,309,1,0,0,4,1
+20728,3,4800,1,100,Scapular Mantle,309,90,0,0,0,1
+20729,3,4800,1,100,Scapular Mantle,309,90,0,0,1,1
+20730,3,4800,1,100,Scapular Mantle,309,90,0,0,2,1
+20731,3,4800,1,100,Scapular Mantle,309,90,0,0,3,1
+20732,3,4800,1,100,Scapular Mantle,309,90,0,0,4,1
+20733,3,5040,1,105,Suiere Mantle,309,93,0,0,0,1
+20734,3,5040,1,105,Suiere Mantle,309,93,0,0,1,1
+20735,3,5040,1,105,Suiere Mantle,309,93,0,0,2,1
+20736,3,5040,1,105,Suiere Mantle,309,93,0,0,3,1
+20737,3,5040,1,105,Suiere Mantle,309,93,0,0,4,1
+20738,3,5280,1,110,Bachelor's Mantle,309,95,0,0,0,1
+20739,3,5280,1,110,Bachelor's Mantle,309,95,0,0,1,1
+20740,3,5280,1,110,Bachelor's Mantle,309,95,0,0,2,1
+20741,3,5280,1,110,Bachelor's Mantle,309,95,0,0,3,1
+20742,3,5280,1,110,Bachelor's Mantle,309,95,0,0,4,1
+21072,3,5280,1,110,Rébellion Cloak,309,95,0,0,0,1
+21073,3,5280,1,110,Rébellion Cloak,309,95,0,0,1,1
+21074,3,5280,1,110,Rébellion Cloak,309,95,0,0,2,1
+21075,3,5280,1,110,Rébellion Cloak,309,95,0,0,3,1
+21076,3,5280,1,110,Rébellion Cloak,309,95,0,0,4,1
+21077,3,5520,1,115,Traître Mantle,309,98,0,0,0,1
+21078,3,5520,1,115,Traître Mantle,309,98,0,0,1,1
+21079,3,5520,1,115,Traître Mantle,309,98,0,0,2,1
+21080,3,5520,1,115,Traître Mantle,309,98,0,0,3,1
+21081,3,5520,1,115,Traître Mantle,309,98,0,0,4,1
+21082,3,5760,1,120,Revanche Mantle,309,100,0,0,0,1
+21083,3,5760,1,120,Revanche Mantle,309,100,0,0,1,1
+21084,3,5760,1,120,Revanche Mantle,309,100,0,0,2,1
+21085,3,5760,1,120,Revanche Mantle,309,100,0,0,3,1
+21086,3,5760,1,120,Revanche Mantle,309,100,0,0,4,1
 20442,3,10000,1,10,Magical Night Vampire Mantle,309,1,0,0,4,1
-21142,3,0,1,5,Sadek Mantle,309,90,0,0,0,1
-21143,3,0,1,5,Sadek Mantle,309,90,0,0,1,1
-21144,3,0,1,10,Sadek Mantle,309,90,0,0,2,1
-21145,3,0,1,15,Sadek Mantle,309,90,0,0,3,1
-21146,3,0,1,4,Sadek Mantle,309,90,0,0,4,1
-21147,3,0,1,15,Royal Mantle of the Shoulder Armor,309,95,0,0,0,1
-21148,3,0,1,15,Royal Mantle of the Shoulder Armor,309,95,0,0,1,1
-21149,3,0,1,4,Royal Mantle of the Shoulder Armor,309,95,0,0,2,1
-21150,3,0,1,9,Royal Mantle of the Shoulder Armor,309,95,0,0,3,1
-21151,3,0,1,14,Royal Mantle of the Shoulder Armor,309,95,0,0,4,1
-21152,3,0,1,9,Sauveur Mantle of the Royal Family,309,100,0,0,0,1
-21153,3,0,1,9,Sauveur Mantle of the Royal Family,309,100,0,0,1,1
-21154,3,0,1,14,Sauveur Mantle of the Royal Family,309,100,0,0,2,1
-21155,3,0,1,3,Sauveur Mantle of the Royal Family,309,100,0,0,3,1
-21156,3,0,1,8,Sauveur Mantle of the Royal Family,309,100,0,0,4,1
-21102,3,10000,1,4,Necromanced Mantle,309,1,0,0,4,1
-21103,3,10000,1,4,Cloak of Lament,309,1,0,0,4,1
-21104,3,10000,1,14,Corpse Mantle,309,1,0,0,4,1
-21105,3,10000,1,14,Death Hunter's Corpse Mantle,309,1,0,0,4,1
-21106,3,10000,1,8,Wings of Lahar,309,1,0,0,4,1
-21107,3,10000,1,8,Sparkling Wings of Lahar,309,1,0,0,4,1
-21295,3,10000,1,12,Maestro Mantle,309,1,0,0,4,1
-21297,3,10000,1,15,Virtuoso Mantle,309,1,0,0,4,1
-21704,3,10000,1,11,Bunny Tail (White),309,1,0,0,4,1
-21705,3,10000,1,11,Bunny Tail (Black),309,1,0,0,4,1
-21706,3,10000,1,11,Bunny Tail (White),309,1,0,0,4,1
-21707,3,10000,1,11,Kitty Tail (Brown),309,1,0,0,4,1
-21708,3,10000,1,11,Kitty Tail (Black),309,1,0,0,4,1
-21709,3,10000,1,11,Kitty Tail (Brown),309,1,0,0,4,1
-21710,3,10000,1,11,Raccoon Tail (White),309,1,0,0,4,1
-21711,3,10000,1,11,Raccoon Tail (Black),309,1,0,0,4,1
-21712,3,10000,1,11,Raccoon Tail (Brown),309,1,0,0,4,1
+21142,3,0,1,85,Sadek Mantle,309,90,0,0,0,1
+21143,3,0,1,85,Sadek Mantle,309,90,0,0,1,1
+21144,3,0,1,90,Sadek Mantle,309,90,0,0,2,1
+21145,3,0,1,95,Sadek Mantle,309,90,0,0,3,1
+21146,3,0,1,100,Sadek Mantle,309,90,0,0,4,1
+21147,3,0,1,95,Royal Mantle of the Shoulder Armor,309,95,0,0,0,1
+21148,3,0,1,95,Royal Mantle of the Shoulder Armor,309,95,0,0,1,1
+21149,3,0,1,100,Royal Mantle of the Shoulder Armor,309,95,0,0,2,1
+21150,3,0,1,105,Royal Mantle of the Shoulder Armor,309,95,0,0,3,1
+21151,3,0,1,110,Royal Mantle of the Shoulder Armor,309,95,0,0,4,1
+21152,3,0,1,105,Sauveur Mantle of the Royal Family,309,100,0,0,0,1
+21153,3,0,1,105,Sauveur Mantle of the Royal Family,309,100,0,0,1,1
+21154,3,0,1,110,Sauveur Mantle of the Royal Family,309,100,0,0,2,1
+21155,3,0,1,115,Sauveur Mantle of the Royal Family,309,100,0,0,3,1
+21156,3,0,1,120,Sauveur Mantle of the Royal Family,309,100,0,0,4,1
+21102,3,10000,1,100,Necromanced Mantle,309,1,0,0,4,1
+21103,3,10000,1,100,Cloak of Lament,309,1,0,0,4,1
+21104,3,10000,1,110,Corpse Mantle,309,1,0,0,4,1
+21105,3,10000,1,110,Death Hunter's Corpse Mantle,309,1,0,0,4,1
+21106,3,10000,1,120,Wings of Lahar,309,1,0,0,4,1
+21107,3,10000,1,120,Sparkling Wings of Lahar,309,1,0,0,4,1
+21295,3,10000,1,92,Maestro Mantle,309,1,0,0,4,1
+21297,3,10000,1,95,Virtuoso Mantle,309,1,0,0,4,1
+21704,3,10000,1,75,Bunny Tail (White),309,1,0,0,4,1
+21705,3,10000,1,75,Bunny Tail (Black),309,1,0,0,4,1
+21706,3,10000,1,75,Bunny Tail (White),309,1,0,0,4,1
+21707,3,10000,1,75,Kitty Tail (Brown),309,1,0,0,4,1
+21708,3,10000,1,75,Kitty Tail (Black),309,1,0,0,4,1
+21709,3,10000,1,75,Kitty Tail (Brown),309,1,0,0,4,1
+21710,3,10000,1,75,Raccoon Tail (White),309,1,0,0,4,1
+21711,3,10000,1,75,Raccoon Tail (Black),309,1,0,0,4,1
+21712,3,10000,1,75,Raccoon Tail (Brown),309,1,0,0,4,1
 23430,3,10000,1,1,Demon's Bat Wings (White),309,1,0,0,4,1
 23431,3,10000,1,1,Demon's Bat Wings (Red),309,1,0,0,4,1
 23432,3,10000,1,1,Angel's Feather Wings (White),309,1,0,0,4,1
 23433,3,10000,1,1,Angel's Feather Wings (Black),309,1,0,0,4,1
-24669,3,0,1,2,Spirit's Cloak,309,100,0,0,0,1
-24670,3,0,1,2,Spirit's Cloak,309,100,0,0,1,1
-24671,3,0,1,2,Spirit's Cloak,309,100,0,0,2,1
-24672,3,0,1,2,Spirit's Cloak,309,100,0,0,3,1
-24673,3,0,1,2,Spirit's Cloak,309,100,0,0,4,1
-24674,3,0,1,2,Fire King's Cloak,309,100,0,0,0,1
-24675,3,0,1,2,Fire King's Cloak,309,100,0,0,1,1
-24676,3,0,1,2,Fire King's Cloak,309,100,0,0,2,1
-24677,3,0,1,2,Fire King's Cloak,309,100,0,0,3,1
-24678,3,0,1,2,Fire King's Cloak,309,100,0,0,4,1
-24679,3,0,1,2,White Wings' Cloak,309,100,0,0,0,1
-24680,3,0,1,2,White Wings' Cloak,309,100,0,0,1,1
-24681,3,0,1,2,White Wings' Cloak,309,100,0,0,2,1
-24682,3,0,1,2,White Wings' Cloak,309,100,0,0,3,1
-24683,3,0,1,2,White Wings' Cloak,309,100,0,0,4,1
-24684,3,0,1,2,Golden Cloak,309,100,0,0,0,1
-24685,3,0,1,2,Golden Cloak,309,100,0,0,1,1
-24686,3,0,1,2,Golden Cloak,309,100,0,0,2,1
-24687,3,0,1,2,Golden Cloak,309,100,0,0,3,1
-24688,3,0,1,2,Golden Cloak,309,100,0,0,4,1
-24689,3,0,1,7,Blackshatter Cloak,309,100,0,0,0,1
-24690,3,0,1,7,Blackshatter Cloak,309,100,0,0,1,1
-24691,3,0,1,7,Blackshatter Cloak,309,100,0,0,2,1
-24692,3,0,1,7,Blackshatter Cloak,309,100,0,0,3,1
-24693,3,0,1,7,Blackshatter Cloak,309,100,0,0,4,1
+24669,3,0,1,130,Spirit's Cloak,309,100,0,0,0,1
+24670,3,0,1,130,Spirit's Cloak,309,100,0,0,1,1
+24671,3,0,1,130,Spirit's Cloak,309,100,0,0,2,1
+24672,3,0,1,130,Spirit's Cloak,309,100,0,0,3,1
+24673,3,0,1,130,Spirit's Cloak,309,100,0,0,4,1
+24674,3,0,1,130,Fire King's Cloak,309,100,0,0,0,1
+24675,3,0,1,130,Fire King's Cloak,309,100,0,0,1,1
+24676,3,0,1,130,Fire King's Cloak,309,100,0,0,2,1
+24677,3,0,1,130,Fire King's Cloak,309,100,0,0,3,1
+24678,3,0,1,130,Fire King's Cloak,309,100,0,0,4,1
+24679,3,0,1,130,White Wings' Cloak,309,100,0,0,0,1
+24680,3,0,1,130,White Wings' Cloak,309,100,0,0,1,1
+24681,3,0,1,130,White Wings' Cloak,309,100,0,0,2,1
+24682,3,0,1,130,White Wings' Cloak,309,100,0,0,3,1
+24683,3,0,1,130,White Wings' Cloak,309,100,0,0,4,1
+24684,3,0,1,130,Golden Cloak,309,100,0,0,0,1
+24685,3,0,1,130,Golden Cloak,309,100,0,0,1,1
+24686,3,0,1,130,Golden Cloak,309,100,0,0,2,1
+24687,3,0,1,130,Golden Cloak,309,100,0,0,3,1
+24688,3,0,1,130,Golden Cloak,309,100,0,0,4,1
+24689,3,0,1,135,Blackshatter Cloak,309,100,0,0,0,1
+24690,3,0,1,135,Blackshatter Cloak,309,100,0,0,1,1
+24691,3,0,1,135,Blackshatter Cloak,309,100,0,0,2,1
+24692,3,0,1,135,Blackshatter Cloak,309,100,0,0,3,1
+24693,3,0,1,135,Blackshatter Cloak,309,100,0,0,4,1
 24931,3,10000,1,1,Bunny Tail (Deep Red),309,1,0,0,0,1
 24932,3,10000,1,1,Kitty Tail (Deep Red),309,1,0,0,0,1
 24933,3,10000,1,1,Raccoon Tail (Deep Red),309,1,0,0,0,1
 24942,3,10000,1,1,Spriggan Mantle,309,1,0,0,4,1
-25486,3,5900,1,12,Holy Seal's Lively Cloak,309,105,0,0,0,1
-25487,3,5900,1,12,Holy Seal's Lively Cloak,309,105,0,0,1,1
-25488,3,5900,1,12,Holy Seal's Lively Cloak,309,105,0,0,2,1
-25489,3,5900,1,12,Holy Seal's Lively Cloak,309,105,0,0,3,1
-25490,3,5900,1,12,Holy Seal's Lively Cloak,309,105,0,0,4,1
-25501,3,5900,1,1,Trickster's Lively Cloak,309,110,0,0,0,1
-25502,3,5900,1,1,Trickster's Lively Cloak,309,110,0,0,1,1
-25503,3,5900,1,1,Trickster's Lively Cloak,309,110,0,0,2,1
-25504,3,5900,1,1,Trickster's Lively Cloak,309,110,0,0,3,1
-25505,3,5900,1,1,Trickster's Lively Cloak,309,110,0,0,4,1
-25516,3,5900,1,6,Hero's Lively Cloak,309,115,0,0,0,1
-25517,3,5900,1,6,Hero's Lively Cloak,309,115,0,0,1,1
-25518,3,5900,1,6,Hero's Lively Cloak,309,115,0,0,2,1
-25519,3,5900,1,6,Hero's Lively Cloak,309,115,0,0,3,1
-25520,3,5900,1,6,Hero's Lively Cloak,309,115,0,0,4,1
+25486,3,5900,1,140,Holy Seal's Lively Cloak,309,105,0,0,0,1
+25487,3,5900,1,140,Holy Seal's Lively Cloak,309,105,0,0,1,1
+25488,3,5900,1,140,Holy Seal's Lively Cloak,309,105,0,0,2,1
+25489,3,5900,1,140,Holy Seal's Lively Cloak,309,105,0,0,3,1
+25490,3,5900,1,140,Holy Seal's Lively Cloak,309,105,0,0,4,1
+25501,3,5900,1,145,Trickster's Lively Cloak,309,110,0,0,0,1
+25502,3,5900,1,145,Trickster's Lively Cloak,309,110,0,0,1,1
+25503,3,5900,1,145,Trickster's Lively Cloak,309,110,0,0,2,1
+25504,3,5900,1,145,Trickster's Lively Cloak,309,110,0,0,3,1
+25505,3,5900,1,145,Trickster's Lively Cloak,309,110,0,0,4,1
+25516,3,5900,1,150,Hero's Lively Cloak,309,115,0,0,0,1
+25517,3,5900,1,150,Hero's Lively Cloak,309,115,0,0,1,1
+25518,3,5900,1,150,Hero's Lively Cloak,309,115,0,0,2,1
+25519,3,5900,1,150,Hero's Lively Cloak,309,115,0,0,3,1
+25520,3,5900,1,150,Hero's Lively Cloak,309,115,0,0,4,1
 9465,3,5,1,1,Lantern,311,1,0,0,0,1
 9466,3,150,1,3,Elite Lantern,311,1,0,0,0,1
 9467,3,750,1,6,Artisan's Lantern,311,1,0,0,0,1
@@ -19952,46 +19952,46 @@
 10631,3,15000,1,10,Passion Town Maiden's Dress,312,1,0,0,2,3
 10632,3,15000,1,10,Passion Town Maiden's Dress,312,1,0,0,3,3
 10633,3,15000,1,10,Passion Town Maiden's Dress,312,1,0,0,4,3
-13515,3,20000,1,0,Apprentice Priest Robes (Refined),312,1,0,4,0,2
-13516,3,20000,1,0,Apprentice Priest Robes (Refined),312,1,0,4,1,2
-13517,3,20000,1,0,Apprentice Priest Robes (Refined),312,1,0,4,2,2
-13518,3,20000,1,0,Apprentice Priest Robes (Refined),312,1,0,4,3,2
-13519,3,20000,1,0,Apprentice Priest Robes (Refined),312,1,0,4,4,2
-13520,3,20000,1,0,Apprentice Priest Robes (Plain),312,1,0,4,0,2
-13521,3,20000,1,0,Apprentice Priest Robes (Plain),312,1,0,4,1,2
-13522,3,20000,1,0,Apprentice Priest Robes (Plain),312,1,0,4,2,2
-13523,3,20000,1,0,Apprentice Priest Robes (Plain),312,1,0,4,3,2
-13524,3,20000,1,0,Apprentice Priest Robes (Plain),312,1,0,4,4,2
-13525,3,20000,1,0,Tomboy Arisen's Clothes (Refined),312,1,0,4,0,3
-13526,3,20000,1,0,Tomboy Arisen's Clothes (Refined),312,1,0,4,1,3
-13527,3,20000,1,0,Tomboy Arisen's Clothes (Refined),312,1,0,4,2,3
-13528,3,20000,1,0,Tomboy Arisen's Clothes (Refined),312,1,0,4,3,3
-13529,3,20000,1,0,Tomboy Arisen's Clothes (Refined),312,1,0,4,4,3
-13530,3,20000,1,0,Tomboy Arisen's Clothes (Plain),312,1,0,4,0,3
-13531,3,20000,1,0,Tomboy Arisen's Clothes (Plain),312,1,0,4,1,3
-13532,3,20000,1,0,Tomboy Arisen's Clothes (Plain),312,1,0,4,2,3
-13533,3,20000,1,0,Tomboy Arisen's Clothes (Plain),312,1,0,4,3,3
-13534,3,20000,1,0,Tomboy Arisen's Clothes (Plain),312,1,0,4,4,3
-13535,3,20000,1,15,Prodigal Arisen's Clothes,312,1,0,4,0,2
-13536,3,20000,1,15,Prodigal Arisen's Clothes,312,1,0,4,1,2
-13537,3,20000,1,15,Prodigal Arisen's Clothes,312,1,0,4,2,2
-13538,3,20000,1,15,Prodigal Arisen's Clothes,312,1,0,4,3,2
-13539,3,20000,1,15,Prodigal Arisen's Clothes,312,1,0,4,4,2
-13540,3,20000,1,15,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,0,2
-13541,3,20000,1,15,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,1,2
-13542,3,20000,1,15,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,2,2
-13543,3,20000,1,15,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,3,2
-13544,3,20000,1,15,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,4,2
-13545,3,20000,1,15,Young Maiden's Battle Attire,312,1,0,4,0,3
-13546,3,20000,1,15,Young Maiden's Battle Attire,312,1,0,4,1,3
-13547,3,20000,1,15,Young Maiden's Battle Attire,312,1,0,4,2,3
-13548,3,20000,1,15,Young Maiden's Battle Attire,312,1,0,4,3,3
-13549,3,20000,1,15,Young Maiden's Battle Attire,312,1,0,4,4,3
-13550,3,20000,1,15,Young Maiden's Battle Attire (Dazzling),312,1,0,4,0,3
-13551,3,20000,1,15,Young Maiden's Battle Attire (Dazzling),312,1,0,4,1,3
-13552,3,20000,1,15,Young Maiden's Battle Attire (Dazzling),312,1,0,4,2,3
-13553,3,20000,1,15,Young Maiden's Battle Attire (Dazzling),312,1,0,4,3,3
-13554,3,20000,1,15,Young Maiden's Battle Attire (Dazzling),312,1,0,4,4,3
+13515,3,20000,1,16,Apprentice Priest Robes (Refined),312,1,0,4,0,2
+13516,3,20000,1,16,Apprentice Priest Robes (Refined),312,1,0,4,1,2
+13517,3,20000,1,16,Apprentice Priest Robes (Refined),312,1,0,4,2,2
+13518,3,20000,1,16,Apprentice Priest Robes (Refined),312,1,0,4,3,2
+13519,3,20000,1,16,Apprentice Priest Robes (Refined),312,1,0,4,4,2
+13520,3,20000,1,16,Apprentice Priest Robes (Plain),312,1,0,4,0,2
+13521,3,20000,1,16,Apprentice Priest Robes (Plain),312,1,0,4,1,2
+13522,3,20000,1,16,Apprentice Priest Robes (Plain),312,1,0,4,2,2
+13523,3,20000,1,16,Apprentice Priest Robes (Plain),312,1,0,4,3,2
+13524,3,20000,1,16,Apprentice Priest Robes (Plain),312,1,0,4,4,2
+13525,3,20000,1,16,Tomboy Arisen's Clothes (Refined),312,1,0,4,0,3
+13526,3,20000,1,16,Tomboy Arisen's Clothes (Refined),312,1,0,4,1,3
+13527,3,20000,1,16,Tomboy Arisen's Clothes (Refined),312,1,0,4,2,3
+13528,3,20000,1,16,Tomboy Arisen's Clothes (Refined),312,1,0,4,3,3
+13529,3,20000,1,16,Tomboy Arisen's Clothes (Refined),312,1,0,4,4,3
+13530,3,20000,1,16,Tomboy Arisen's Clothes (Plain),312,1,0,4,0,3
+13531,3,20000,1,16,Tomboy Arisen's Clothes (Plain),312,1,0,4,1,3
+13532,3,20000,1,16,Tomboy Arisen's Clothes (Plain),312,1,0,4,2,3
+13533,3,20000,1,16,Tomboy Arisen's Clothes (Plain),312,1,0,4,3,3
+13534,3,20000,1,16,Tomboy Arisen's Clothes (Plain),312,1,0,4,4,3
+13535,3,20000,1,31,Prodigal Arisen's Clothes,312,1,0,4,0,2
+13536,3,20000,1,31,Prodigal Arisen's Clothes,312,1,0,4,1,2
+13537,3,20000,1,31,Prodigal Arisen's Clothes,312,1,0,4,2,2
+13538,3,20000,1,31,Prodigal Arisen's Clothes,312,1,0,4,3,2
+13539,3,20000,1,31,Prodigal Arisen's Clothes,312,1,0,4,4,2
+13540,3,20000,1,31,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,0,2
+13541,3,20000,1,31,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,1,2
+13542,3,20000,1,31,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,2,2
+13543,3,20000,1,31,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,3,2
+13544,3,20000,1,31,Prodigal Arisen's Clothes (Dazzling),312,1,0,4,4,2
+13545,3,20000,1,31,Young Maiden's Battle Attire,312,1,0,4,0,3
+13546,3,20000,1,31,Young Maiden's Battle Attire,312,1,0,4,1,3
+13547,3,20000,1,31,Young Maiden's Battle Attire,312,1,0,4,2,3
+13548,3,20000,1,31,Young Maiden's Battle Attire,312,1,0,4,3,3
+13549,3,20000,1,31,Young Maiden's Battle Attire,312,1,0,4,4,3
+13550,3,20000,1,31,Young Maiden's Battle Attire (Dazzling),312,1,0,4,0,3
+13551,3,20000,1,31,Young Maiden's Battle Attire (Dazzling),312,1,0,4,1,3
+13552,3,20000,1,31,Young Maiden's Battle Attire (Dazzling),312,1,0,4,2,3
+13553,3,20000,1,31,Young Maiden's Battle Attire (Dazzling),312,1,0,4,3,3
+13554,3,20000,1,31,Young Maiden's Battle Attire (Dazzling),312,1,0,4,4,3
 13759,3,2600,1,10,Bathrobe of Relaxation (Fine),312,1,0,0,0,2
 13760,3,2600,1,10,Bathrobe of Relaxation (Elegant),312,1,0,0,0,3
 14163,3,15000,1,8,Phantom Suit,312,1,0,4,0,2
@@ -20004,36 +20004,36 @@
 14170,3,15000,1,8,Panther Rubber,312,1,0,4,2,3
 14171,3,15000,1,8,Panther Rubber,312,1,0,4,3,3
 14172,3,15000,1,8,Panther Rubber,312,1,0,4,4,3
-14173,3,25000,1,15,Trickster Suit,312,40,0,4,0,2
-14174,3,25000,1,15,Trickster Suit,312,40,0,4,1,2
-14175,3,25000,1,15,Trickster Suit,312,40,0,4,2,2
-14176,3,25000,1,15,Trickster Suit,312,40,0,4,3,2
-14177,3,25000,1,15,Trickster Suit,312,40,0,4,4,2
-14178,3,25000,1,15,Trickster Rubber,312,40,0,4,0,3
-14179,3,25000,1,15,Trickster Rubber,312,40,0,4,1,3
-14180,3,25000,1,15,Trickster Rubber,312,40,0,4,2,3
-14181,3,25000,1,15,Trickster Rubber,312,40,0,4,3,3
-14182,3,25000,1,15,Trickster Rubber,312,40,0,4,4,3
-15615,3,20000,1,13,Knight Commander's Armor (Refined),312,1,0,4,0,2
-15616,3,20000,1,13,Knight Commander's Armor (Refined),312,1,0,4,1,2
-15617,3,20000,1,13,Knight Commander's Armor (Refined),312,1,0,4,2,2
-15618,3,20000,1,13,Knight Commander's Armor (Refined),312,1,0,4,3,2
-15619,3,20000,1,13,Knight Commander's Armor (Refined),312,1,0,4,4,2
-15620,3,20000,1,13,Knight Commander's Armor (Plain),312,1,0,4,0,2
-15621,3,20000,1,13,Knight Commander's Armor (Plain),312,1,0,4,1,2
-15622,3,20000,1,13,Knight Commander's Armor (Plain),312,1,0,4,2,2
-15623,3,20000,1,13,Knight Commander's Armor (Plain),312,1,0,4,3,2
-15624,3,20000,1,13,Knight Commander's Armor (Plain),312,1,0,4,4,2
-15625,3,20000,1,13,Deputy Knight Commander's Armor (Refined),312,1,0,4,0,3
-15626,3,20000,1,13,Deputy Knight Commander's Armor (Refined),312,1,0,4,1,3
-15627,3,20000,1,13,Deputy Knight Commander's Armor (Refined),312,1,0,4,2,3
-15628,3,20000,1,13,Deputy Knight Commander's Armor (Refined),312,1,0,4,3,3
-15629,3,20000,1,13,Deputy Knight Commander's Armor (Refined),312,1,0,4,4,3
-15630,3,20000,1,13,Deputy Knight Commander's Armor (Plain),312,1,0,4,0,3
-15631,3,20000,1,13,Deputy Knight Commander's Armor (Plain),312,1,0,4,1,3
-15632,3,20000,1,13,Deputy Knight Commander's Armor (Plain),312,1,0,4,2,3
-15633,3,20000,1,13,Deputy Knight Commander's Armor (Plain),312,1,0,4,3,3
-15634,3,20000,1,13,Deputy Knight Commander's Armor (Plain),312,1,0,4,4,3
+14173,3,25000,1,31,Trickster Suit,312,40,0,4,0,2
+14174,3,25000,1,31,Trickster Suit,312,40,0,4,1,2
+14175,3,25000,1,31,Trickster Suit,312,40,0,4,2,2
+14176,3,25000,1,31,Trickster Suit,312,40,0,4,3,2
+14177,3,25000,1,31,Trickster Suit,312,40,0,4,4,2
+14178,3,25000,1,31,Trickster Rubber,312,40,0,4,0,3
+14179,3,25000,1,31,Trickster Rubber,312,40,0,4,1,3
+14180,3,25000,1,31,Trickster Rubber,312,40,0,4,2,3
+14181,3,25000,1,31,Trickster Rubber,312,40,0,4,3,3
+14182,3,25000,1,31,Trickster Rubber,312,40,0,4,4,3
+15615,3,20000,1,45,Knight Commander's Armor (Refined),312,1,0,4,0,2
+15616,3,20000,1,45,Knight Commander's Armor (Refined),312,1,0,4,1,2
+15617,3,20000,1,45,Knight Commander's Armor (Refined),312,1,0,4,2,2
+15618,3,20000,1,45,Knight Commander's Armor (Refined),312,1,0,4,3,2
+15619,3,20000,1,45,Knight Commander's Armor (Refined),312,1,0,4,4,2
+15620,3,20000,1,45,Knight Commander's Armor (Plain),312,1,0,4,0,2
+15621,3,20000,1,45,Knight Commander's Armor (Plain),312,1,0,4,1,2
+15622,3,20000,1,45,Knight Commander's Armor (Plain),312,1,0,4,2,2
+15623,3,20000,1,45,Knight Commander's Armor (Plain),312,1,0,4,3,2
+15624,3,20000,1,45,Knight Commander's Armor (Plain),312,1,0,4,4,2
+15625,3,20000,1,45,Deputy Knight Commander's Armor (Refined),312,1,0,4,0,3
+15626,3,20000,1,45,Deputy Knight Commander's Armor (Refined),312,1,0,4,1,3
+15627,3,20000,1,45,Deputy Knight Commander's Armor (Refined),312,1,0,4,2,3
+15628,3,20000,1,45,Deputy Knight Commander's Armor (Refined),312,1,0,4,3,3
+15629,3,20000,1,45,Deputy Knight Commander's Armor (Refined),312,1,0,4,4,3
+15630,3,20000,1,45,Deputy Knight Commander's Armor (Plain),312,1,0,4,0,3
+15631,3,20000,1,45,Deputy Knight Commander's Armor (Plain),312,1,0,4,1,3
+15632,3,20000,1,45,Deputy Knight Commander's Armor (Plain),312,1,0,4,2,3
+15633,3,20000,1,45,Deputy Knight Commander's Armor (Plain),312,1,0,4,3,3
+15634,3,20000,1,45,Deputy Knight Commander's Armor (Plain),312,1,0,4,4,3
 15635,3,2600,1,1,White Snow Towel (Fine),312,1,0,0,0,2
 15636,3,2600,1,1,Cherry Blossom Towel (Fine),312,1,0,0,0,2
 15637,3,2600,1,1,Pale Aqua Towel (Fine),312,1,0,0,0,2
@@ -20046,56 +20046,56 @@
 15644,3,2600,1,1,Bluish Purple Towel (Elegant),312,1,0,0,0,3
 15645,3,2600,1,1,Red Ochre Towel (Elegant),312,1,0,0,0,3
 15646,3,2600,1,1,Night Black Towel (Elegant),312,1,0,0,0,3
-15647,3,20000,1,12,Ancient Folk Soldier's Armor,312,1,0,4,0,2
-15648,3,20000,1,12,Ancient Folk Soldier's Armor,312,1,0,4,1,2
-15649,3,20000,1,12,Ancient Folk Soldier's Armor,312,1,0,4,2,2
-15650,3,20000,1,12,Ancient Folk Soldier's Armor,312,1,0,4,3,2
-15651,3,20000,1,12,Ancient Folk Soldier's Armor,312,1,0,4,4,2
-15652,3,20000,1,12,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,0,2
-15653,3,20000,1,12,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,1,2
-15654,3,20000,1,12,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,2,2
-15655,3,20000,1,12,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,3,2
-15656,3,20000,1,12,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,4,2
-15657,3,20000,1,12,Ancient Folk Maiden's Clothes,312,1,0,4,0,3
-15658,3,20000,1,12,Ancient Folk Maiden's Clothes,312,1,0,4,1,3
-15659,3,20000,1,12,Ancient Folk Maiden's Clothes,312,1,0,4,2,3
-15660,3,20000,1,12,Ancient Folk Maiden's Clothes,312,1,0,4,3,3
-15661,3,20000,1,12,Ancient Folk Maiden's Clothes,312,1,0,4,4,3
-15662,3,20000,1,12,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,0,3
-15663,3,20000,1,12,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,1,3
-15664,3,20000,1,12,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,2,3
-15665,3,20000,1,12,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,3,3
-15666,3,20000,1,12,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,4,3
-16154,3,20000,1,15,Aurum Garment,312,1,0,0,0,2
-16155,3,20000,1,15,Aurum Garment,312,1,0,0,1,2
-16156,3,20000,1,15,Aurum Garment,312,1,0,0,2,2
-16157,3,20000,1,15,Aurum Garment,312,1,0,0,3,2
-16158,3,20000,1,15,Aurum Garment,312,1,0,0,4,2
-16159,3,20000,1,15,Rose Evening Gown,312,1,0,0,0,3
-16160,3,20000,1,15,Rose Evening Gown,312,1,0,0,1,3
-16161,3,20000,1,15,Rose Evening Gown,312,1,0,0,2,3
-16162,3,20000,1,15,Rose Evening Gown,312,1,0,0,3,3
-16163,3,20000,1,15,Rose Evening Gown,312,1,0,0,4,3
+15647,3,20000,1,60,Ancient Folk Soldier's Armor,312,1,0,4,0,2
+15648,3,20000,1,60,Ancient Folk Soldier's Armor,312,1,0,4,1,2
+15649,3,20000,1,60,Ancient Folk Soldier's Armor,312,1,0,4,2,2
+15650,3,20000,1,60,Ancient Folk Soldier's Armor,312,1,0,4,3,2
+15651,3,20000,1,60,Ancient Folk Soldier's Armor,312,1,0,4,4,2
+15652,3,20000,1,60,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,0,2
+15653,3,20000,1,60,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,1,2
+15654,3,20000,1,60,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,2,2
+15655,3,20000,1,60,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,3,2
+15656,3,20000,1,60,Ancient Folk Soldier's Armor (Dazzling),312,1,0,4,4,2
+15657,3,20000,1,60,Ancient Folk Maiden's Clothes,312,1,0,4,0,3
+15658,3,20000,1,60,Ancient Folk Maiden's Clothes,312,1,0,4,1,3
+15659,3,20000,1,60,Ancient Folk Maiden's Clothes,312,1,0,4,2,3
+15660,3,20000,1,60,Ancient Folk Maiden's Clothes,312,1,0,4,3,3
+15661,3,20000,1,60,Ancient Folk Maiden's Clothes,312,1,0,4,4,3
+15662,3,20000,1,60,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,0,3
+15663,3,20000,1,60,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,1,3
+15664,3,20000,1,60,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,2,3
+15665,3,20000,1,60,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,3,3
+15666,3,20000,1,60,Ancient Folk Maiden's Clothes (Dazzling),312,1,0,4,4,3
+16154,3,20000,1,31,Aurum Garment,312,1,0,0,0,2
+16155,3,20000,1,31,Aurum Garment,312,1,0,0,1,2
+16156,3,20000,1,31,Aurum Garment,312,1,0,0,2,2
+16157,3,20000,1,31,Aurum Garment,312,1,0,0,3,2
+16158,3,20000,1,31,Aurum Garment,312,1,0,0,4,2
+16159,3,20000,1,31,Rose Evening Gown,312,1,0,0,0,3
+16160,3,20000,1,31,Rose Evening Gown,312,1,0,0,1,3
+16161,3,20000,1,31,Rose Evening Gown,312,1,0,0,2,3
+16162,3,20000,1,31,Rose Evening Gown,312,1,0,0,3,3
+16163,3,20000,1,31,Rose Evening Gown,312,1,0,0,4,3
 17941,3,20000,1,10,Rival Schools: Batsu Ichimonji A,312,1,0,4,0,2
 18620,3,20000,1,12,Rival Schools: Batsu Ichimonji A,312,1,0,4,1,2
-18621,3,20000,1,0,Rival Schools: Batsu Ichimonji A,312,1,0,4,2,2
-18622,3,20000,1,15,Rival Schools: Batsu Ichimonji A,312,1,0,4,3,2
-18623,3,20000,1,6,Rival Schools: Batsu Ichimonji A,312,1,0,4,4,2
+18621,3,20000,1,16,Rival Schools: Batsu Ichimonji A,312,1,0,4,2,2
+18622,3,20000,1,31,Rival Schools: Batsu Ichimonji A,312,1,0,4,3,2
+18623,3,20000,1,70,Rival Schools: Batsu Ichimonji A,312,1,0,4,4,2
 17942,3,20000,1,10,Rival Schools: Batsu Ichimonji B,312,1,0,4,0,2
 18624,3,20000,1,12,Rival Schools: Batsu Ichimonji B,312,1,0,4,1,2
-18625,3,20000,1,0,Rival Schools: Batsu Ichimonji B,312,1,0,4,2,2
-18626,3,20000,1,15,Rival Schools: Batsu Ichimonji B,312,1,0,4,3,2
-18627,3,20000,1,6,Rival Schools: Batsu Ichimonji B,312,1,0,4,4,2
+18625,3,20000,1,16,Rival Schools: Batsu Ichimonji B,312,1,0,4,2,2
+18626,3,20000,1,31,Rival Schools: Batsu Ichimonji B,312,1,0,4,3,2
+18627,3,20000,1,70,Rival Schools: Batsu Ichimonji B,312,1,0,4,4,2
 17943,3,20000,1,10,Rival Schools: Hinata Wakaba A,312,1,0,4,0,3
 18628,3,20000,1,12,Rival Schools: Hinata Wakaba A,312,1,0,4,1,3
-18629,3,20000,1,0,Rival Schools: Hinata Wakaba A,312,1,0,4,2,3
-18630,3,20000,1,15,Rival Schools: Hinata Wakaba A,312,1,0,4,3,3
-18631,3,20000,1,6,Rival Schools: Hinata Wakaba A,312,1,0,4,4,3
+18629,3,20000,1,16,Rival Schools: Hinata Wakaba A,312,1,0,4,2,3
+18630,3,20000,1,31,Rival Schools: Hinata Wakaba A,312,1,0,4,3,3
+18631,3,20000,1,70,Rival Schools: Hinata Wakaba A,312,1,0,4,4,3
 17944,3,20000,1,10,Rival Schools: Hinata Wakaba B,312,1,0,4,0,3
 18632,3,20000,1,12,Rival Schools: Hinata Wakaba B,312,1,0,4,1,3
-18633,3,20000,1,0,Rival Schools: Hinata Wakaba B,312,1,0,4,2,3
-18634,3,20000,1,15,Rival Schools: Hinata Wakaba B,312,1,0,4,3,3
-18635,3,20000,1,6,Rival Schools: Hinata Wakaba B,312,1,0,4,4,3
+18633,3,20000,1,16,Rival Schools: Hinata Wakaba B,312,1,0,4,2,3
+18634,3,20000,1,31,Rival Schools: Hinata Wakaba B,312,1,0,4,3,3
+18635,3,20000,1,70,Rival Schools: Hinata Wakaba B,312,1,0,4,4,3
 19115,3,5000,1,4,Survey Corps Male Soldier's Clothes,312,1,0,4,0,2
 19116,3,5000,1,6,Survey Corps Male Soldier's Clothes,312,1,0,4,1,2
 19117,3,5000,1,8,Survey Corps Male Soldier's Clothes,312,1,0,4,2,2
@@ -20103,9 +20103,9 @@
 19119,3,5000,1,15,Survey Corps Male Soldier's Clothes,312,1,0,4,4,2
 19125,3,50000,1,10,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,0,2
 19126,3,50000,1,12,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,1,2
-19127,3,50000,1,0,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,2,2
-19128,3,50000,1,15,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,3,2
-19129,3,50000,1,11,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,4,2
+19127,3,50000,1,16,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,2,2
+19128,3,50000,1,31,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,3,2
+19129,3,50000,1,75,Survey Corps Male Soldier's Clothes (Outside Wall Use),312,1,0,4,4,2
 19120,3,5000,1,4,Survey Corps Female Soldier's Clothes,312,1,0,4,0,3
 19121,3,5000,1,6,Survey Corps Female Soldier's Clothes,312,1,0,4,1,3
 19122,3,5000,1,8,Survey Corps Female Soldier's Clothes,312,1,0,4,2,3
@@ -20113,88 +20113,88 @@
 19124,3,5000,1,15,Survey Corps Female Soldier's Clothes,312,1,0,4,4,3
 19130,3,50000,1,10,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,0,3
 19131,3,50000,1,12,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,1,3
-19132,3,50000,1,0,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,2,3
-19133,3,50000,1,15,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,3,3
-19134,3,50000,1,11,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,4,3
+19132,3,50000,1,16,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,2,3
+19133,3,50000,1,31,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,3,3
+19134,3,50000,1,75,Survey Corps Female Soldier's Clothes (Outside Wall Use),312,1,0,4,4,3
 19450,3,0,1,10,DDDA Feste Equipment,312,1,0,4,4,1
 19451,3,0,1,10,DDDA Aelinore Equipment,312,1,0,4,4,1
-19513,3,50000,1,6,Aurora Mirage Armor (Plain),312,80,0,4,4,2
-19514,3,50000,1,6,Aurora Bright Armor (Plain),312,80,0,4,4,3
-19517,3,50000,1,8,Dawn Mirage Armor (Dark),312,80,0,4,4,2
-19518,3,50000,1,8,Dawn Bright Armor (Dark),312,80,0,4,4,3
-19515,3,50000,1,0,Apprentice Priest Robes (Origin),312,85,0,4,4,2
-19516,3,50000,1,0,Tomboy Arisen's Clothes (Origin),312,85,0,4,4,3
-19519,3,50000,1,0,Apprentice Priest Robes (Bloom),312,85,0,4,4,2
-19520,3,50000,1,0,Tomboy Arisen's Clothes (Bloom),312,85,0,4,4,3
-19595,3,50000,1,0,Ghosts 'n Goblins Arthur Equipment (Steel Armor),312,1,0,4,4,1
-19596,3,50000,1,0,Ghosts 'n Goblins Arthur Equipment (Gold Armor),312,1,0,4,4,1
-19597,3,50000,1,0,Ghosts 'n Goblins Princess Equipment,312,1,0,4,4,1
-19598,3,50000,1,0,Ghosts 'n Goblins Princess Equipment (Crimson),312,1,0,4,4,1
+19513,3,50000,1,86,Aurora Mirage Armor (Plain),312,80,0,4,4,2
+19514,3,50000,1,86,Aurora Bright Armor (Plain),312,80,0,4,4,3
+19517,3,50000,1,88,Dawn Mirage Armor (Dark),312,80,0,4,4,2
+19518,3,50000,1,88,Dawn Bright Armor (Dark),312,80,0,4,4,3
+19515,3,50000,1,96,Apprentice Priest Robes (Origin),312,85,0,4,4,2
+19516,3,50000,1,96,Tomboy Arisen's Clothes (Origin),312,85,0,4,4,3
+19519,3,50000,1,96,Apprentice Priest Robes (Bloom),312,85,0,4,4,2
+19520,3,50000,1,96,Tomboy Arisen's Clothes (Bloom),312,85,0,4,4,3
+19595,3,50000,1,80,Ghosts 'n Goblins Arthur Equipment (Steel Armor),312,1,0,4,4,1
+19596,3,50000,1,80,Ghosts 'n Goblins Arthur Equipment (Gold Armor),312,1,0,4,4,1
+19597,3,50000,1,80,Ghosts 'n Goblins Princess Equipment,312,1,0,4,4,1
+19598,3,50000,1,80,Ghosts 'n Goblins Princess Equipment (Crimson),312,1,0,4,4,1
 19601,3,10000,1,7,Easy Sweat - Gray,312,1,0,0,0,1
 19602,3,10000,1,7,Easy Sweat - Yellow,312,1,0,0,0,1
 19603,3,10000,1,7,Rabbit Wear - Pink,312,1,0,0,0,1
 19604,3,10000,1,7,Rabbit Wear - Blue,312,1,0,0,0,1
-19613,3,50000,1,8,Dawn Mirage Armor (Plain),312,80,0,4,4,2
-19614,3,50000,1,8,Dawn Bright Armor (Plain),312,80,0,4,4,3
-19615,3,50000,1,6,Aurora Mirage Armor (Dark),312,80,0,4,4,2
-19616,3,50000,1,6,Aurora Bright Armor (Dark),312,80,0,4,4,3
-19618,3,15000,1,4,White Dragon Temple Priest,312,1,0,0,0,2
-19619,3,15000,1,4,White Dragon Temple Priestess,312,1,0,0,0,3
-19620,3,15000,1,4,Animus Clothes,312,1,0,0,0,2
-19621,3,15000,1,4,Anima Clothes,312,1,0,0,0,3
-20743,3,50000,1,6,Young Wise General's Battle Attire (Plain),312,1,0,4,4,2
-20744,3,50000,1,6,Young Wise General's Battle Attire (Dark),312,1,0,4,4,2
-20745,3,50000,1,6,Crimson Fierce General's Battle Armor (Plain),312,1,0,4,4,3
-20746,3,50000,1,6,Crimson Fierce General's Battle Armor (Dark),312,1,0,4,4,3
-21087,3,50000,1,0,White Knights Male Armor (Origin),312,1,0,4,4,2
-21092,3,50000,1,0,White Knights Male Armor (Bloom),312,1,0,4,4,2
-21093,3,50000,1,0,White Knights Female Armor (Origin),312,1,0,4,4,3
-21094,3,50000,1,0,White Knights Female Armor (Bloom),312,1,0,4,4,3
+19613,3,50000,1,88,Dawn Mirage Armor (Plain),312,80,0,4,4,2
+19614,3,50000,1,88,Dawn Bright Armor (Plain),312,80,0,4,4,3
+19615,3,50000,1,86,Aurora Mirage Armor (Dark),312,80,0,4,4,2
+19616,3,50000,1,86,Aurora Bright Armor (Dark),312,80,0,4,4,3
+19618,3,15000,1,20,White Dragon Temple Priest,312,1,0,0,0,2
+19619,3,15000,1,20,White Dragon Temple Priestess,312,1,0,0,0,3
+19620,3,15000,1,20,Animus Clothes,312,1,0,0,0,2
+19621,3,15000,1,20,Anima Clothes,312,1,0,0,0,3
+20743,3,50000,1,102,Young Wise General's Battle Attire (Plain),312,1,0,4,4,2
+20744,3,50000,1,102,Young Wise General's Battle Attire (Dark),312,1,0,4,4,2
+20745,3,50000,1,102,Crimson Fierce General's Battle Armor (Plain),312,1,0,4,4,3
+20746,3,50000,1,102,Crimson Fierce General's Battle Armor (Dark),312,1,0,4,4,3
+21087,3,50000,1,112,White Knights Male Armor (Origin),312,1,0,4,4,2
+21092,3,50000,1,112,White Knights Male Armor (Bloom),312,1,0,4,4,2
+21093,3,50000,1,112,White Knights Female Armor (Origin),312,1,0,4,4,3
+21094,3,50000,1,112,White Knights Female Armor (Bloom),312,1,0,4,4,3
 21108,3,10000,1,10,Scarlet Lover's Sweet Mail,312,1,0,0,0,2
 21109,3,10000,1,10,Scarlet Lover's Sweet Dress,312,1,0,0,0,3
-21110,3,10000,1,14,Ruler of Death's Costume,312,1,0,4,4,2
-21111,3,10000,1,14,"Merciful, Pure-White Devil's Costume",312,1,0,4,4,3
+21110,3,10000,1,94,Ruler of Death's Costume,312,1,0,4,4,2
+21111,3,10000,1,94,"Merciful, Pure-White Devil's Costume",312,1,0,4,4,3
 21117,3,10000,1,10,Passionate Lover's Melt Mail,312,1,0,0,4,2
 21118,3,10000,1,10,Passionate Lover's Melt Dress,312,1,0,0,4,3
-21157,3,50000,1,2,Supreme Apprentice Priest Robes (Origin),312,85,0,4,4,2
-21158,3,50000,1,2,Supreme Apprentice Priest Robes (Bloom),312,85,0,4,4,2
-21159,3,50000,1,2,Supreme Tomboy Arisen's Clothes (Origin),312,85,0,4,4,3
-21160,3,50000,1,2,Supreme Tomboy Arisen's Clothes (Bloom),312,85,0,4,4,3
-21166,3,50000,1,9,Supreme Young Wise General's Battle Attire (Plain),312,1,0,4,4,2
-21167,3,50000,1,9,Supreme Young Wise General's Battle Attire (Dark),312,1,0,4,4,2
-21168,3,50000,1,9,Supreme Crimson Fierce General's Battle Armor (Plain),312,1,0,4,4,3
-21169,3,50000,1,9,Supreme Crimson Fierce General's Battle Armor (Dark),312,1,0,4,4,3
-21174,3,50000,1,3,Supreme White Knights Male Armor (Origin),312,1,0,4,4,2
-21175,3,50000,1,3,Supreme White Knights Male Armor (Bloom),312,1,0,4,4,2
-21176,3,50000,1,3,Supreme White Knights Female Armor (Origin),312,1,0,4,4,3
-21177,3,50000,1,3,Supreme White Knights Female Armor (Bloom),312,1,0,4,4,3
-21189,3,10000,1,14,Great Momonga Robe,312,1,0,4,4,2
-21190,3,10000,1,14,Albedo's Dress,312,1,0,4,4,3
-21323,3,10000,1,4,Subaru's Jersey,312,1,0,4,4,2
-21324,3,10000,1,4,Rem's Maid Clothes,312,1,0,4,4,3
-21325,3,10000,1,4,Ram's Maid Clothes,312,1,0,4,4,3
-21673,3,10000,1,9,Guts' Equipment,312,1,0,4,4,1
-21674,3,10000,1,9,Griffith's Equipment,312,1,0,4,4,1
-21675,3,10000,1,9,Griffith's Equipment (White Falcon),312,1,0,4,4,1
+21157,3,50000,1,98,Supreme Apprentice Priest Robes (Origin),312,85,0,4,4,2
+21158,3,50000,1,98,Supreme Apprentice Priest Robes (Bloom),312,85,0,4,4,2
+21159,3,50000,1,98,Supreme Tomboy Arisen's Clothes (Origin),312,85,0,4,4,3
+21160,3,50000,1,98,Supreme Tomboy Arisen's Clothes (Bloom),312,85,0,4,4,3
+21166,3,50000,1,105,Supreme Young Wise General's Battle Attire (Plain),312,1,0,4,4,2
+21167,3,50000,1,105,Supreme Young Wise General's Battle Attire (Dark),312,1,0,4,4,2
+21168,3,50000,1,105,Supreme Crimson Fierce General's Battle Armor (Plain),312,1,0,4,4,3
+21169,3,50000,1,105,Supreme Crimson Fierce General's Battle Armor (Dark),312,1,0,4,4,3
+21174,3,50000,1,115,Supreme White Knights Male Armor (Origin),312,1,0,4,4,2
+21175,3,50000,1,115,Supreme White Knights Male Armor (Bloom),312,1,0,4,4,2
+21176,3,50000,1,115,Supreme White Knights Female Armor (Origin),312,1,0,4,4,3
+21177,3,50000,1,115,Supreme White Knights Female Armor (Bloom),312,1,0,4,4,3
+21189,3,10000,1,94,Great Momonga Robe,312,1,0,4,4,2
+21190,3,10000,1,94,Albedo's Dress,312,1,0,4,4,3
+21323,3,10000,1,100,Subaru's Jersey,312,1,0,4,4,2
+21324,3,10000,1,100,Rem's Maid Clothes,312,1,0,4,4,3
+21325,3,10000,1,100,Ram's Maid Clothes,312,1,0,4,4,3
+21673,3,10000,1,105,Guts' Equipment,312,1,0,4,4,1
+21674,3,10000,1,105,Griffith's Equipment,312,1,0,4,4,1
+21675,3,10000,1,105,Griffith's Equipment (White Falcon),312,1,0,4,4,1
 21812,3,10000,1,8,Griffith's Equipment (White Falcon),312,1,0,4,0,1
 21813,3,10000,1,12,Griffith's Equipment (White Falcon),312,1,0,4,1,1
-21814,3,10000,1,3,Griffith's Equipment (White Falcon),312,1,0,4,2,1
-21815,3,10000,1,11,Griffith's Equipment (White Falcon),312,1,0,4,3,1
-21676,3,10000,1,9,Casca's Equipment,312,1,0,4,4,1
-21785,3,20000,1,14,Aurum Garment+,312,1,0,0,4,2
-21786,3,20000,1,14,Rose Evening Gown+,312,1,0,0,4,3
+21814,3,10000,1,35,Griffith's Equipment (White Falcon),312,1,0,4,2,1
+21815,3,10000,1,75,Griffith's Equipment (White Falcon),312,1,0,4,3,1
+21676,3,10000,1,105,Casca's Equipment,312,1,0,4,4,1
+21785,3,20000,1,110,Aurum Garment+,312,1,0,0,4,2
+21786,3,20000,1,110,Rose Evening Gown+,312,1,0,0,4,3
 23397,3,10000,1,1,Mischievous Ghost Costume,312,1,0,0,4,1
-23533,3,10000,1,3,Ultramarine Hard Shell Armor,312,1,0,4,4,2
-23534,3,10000,1,3,Bloodsucking Princess's Dress,312,1,0,4,4,3
-23535,3,10000,1,3,Cocytus's Armor Shell,312,1,0,4,4,2
-23536,3,10000,1,3,Shalltear's Dress,312,1,0,4,4,3
-23537,3,10000,1,3,Great Momonga Robe+,312,1,0,4,4,2
-23538,3,10000,1,3,Albedo's Dress+,312,1,0,4,4,3
-24694,3,50000,1,2,Acre Selund Supreme General's Armor (Origin),312,1,0,4,4,2
-24695,3,50000,1,2,Acre Selund Female Warrior's Armor (Origin),312,1,0,4,4,3
-24696,3,50000,1,2,Acre Selund Arisen's Garment (Origin),312,1,0,4,4,2
-24697,3,50000,1,2,Phindym Arisen's Garment (Origin),312,1,0,4,4,3
-24698,3,50000,1,2,Arisen of the Dark Continent (Origin),312,1,0,4,4,1
+23533,3,10000,1,115,Ultramarine Hard Shell Armor,312,1,0,4,4,2
+23534,3,10000,1,115,Bloodsucking Princess's Dress,312,1,0,4,4,3
+23535,3,10000,1,115,Cocytus's Armor Shell,312,1,0,4,4,2
+23536,3,10000,1,115,Shalltear's Dress,312,1,0,4,4,3
+23537,3,10000,1,115,Great Momonga Robe+,312,1,0,4,4,2
+23538,3,10000,1,115,Albedo's Dress+,312,1,0,4,4,3
+24694,3,50000,1,130,Acre Selund Supreme General's Armor (Origin),312,1,0,4,4,2
+24695,3,50000,1,130,Acre Selund Female Warrior's Armor (Origin),312,1,0,4,4,3
+24696,3,50000,1,130,Acre Selund Arisen's Garment (Origin),312,1,0,4,4,2
+24697,3,50000,1,130,Phindym Arisen's Garment (Origin),312,1,0,4,4,3
+24698,3,50000,1,130,Arisen of the Dark Continent (Origin),312,1,0,4,4,1
 24866,3,50000,1,10,Ultra-Rich White Chocolate Suit,312,1,0,0,4,1
 24867,3,50000,1,10,Ultra-Rich White Chocolate Suit (Limited Edition),312,1,0,0,4,1
 24868,3,50000,1,10,Ultra-Rich White Chocolate Dress,312,1,0,0,4,1
@@ -20215,15 +20215,15 @@
 24883,3,50000,1,1,Ghosts 'n Goblins Arthur Equipment (Bone Color Armor),312,1,0,0,0,1
 24884,3,50000,1,1,Easy Sweat - Pink,312,1,0,0,0,1
 24885,3,50000,1,1,Honeybee Wear,312,1,0,0,0,1
-25013,3,50000,1,2,Supreme Acre Selund Supreme General's Armor (Origin),312,1,0,4,4,2
-25014,3,50000,1,2,Supreme Acre Selund Female Warrior's Armor (Origin),312,1,0,4,4,3
-25020,3,50000,1,2,Arisen of the Dark Continent (Gold),312,1,0,4,4,1
-25617,3,50000,1,12,Guardian's Prayer Attire [Male],312,1,0,4,4,2
-25618,3,50000,1,12,Guardian's Prayer Attire [Female],312,1,0,4,4,3
-25619,3,50000,1,1,Fortress Guard's Fortified Armor【Man】,312,1,0,4,4,2
-25620,3,50000,1,1,Fortress Guard's Fortified Armor【Woman】,312,1,0,4,4,3
-25621,3,50000,1,6,Lost Ancient Costume [Male],312,1,0,4,4,2
-25622,3,50000,1,6,Lost Ancient Costume [Female],312,1,0,4,4,3
+25013,3,50000,1,130,Supreme Acre Selund Supreme General's Armor (Origin),312,1,0,4,4,2
+25014,3,50000,1,130,Supreme Acre Selund Female Warrior's Armor (Origin),312,1,0,4,4,3
+25020,3,50000,1,130,Arisen of the Dark Continent (Gold),312,1,0,4,4,1
+25617,3,50000,1,140,Guardian's Prayer Attire [Male],312,1,0,4,4,2
+25618,3,50000,1,140,Guardian's Prayer Attire [Female],312,1,0,4,4,3
+25619,3,50000,1,145,Fortress Guard's Fortified Armor【Man】,312,1,0,4,4,2
+25620,3,50000,1,145,Fortress Guard's Fortified Armor【Woman】,312,1,0,4,4,3
+25621,3,50000,1,150,Lost Ancient Costume [Male],312,1,0,4,4,2
+25622,3,50000,1,150,Lost Ancient Costume [Female],312,1,0,4,4,3
 8928,3,50,1,1,Green Grass Ring,426,1,0,32,,1
 8929,3,50,1,1,Leather Bracelet,426,1,0,16,,1
 8930,3,50,1,1,Fang Earrings,426,1,0,27,,1
@@ -20411,291 +20411,291 @@
 14231,3,500,1,15,Earrings of Holy Resist 2,474,1,0,1,,1
 14232,3,500,1,15,Earrings of Dark Resist 1,474,1,0,1,,1
 14233,3,500,1,15,Earrings of Dark Resist 2,474,1,0,1,,1
-16201,3,3500,1,11,Phindym Bracelet,458,1,0,0,,1
-16383,3,100,1,2,Dragon Skill Ring (Fighter),442,1,1,1,,1
-16384,3,100,1,2,Dragon Skill Bracelet (Fighter),458,1,1,1,,1
-16385,3,100,1,2,Dragon Skill Earrings (Fighter),474,1,1,1,,1
-16386,3,100,1,2,Dragon Skill Ring (Seeker),442,1,2,1,,1
-16387,3,100,1,2,Dragon Skill Bracelet (Seeker),458,1,2,1,,1
-16388,3,100,1,2,Dragon Skill Earrings (Seeker),474,1,2,1,,1
-16389,3,100,1,2,Dragon Skill Ring (Hunter),442,1,3,1,,1
-16390,3,100,1,2,Dragon Skill Bracelet (Hunter),458,1,3,1,,1
-16391,3,100,1,2,Dragon Skill Earrings (Hunter),474,1,3,1,,1
-16437,3,100,1,2,Dragon Skill Ring (Priest),442,1,4,1,,1
-16438,3,100,1,2,Dragon Skill Bracelet (Priest),458,1,4,1,,1
-16439,3,100,1,2,Dragon Skill Earrings (Priest),474,1,4,1,,1
-16440,3,100,1,2,Dragon Skill Ring (Shield Sage),442,1,5,1,,1
-16441,3,100,1,2,Dragon Skill Bracelet (Shield Sage),458,1,5,1,,1
-16442,3,100,1,2,Dragon Skill Earrings (Shield Sage),474,1,5,1,,1
-16443,3,100,1,2,Dragon Skill Ring (Sorcerer),442,1,6,1,,1
-16444,3,100,1,2,Dragon Skill Bracelet (Sorcerer),458,1,6,1,,1
-16445,3,100,1,2,Dragon Skill Earrings (Sorcerer),474,1,6,1,,1
-16446,3,100,1,2,Dragon Skill Ring (Warrior),442,1,7,1,,1
-16447,3,100,1,2,Dragon Skill Bracelet (Warrior),458,1,7,1,,1
-16448,3,100,1,2,Dragon Skill Earrings (Warrior),474,1,7,1,,1
-16449,3,100,1,2,Dragon Skill Ring (Element Archer),442,1,8,1,,1
-16450,3,100,1,2,Dragon Skill Bracelet (Element Archer),458,1,8,1,,1
-16451,3,100,1,2,Dragon Skill Earrings (Element Archer),474,1,8,1,,1
-16452,3,100,1,2,Dragon Skill Ring (Alchemist),442,1,9,1,,1
-16453,3,100,1,2,Dragon Skill Bracelet (Alchemist),458,1,9,1,,1
-16454,3,100,1,2,Dragon Skill Earrings (Alchemist),474,1,9,1,,1
-16722,3,100,1,2,Dragon Skill Ring (Spirit Lancer),442,1,10,1,,1
-16723,3,100,1,2,Dragon Skill Bracelet (Spirit Lancer),458,1,10,1,,1
-16724,3,100,1,2,Dragon Skill Earrings (Spirit Lancer),474,1,10,1,,1
-17154,3,10000,1,11,Ancient Clear Shell Ring,426,80,0,0,,1
-18143,3,100,1,11,Emblem Stone (Fighter),490,1,1,4,,1
-18144,3,100,1,11,Emblem Stone (Seeker),490,1,2,4,,1
-18145,3,100,1,11,Emblem Stone (Hunter),490,1,3,4,,1
-18146,3,100,1,11,Emblem Stone (Priest),490,1,4,4,,1
-18147,3,100,1,11,Emblem Stone (Shield Sage),490,1,5,4,,1
-18148,3,100,1,11,Emblem Stone (Sorcerer),490,1,6,4,,1
-18149,3,100,1,11,Emblem Stone (Warrior),490,1,7,4,,1
-18150,3,100,1,11,Emblem Stone (Element Archer),490,1,8,4,,1
-18151,3,100,1,11,Emblem Stone (Alchemist),490,1,9,4,,1
-18152,3,100,1,11,Emblem Stone (Spirit Lancer),490,1,10,4,,1
-18599,3,100,1,2,Supreme Ring (Myrmidon),442,1,0,1,,1
-18600,3,100,1,2,Supreme Bracelet (Myrmidon),458,1,0,1,,1
-18601,3,100,1,2,Supreme Earrings (Myrmidon),474,1,0,1,,1
-18602,3,100,1,2,Supreme Ring (Inquiry),442,1,0,1,,1
-18603,3,100,1,2,Supreme Bracelet (Inquiry),458,1,0,1,,1
-18604,3,100,1,2,Supreme Earrings (Inquiry),474,1,0,1,,1
-18605,3,100,1,2,Supreme Ring (Purge),442,1,0,1,,1
-18606,3,100,1,2,Supreme Bracelet (Purge),458,1,0,1,,1
-18607,3,100,1,2,Supreme Earrings (Purge),474,1,0,1,,1
-18608,3,100,1,2,Supreme Ring (Night Emperor),442,1,0,1,,1
-18609,3,100,1,2,Supreme Bracelet (Night Emperor),458,1,0,1,,1
-18610,3,100,1,2,Supreme Earrings (Night Emperor),474,1,0,1,,1
-18736,3,34464,1,10,Depth Opal Ring,442,1,0,0,,1
-19351,3,50000,1,6,Battlefield Aquamarine Ring,426,1,0,1,,1
-19352,3,50000,1,6,Battlefield Amethyst Ring,426,1,0,1,,1
-19353,3,50000,1,6,Battlefield Peridot Ring,426,1,0,1,,1
-19354,3,50000,1,6,Battlefield Morion Ring,426,1,0,1,,1
-19355,3,50000,1,6,Battlefield Emerald Ring,426,1,0,1,,1
-19356,3,50000,1,6,Battlefield Citrine Ring,426,1,0,1,,1
-21210,3,34464,1,4,Ring of Evil Eye,442,1,0,0,,1
-21299,3,34464,1,0,Bracelet of Seizing - Extreme (Fighter),458,1,1,1,,1
-21300,3,34464,1,0,Bracelet of Seizing - Extreme (Shield Sage),458,1,5,1,,1
-21301,3,34464,1,0,Bracelet of Seizing - Extreme (Hunter),458,1,3,1,,1
-21302,3,34464,1,0,Bracelet of Seizing - Extreme (Priest),458,1,4,1,,1
-21303,3,34464,1,0,Bracelet of Seizing - Extreme (Sorcerer),458,1,6,1,,1
-21304,3,34464,1,0,Bracelet of Seizing - Extreme (Seeker),458,1,2,1,,1
-21305,3,34464,1,0,Bracelet of Seizing - Extreme (Element Archer),458,1,8,1,,1
-21306,3,34464,1,0,Bracelet of Seizing - Extreme (Warrior),458,1,7,1,,1
-21307,3,34464,1,0,Bracelet of Seizing - Extreme (Alchemist),458,1,9,1,,1
-21308,3,34464,1,0,Bracelet of Seizing - Extreme (Spirit Lancer),458,1,10,1,,1
-21309,3,34464,1,0,Earrings of Soaring - Extreme (Fighter),474,1,1,1,,1
-21310,3,34464,1,0,Earrings of Soaring - Extreme (Shield Sage),474,1,5,1,,1
-21311,3,34464,1,0,Earrings of Soaring - Extreme (Hunter),474,1,3,1,,1
-21312,3,34464,1,0,Earrings of Soaring - Extreme (Priest),474,1,4,1,,1
-21313,3,34464,1,0,Earrings of Soaring - Extreme (Sorcerer),474,1,6,1,,1
-21314,3,34464,1,0,Earrings of Soaring - Extreme (Seeker),474,1,2,1,,1
-21315,3,34464,1,0,Earrings of Soaring - Extreme (Element Archer),474,1,8,1,,1
-21316,3,34464,1,0,Earrings of Soaring - Extreme (Warrior),474,1,7,1,,1
-21317,3,34464,1,0,Earrings of Soaring - Extreme (Alchemist),474,1,9,1,,1
-21318,3,34464,1,0,Earrings of Soaring - Extreme (Spirit Lancer),474,1,10,1,,1
-21354,3,100,1,11,Emblem Stone (High Scepter),490,1,11,4,,1
-21359,3,34464,1,0,Bracelet of Unburdening - Extreme (Fighter),458,1,1,1,,1
-21360,3,34464,1,0,Bracelet of Unburdening - Extreme (Shield Sage),458,1,5,1,,1
-21361,3,34464,1,0,Bracelet of Unburdening - Extreme (Hunter),458,1,3,1,,1
-21362,3,34464,1,0,Bracelet of Unburdening - Extreme (Priest),458,1,4,1,,1
-21363,3,34464,1,0,Bracelet of Unburdening - Extreme (Sorcerer),458,1,6,1,,1
-21364,3,34464,1,0,Bracelet of Unburdening - Extreme (Seeker),458,1,2,1,,1
-21365,3,34464,1,0,Bracelet of Unburdening - Extreme (Element Archer),458,1,8,1,,1
-21366,3,34464,1,0,Bracelet of Unburdening - Extreme (Warrior),458,1,7,1,,1
-21367,3,34464,1,0,Bracelet of Unburdening - Extreme (Alchemist),458,1,9,1,,1
-21368,3,34464,1,0,Bracelet of Unburdening - Extreme (Spirit Lancer),458,1,10,1,,1
-21369,3,34464,1,0,Earrings of Dashing - Extreme (Fighter),474,1,1,1,,1
-21370,3,34464,1,0,Earrings of Dashing - Extreme (Shield Sage),474,1,5,1,,1
-21371,3,34464,1,0,Earrings of Dashing - Extreme (Hunter),474,1,3,1,,1
-21372,3,34464,1,0,Earrings of Dashing - Extreme (Priest),474,1,4,1,,1
-21373,3,34464,1,0,Earrings of Dashing - Extreme (Sorcerer),474,1,6,1,,1
-21374,3,34464,1,0,Earrings of Dashing - Extreme (Seeker),474,1,2,1,,1
-21375,3,34464,1,0,Earrings of Dashing - Extreme (Element Archer),474,1,8,1,,1
-21376,3,34464,1,0,Earrings of Dashing - Extreme (Warrior),474,1,7,1,,1
-21377,3,34464,1,0,Earrings of Dashing - Extreme (Alchemist),474,1,9,1,,1
-21378,3,34464,1,0,Earrings of Dashing - Extreme (Spirit Lancer),474,1,10,1,,1
-21394,3,34464,1,14,Ring of the Flame Demon,442,1,0,0,,1
-21395,3,34464,1,8,Ring of the Wise Dragon,442,1,0,0,,1
-21592,3,100,1,2,Dragon Skill Ring II (Fighter),442,1,1,1,,1
-21594,3,100,1,2,Dragon Skill Earrings II (Fighter),474,1,1,1,,1
-21595,3,100,1,2,Dragon Skill Bracelet II (Fighter),458,1,1,1,,1
-21597,3,100,1,2,Dragon Skill Ring II (Hunter),442,1,3,1,,1
-21596,3,100,1,2,Dragon Skill Earrings II (Hunter),474,1,3,1,,1
-21598,3,100,1,2,Dragon Skill Bracelet II (Hunter),458,1,3,1,,1
-21599,3,100,1,2,Dragon Skill Ring II (Priest),442,1,4,1,,1
-21600,3,100,1,2,Dragon Skill Earrings II (Priest),474,1,4,1,,1
-21601,3,100,1,2,Dragon Skill Bracelet II (Priest),458,1,4,1,,1
-21602,3,100,1,2,Dragon Skill Ring II (Shield Sage),442,1,5,1,,1
-21589,3,100,1,2,Dragon Skill Earrings II (Shield Sage),474,1,5,1,,1
-21590,3,100,1,2,Dragon Skill Bracelet II (Shield Sage),458,1,5,1,,1
-21591,3,100,1,2,Dragon Skill Ring II (Seeker),442,1,2,1,,1
-21587,3,100,1,2,Dragon Skill Earrings II (Seeker),474,1,2,1,,1
-21588,3,100,1,2,Dragon Skill Bracelet II (Seeker),458,1,2,1,,1
-21586,3,100,1,2,Dragon Skill Ring II (Sorcerer),442,1,6,1,,1
-21585,3,100,1,2,Dragon Skill Earrings II (Sorcerer),474,1,6,1,,1
-21584,3,100,1,2,Dragon Skill Bracelet II (Sorcerer),458,1,6,1,,1
-21583,3,100,1,2,Dragon Skill Ring II (Element Archer),442,1,8,1,,1
-21582,3,100,1,2,Dragon Skill Earrings II (Element Archer),474,1,8,1,,1
-21581,3,100,1,2,Dragon Skill Bracelet II (Element Archer),458,1,8,1,,1
-21603,3,100,1,2,Dragon Skill Ring II (Warrior),442,1,7,1,,1
-21580,3,100,1,2,Dragon Skill Earrings II (Warrior),474,1,7,1,,1
-21579,3,100,1,2,Dragon Skill Bracelet II (Warrior),458,1,7,1,,1
-21578,3,100,1,2,Dragon Skill Ring II (Alchemist),442,1,9,1,,1
-21575,3,100,1,2,Dragon Skill Earrings II (Alchemist),474,1,9,1,,1
-21576,3,100,1,2,Dragon Skill Bracelet II (Alchemist),458,1,9,1,,1
-21577,3,100,1,2,Dragon Skill Ring II (Spirit Lancer),442,1,10,1,,1
-21568,3,100,1,2,Dragon Skill Earrings II (Spirit Lancer),474,1,10,1,,1
-21574,3,100,1,2,Dragon Skill Bracelet II (Spirit Lancer),458,1,10,1,,1
-21573,3,100,1,2,Dragon Skill Ring (High Scepter),442,1,11,1,,1
-21572,3,100,1,2,Dragon Skill Earrings (High Scepter),474,1,11,1,,1
-21571,3,100,1,2,Dragon Skill Bracelet (High Scepter),458,1,11,1,,1
-21570,3,34464,1,0,Bracelet of Seizing - Extreme (High Scepter),458,1,11,1,,1
-21569,3,34464,1,0,Earrings of Soaring - Extreme (High Scepter),474,1,11,1,,1
-21604,3,34464,1,0,Bracelet of Unburdening - Extreme (High Scepter),458,1,11,1,,1
-21605,3,34464,1,0,Earrings of Dashing - Extreme (High Scepter),474,1,11,1,,1
-21651,3,100,1,2,Bitterblack Bracelet,458,1,0,1,,1
-23361,3,100,1,2,Dragon Skill Earrings II (High Scepter),474,1,11,1,,1
-23362,3,100,1,2,Dragon Skill Ring II (High Scepter),442,1,11,1,,1
-23363,3,100,1,2,Dragon Skill Bracelet II (High Scepter),458,1,11,1,,1
-23377,3,0,1,8,Ring of the First King,426,1,0,0,,1
-23602,3,0,1,8,Bracelet of the First King,426,1,0,0,,1
-23710,3,100,1,2,Bitterblack Ring,442,1,0,1,,1
-23711,3,100,1,2,Bitterblack Earring,474,1,0,1,,1
-24741,3,100,1,2,Ring of Order,426,1,0,0,,1
+16201,3,3500,1,75,Phindym Bracelet,458,1,0,0,,1
+16383,3,100,1,50,Dragon Skill Ring (Fighter),442,1,1,1,,1
+16384,3,100,1,50,Dragon Skill Bracelet (Fighter),458,1,1,1,,1
+16385,3,100,1,50,Dragon Skill Earrings (Fighter),474,1,1,1,,1
+16386,3,100,1,50,Dragon Skill Ring (Seeker),442,1,2,1,,1
+16387,3,100,1,50,Dragon Skill Bracelet (Seeker),458,1,2,1,,1
+16388,3,100,1,50,Dragon Skill Earrings (Seeker),474,1,2,1,,1
+16389,3,100,1,50,Dragon Skill Ring (Hunter),442,1,3,1,,1
+16390,3,100,1,50,Dragon Skill Bracelet (Hunter),458,1,3,1,,1
+16391,3,100,1,50,Dragon Skill Earrings (Hunter),474,1,3,1,,1
+16437,3,100,1,50,Dragon Skill Ring (Priest),442,1,4,1,,1
+16438,3,100,1,50,Dragon Skill Bracelet (Priest),458,1,4,1,,1
+16439,3,100,1,50,Dragon Skill Earrings (Priest),474,1,4,1,,1
+16440,3,100,1,50,Dragon Skill Ring (Shield Sage),442,1,5,1,,1
+16441,3,100,1,50,Dragon Skill Bracelet (Shield Sage),458,1,5,1,,1
+16442,3,100,1,50,Dragon Skill Earrings (Shield Sage),474,1,5,1,,1
+16443,3,100,1,50,Dragon Skill Ring (Sorcerer),442,1,6,1,,1
+16444,3,100,1,50,Dragon Skill Bracelet (Sorcerer),458,1,6,1,,1
+16445,3,100,1,50,Dragon Skill Earrings (Sorcerer),474,1,6,1,,1
+16446,3,100,1,50,Dragon Skill Ring (Warrior),442,1,7,1,,1
+16447,3,100,1,50,Dragon Skill Bracelet (Warrior),458,1,7,1,,1
+16448,3,100,1,50,Dragon Skill Earrings (Warrior),474,1,7,1,,1
+16449,3,100,1,50,Dragon Skill Ring (Element Archer),442,1,8,1,,1
+16450,3,100,1,50,Dragon Skill Bracelet (Element Archer),458,1,8,1,,1
+16451,3,100,1,50,Dragon Skill Earrings (Element Archer),474,1,8,1,,1
+16452,3,100,1,50,Dragon Skill Ring (Alchemist),442,1,9,1,,1
+16453,3,100,1,50,Dragon Skill Bracelet (Alchemist),458,1,9,1,,1
+16454,3,100,1,50,Dragon Skill Earrings (Alchemist),474,1,9,1,,1
+16722,3,100,1,50,Dragon Skill Ring (Spirit Lancer),442,1,10,1,,1
+16723,3,100,1,50,Dragon Skill Bracelet (Spirit Lancer),458,1,10,1,,1
+16724,3,100,1,50,Dragon Skill Earrings (Spirit Lancer),474,1,10,1,,1
+17154,3,10000,1,75,Ancient Clear Shell Ring,426,80,0,0,,1
+18143,3,100,1,75,Emblem Stone (Fighter),490,1,1,4,,1
+18144,3,100,1,75,Emblem Stone (Seeker),490,1,2,4,,1
+18145,3,100,1,75,Emblem Stone (Hunter),490,1,3,4,,1
+18146,3,100,1,75,Emblem Stone (Priest),490,1,4,4,,1
+18147,3,100,1,75,Emblem Stone (Shield Sage),490,1,5,4,,1
+18148,3,100,1,75,Emblem Stone (Sorcerer),490,1,6,4,,1
+18149,3,100,1,75,Emblem Stone (Warrior),490,1,7,4,,1
+18150,3,100,1,75,Emblem Stone (Element Archer),490,1,8,4,,1
+18151,3,100,1,75,Emblem Stone (Alchemist),490,1,9,4,,1
+18152,3,100,1,75,Emblem Stone (Spirit Lancer),490,1,10,4,,1
+18599,3,100,1,50,Supreme Ring (Myrmidon),442,1,0,1,,1
+18600,3,100,1,50,Supreme Bracelet (Myrmidon),458,1,0,1,,1
+18601,3,100,1,50,Supreme Earrings (Myrmidon),474,1,0,1,,1
+18602,3,100,1,50,Supreme Ring (Inquiry),442,1,0,1,,1
+18603,3,100,1,50,Supreme Bracelet (Inquiry),458,1,0,1,,1
+18604,3,100,1,50,Supreme Earrings (Inquiry),474,1,0,1,,1
+18605,3,100,1,50,Supreme Ring (Purge),442,1,0,1,,1
+18606,3,100,1,50,Supreme Bracelet (Purge),458,1,0,1,,1
+18607,3,100,1,50,Supreme Earrings (Purge),474,1,0,1,,1
+18608,3,100,1,50,Supreme Ring (Night Emperor),442,1,0,1,,1
+18609,3,100,1,50,Supreme Bracelet (Night Emperor),458,1,0,1,,1
+18610,3,100,1,50,Supreme Earrings (Night Emperor),474,1,0,1,,1
+18736,3,34464,1,90,Depth Opal Ring,442,1,0,0,,1
+19351,3,50000,1,70,Battlefield Aquamarine Ring,426,1,0,1,,1
+19352,3,50000,1,70,Battlefield Amethyst Ring,426,1,0,1,,1
+19353,3,50000,1,70,Battlefield Peridot Ring,426,1,0,1,,1
+19354,3,50000,1,70,Battlefield Morion Ring,426,1,0,1,,1
+19355,3,50000,1,70,Battlefield Emerald Ring,426,1,0,1,,1
+19356,3,50000,1,70,Battlefield Citrine Ring,426,1,0,1,,1
+21210,3,34464,1,100,Ring of Evil Eye,442,1,0,0,,1
+21299,3,34464,1,80,Bracelet of Seizing - Extreme (Fighter),458,1,1,1,,1
+21300,3,34464,1,80,Bracelet of Seizing - Extreme (Shield Sage),458,1,5,1,,1
+21301,3,34464,1,80,Bracelet of Seizing - Extreme (Hunter),458,1,3,1,,1
+21302,3,34464,1,80,Bracelet of Seizing - Extreme (Priest),458,1,4,1,,1
+21303,3,34464,1,80,Bracelet of Seizing - Extreme (Sorcerer),458,1,6,1,,1
+21304,3,34464,1,80,Bracelet of Seizing - Extreme (Seeker),458,1,2,1,,1
+21305,3,34464,1,80,Bracelet of Seizing - Extreme (Element Archer),458,1,8,1,,1
+21306,3,34464,1,80,Bracelet of Seizing - Extreme (Warrior),458,1,7,1,,1
+21307,3,34464,1,80,Bracelet of Seizing - Extreme (Alchemist),458,1,9,1,,1
+21308,3,34464,1,80,Bracelet of Seizing - Extreme (Spirit Lancer),458,1,10,1,,1
+21309,3,34464,1,80,Earrings of Soaring - Extreme (Fighter),474,1,1,1,,1
+21310,3,34464,1,80,Earrings of Soaring - Extreme (Shield Sage),474,1,5,1,,1
+21311,3,34464,1,80,Earrings of Soaring - Extreme (Hunter),474,1,3,1,,1
+21312,3,34464,1,80,Earrings of Soaring - Extreme (Priest),474,1,4,1,,1
+21313,3,34464,1,80,Earrings of Soaring - Extreme (Sorcerer),474,1,6,1,,1
+21314,3,34464,1,80,Earrings of Soaring - Extreme (Seeker),474,1,2,1,,1
+21315,3,34464,1,80,Earrings of Soaring - Extreme (Element Archer),474,1,8,1,,1
+21316,3,34464,1,80,Earrings of Soaring - Extreme (Warrior),474,1,7,1,,1
+21317,3,34464,1,80,Earrings of Soaring - Extreme (Alchemist),474,1,9,1,,1
+21318,3,34464,1,80,Earrings of Soaring - Extreme (Spirit Lancer),474,1,10,1,,1
+21354,3,100,1,75,Emblem Stone (High Scepter),490,1,11,4,,1
+21359,3,34464,1,80,Bracelet of Unburdening - Extreme (Fighter),458,1,1,1,,1
+21360,3,34464,1,80,Bracelet of Unburdening - Extreme (Shield Sage),458,1,5,1,,1
+21361,3,34464,1,80,Bracelet of Unburdening - Extreme (Hunter),458,1,3,1,,1
+21362,3,34464,1,80,Bracelet of Unburdening - Extreme (Priest),458,1,4,1,,1
+21363,3,34464,1,80,Bracelet of Unburdening - Extreme (Sorcerer),458,1,6,1,,1
+21364,3,34464,1,80,Bracelet of Unburdening - Extreme (Seeker),458,1,2,1,,1
+21365,3,34464,1,80,Bracelet of Unburdening - Extreme (Element Archer),458,1,8,1,,1
+21366,3,34464,1,80,Bracelet of Unburdening - Extreme (Warrior),458,1,7,1,,1
+21367,3,34464,1,80,Bracelet of Unburdening - Extreme (Alchemist),458,1,9,1,,1
+21368,3,34464,1,80,Bracelet of Unburdening - Extreme (Spirit Lancer),458,1,10,1,,1
+21369,3,34464,1,80,Earrings of Dashing - Extreme (Fighter),474,1,1,1,,1
+21370,3,34464,1,80,Earrings of Dashing - Extreme (Shield Sage),474,1,5,1,,1
+21371,3,34464,1,80,Earrings of Dashing - Extreme (Hunter),474,1,3,1,,1
+21372,3,34464,1,80,Earrings of Dashing - Extreme (Priest),474,1,4,1,,1
+21373,3,34464,1,80,Earrings of Dashing - Extreme (Sorcerer),474,1,6,1,,1
+21374,3,34464,1,80,Earrings of Dashing - Extreme (Seeker),474,1,2,1,,1
+21375,3,34464,1,80,Earrings of Dashing - Extreme (Element Archer),474,1,8,1,,1
+21376,3,34464,1,80,Earrings of Dashing - Extreme (Warrior),474,1,7,1,,1
+21377,3,34464,1,80,Earrings of Dashing - Extreme (Alchemist),474,1,9,1,,1
+21378,3,34464,1,80,Earrings of Dashing - Extreme (Spirit Lancer),474,1,10,1,,1
+21394,3,34464,1,110,Ring of the Flame Demon,442,1,0,0,,1
+21395,3,34464,1,120,Ring of the Wise Dragon,442,1,0,0,,1
+21592,3,100,1,50,Dragon Skill Ring II (Fighter),442,1,1,1,,1
+21594,3,100,1,50,Dragon Skill Earrings II (Fighter),474,1,1,1,,1
+21595,3,100,1,50,Dragon Skill Bracelet II (Fighter),458,1,1,1,,1
+21597,3,100,1,50,Dragon Skill Ring II (Hunter),442,1,3,1,,1
+21596,3,100,1,50,Dragon Skill Earrings II (Hunter),474,1,3,1,,1
+21598,3,100,1,50,Dragon Skill Bracelet II (Hunter),458,1,3,1,,1
+21599,3,100,1,50,Dragon Skill Ring II (Priest),442,1,4,1,,1
+21600,3,100,1,50,Dragon Skill Earrings II (Priest),474,1,4,1,,1
+21601,3,100,1,50,Dragon Skill Bracelet II (Priest),458,1,4,1,,1
+21602,3,100,1,50,Dragon Skill Ring II (Shield Sage),442,1,5,1,,1
+21589,3,100,1,50,Dragon Skill Earrings II (Shield Sage),474,1,5,1,,1
+21590,3,100,1,50,Dragon Skill Bracelet II (Shield Sage),458,1,5,1,,1
+21591,3,100,1,50,Dragon Skill Ring II (Seeker),442,1,2,1,,1
+21587,3,100,1,50,Dragon Skill Earrings II (Seeker),474,1,2,1,,1
+21588,3,100,1,50,Dragon Skill Bracelet II (Seeker),458,1,2,1,,1
+21586,3,100,1,50,Dragon Skill Ring II (Sorcerer),442,1,6,1,,1
+21585,3,100,1,50,Dragon Skill Earrings II (Sorcerer),474,1,6,1,,1
+21584,3,100,1,50,Dragon Skill Bracelet II (Sorcerer),458,1,6,1,,1
+21583,3,100,1,50,Dragon Skill Ring II (Element Archer),442,1,8,1,,1
+21582,3,100,1,50,Dragon Skill Earrings II (Element Archer),474,1,8,1,,1
+21581,3,100,1,50,Dragon Skill Bracelet II (Element Archer),458,1,8,1,,1
+21603,3,100,1,50,Dragon Skill Ring II (Warrior),442,1,7,1,,1
+21580,3,100,1,50,Dragon Skill Earrings II (Warrior),474,1,7,1,,1
+21579,3,100,1,50,Dragon Skill Bracelet II (Warrior),458,1,7,1,,1
+21578,3,100,1,50,Dragon Skill Ring II (Alchemist),442,1,9,1,,1
+21575,3,100,1,50,Dragon Skill Earrings II (Alchemist),474,1,9,1,,1
+21576,3,100,1,50,Dragon Skill Bracelet II (Alchemist),458,1,9,1,,1
+21577,3,100,1,50,Dragon Skill Ring II (Spirit Lancer),442,1,10,1,,1
+21568,3,100,1,50,Dragon Skill Earrings II (Spirit Lancer),474,1,10,1,,1
+21574,3,100,1,50,Dragon Skill Bracelet II (Spirit Lancer),458,1,10,1,,1
+21573,3,100,1,50,Dragon Skill Ring (High Scepter),442,1,11,1,,1
+21572,3,100,1,50,Dragon Skill Earrings (High Scepter),474,1,11,1,,1
+21571,3,100,1,50,Dragon Skill Bracelet (High Scepter),458,1,11,1,,1
+21570,3,34464,1,80,Bracelet of Seizing - Extreme (High Scepter),458,1,11,1,,1
+21569,3,34464,1,80,Earrings of Soaring - Extreme (High Scepter),474,1,11,1,,1
+21604,3,34464,1,80,Bracelet of Unburdening - Extreme (High Scepter),458,1,11,1,,1
+21605,3,34464,1,80,Earrings of Dashing - Extreme (High Scepter),474,1,11,1,,1
+21651,3,100,1,50,Bitterblack Bracelet,458,1,0,1,,1
+23361,3,100,1,50,Dragon Skill Earrings II (High Scepter),474,1,11,1,,1
+23362,3,100,1,50,Dragon Skill Ring II (High Scepter),442,1,11,1,,1
+23363,3,100,1,50,Dragon Skill Bracelet II (High Scepter),458,1,11,1,,1
+23377,3,0,1,120,Ring of the First King,426,1,0,0,,1
+23602,3,0,1,120,Bracelet of the First King,426,1,0,0,,1
+23710,3,100,1,50,Bitterblack Ring,442,1,0,1,,1
+23711,3,100,1,50,Bitterblack Earring,474,1,0,1,,1
+24741,3,100,1,130,Ring of Order,426,1,0,0,,1
 9491,3,0,1,0,Diamantes Large Cane,,,,,,
-10012,3,0,1,0,For human enemy_wp300000_1,,,,,,
-10013,3,0,1,0,For human enemy_wp300003_2,,,,,,
-10016,3,0,1,0,For human enemy_wp302006_2,,,,,,
+10012,3,0,1,64,For human enemy_wp300000_1,,,,,,
+10013,3,0,1,64,For human enemy_wp300003_2,,,,,,
+10016,3,0,1,192,For human enemy_wp302006_2,,,,,,
 10017,3,0,1,0,For human enemy_wp303000_2,,,,,,
 10018,3,0,1,0,For human enemy_wp303005_2,,,,,,
-10021,3,0,1,0,For human enemy_wp305000_1,,,,,,
-10022,3,0,1,0,For human enemy_wp305009_2,,,,,,
-10023,3,0,1,0,For human enemy_wp306000_2,,,,,,
-10024,3,0,1,0,For human enemy_wp306007_1,,,,,,
-10025,3,0,1,0,For human enemies_wp310000_1,,,,,,
-10026,3,0,1,0,For human enemy_wp310006_2,,,,,,
+10021,3,0,1,128,For human enemy_wp305000_1,,,,,,
+10022,3,0,1,128,For human enemy_wp305009_2,,,,,,
+10023,3,0,1,192,For human enemy_wp306000_2,,,,,,
+10024,3,0,1,192,For human enemy_wp306007_1,,,,,,
+10025,3,0,1,192,For human enemies_wp310000_1,,,,,,
+10026,3,0,1,192,For human enemy_wp310006_2,,,,,,
 10027,3,0,1,0,For human enemy_wp311000_1,,,,,,
 10028,3,0,1,0,For human enemies_wp311005_3,,,,,,
-10031,3,0,1,0,For human enemy_wp302000_2,,,,,,
-10033,3,0,1,0,For human enemies_wp301009_4,,,,,,
-10034,3,0,1,0,For human enemy_wp302007_4,,,,,,
+10031,3,0,1,192,For human enemy_wp302000_2,,,,,,
+10033,3,0,1,128,For human enemies_wp301009_4,,,,,,
+10034,3,0,1,192,For human enemy_wp302007_4,,,,,,
 10035,3,0,1,0,For human enemy_wp303007_4,,,,,,
-10037,3,0,1,0,For human enemy_wp305008_4,,,,,,
-10038,3,0,1,0,For human enemy_wp306015_4,,,,,,
-10039,3,0,1,0,For human enemy_wp310009_4,,,,,,
+10037,3,0,1,128,For human enemy_wp305008_4,,,,,,
+10038,3,0,1,192,For human enemy_wp306015_4,,,,,,
+10039,3,0,1,192,For human enemy_wp310009_4,,,,,,
 10040,3,0,1,0,For human enemies_wp311006_4,,,,,,
-10101,3,0,1,0,For NPC_wp300000,,,,,,
-10102,3,0,1,0,For NPC_wp300005,,,,,,
-10103,3,0,1,0,For NPC_wp300010,,,,,,
-10104,3,0,1,0,For NPC_wp300014,,,,,,
-10105,3,0,1,0,For NPC_wp300015,,,,,,
-10110,3,0,1,0,For NPC_wp302000,,,,,,
+10101,3,0,1,64,For NPC_wp300000,,,,,,
+10102,3,0,1,64,For NPC_wp300005,,,,,,
+10103,3,0,1,64,For NPC_wp300010,,,,,,
+10104,3,0,1,64,For NPC_wp300014,,,,,,
+10105,3,0,1,64,For NPC_wp300015,,,,,,
+10110,3,0,1,192,For NPC_wp302000,,,,,,
 10111,3,0,1,0,For NPC_wp303000,,,,,,
-10113,3,0,1,0,For NPC_wp305000,,,,,,
-10114,3,0,1,0,For NPC_wp306000,,,,,,
-10115,3,0,1,0,For NPC_wp306018,,,,,,
-10116,3,0,1,0,For NPC_wp308000,,,,,,
-10117,3,0,1,0,For NPC_wp310000,,,,,,
+10113,3,0,1,128,For NPC_wp305000,,,,,,
+10114,3,0,1,192,For NPC_wp306000,,,,,,
+10115,3,0,1,192,For NPC_wp306018,,,,,,
+10116,3,0,1,64,For NPC_wp308000,,,,,,
+10117,3,0,1,192,For NPC_wp310000,,,,,,
 10118,3,0,1,0,For NPC_wp311013,,,,,,
 10125,3,0,1,0,For NPC_wp311000,,,,,,
 10126,3,0,1,0,For NPC_wp307000,,,,,,
-10127,3,0,1,0,For NPC_wp308000,,,,,,
-10129,3,0,1,0,For NPC_wp305010,,,,,,
-10130,3,0,1,0,For NPC_wp306019,,,,,,
-10135,3,0,1,0,For NPC_wp305014,,,,,,
-10136,3,0,1,0,For NPC_wp300003,,,,,,
-10138,3,0,1,0,For NPC_wp306008,,,,,,
-10139,3,0,1,0,For NPC_wp310010,,,,,,
+10127,3,0,1,64,For NPC_wp308000,,,,,,
+10129,3,0,1,128,For NPC_wp305010,,,,,,
+10130,3,0,1,192,For NPC_wp306019,,,,,,
+10135,3,0,1,128,For NPC_wp305014,,,,,,
+10136,3,0,1,64,For NPC_wp300003,,,,,,
+10138,3,0,1,192,For NPC_wp306008,,,,,,
+10139,3,0,1,192,For NPC_wp310010,,,,,,
 10140,3,0,1,0,For NPC_wp303009,,,,,,
-10142,3,0,1,0,For NPC_wp302004,,,,,,
-10143,3,0,1,0,For NPC_wp308007,,,,,,
-10144,3,0,1,0,For NPC_wp305005,,,,,,
-10145,3,0,1,0,For NPC_wp302011,,,,,,
-10670,3,0,1,0,For NPC_wp308002,,,,,,
-11067,3,0,1,0,For NPC_wp300010ver2,,,,,,
-11068,3,0,1,0,For NPC_wp300047,,,,,,
-11071,3,0,1,0,For NPC_wp306006,,,,,,
-11260,3,0,1,0,For NPC_wp300053,,,,,,
+10142,3,0,1,192,For NPC_wp302004,,,,,,
+10143,3,0,1,64,For NPC_wp308007,,,,,,
+10144,3,0,1,128,For NPC_wp305005,,,,,,
+10145,3,0,1,192,For NPC_wp302011,,,,,,
+10670,3,0,1,64,For NPC_wp308002,,,,,,
+11067,3,0,1,64,For NPC_wp300010ver2,,,,,,
+11068,3,0,1,64,For NPC_wp300047,,,,,,
+11071,3,0,1,192,For NPC_wp306006,,,,,,
+11260,3,0,1,64,For NPC_wp300053,,,,,,
 11374,3,0,1,0,For NPC_wp311002,,,,,,
-11375,3,0,1,0,For NPC_wp302014,,,,,,
-11376,3,0,1,0,For NPC_wp305015,,,,,,
-11377,3,0,1,0,For NPC_wp300041,,,,,,
-11379,3,0,1,0,For NPC_wp310025,,,,,,
-11380,3,0,1,0,For NPC_wp300047,,,,,,
-11382,3,0,1,0,For NPC_wp312000,,,,,,
-11383,3,0,1,0,For human enemies_wp300041_28,,,,,,
-11385,3,0,1,0,For human enemies_wp302041_28,,,,,,
+11375,3,0,1,192,For NPC_wp302014,,,,,,
+11376,3,0,1,128,For NPC_wp305015,,,,,,
+11377,3,0,1,64,For NPC_wp300041,,,,,,
+11379,3,0,1,192,For NPC_wp310025,,,,,,
+11380,3,0,1,64,For NPC_wp300047,,,,,,
+11382,3,0,1,64,For NPC_wp312000,,,,,,
+11383,3,0,1,64,For human enemies_wp300041_28,,,,,,
+11385,3,0,1,192,For human enemies_wp302041_28,,,,,,
 11386,3,0,1,0,For human enemies_wp303024_28,,,,,,
-11388,3,0,1,0,For human enemies_wp305024_28,,,,,,
-11389,3,0,1,0,For human enemies_wp306031_28,,,,,,
-11390,3,0,1,0,For human enemies_wp308025_28,,,,,,
-11391,3,0,1,0,For human enemies_wp310025_28,,,,,,
+11388,3,0,1,128,For human enemies_wp305024_28,,,,,,
+11389,3,0,1,192,For human enemies_wp306031_28,,,,,,
+11390,3,0,1,64,For human enemies_wp308025_28,,,,,,
+11391,3,0,1,192,For human enemies_wp310025_28,,,,,,
 11392,3,0,1,0,For human enemies_wp311024_28,,,,,,
 11756,3,0,1,0,For NPC_wp307003,,,,,,
 11757,3,0,1,0,For NPC_wp311003,,,,,,
-11820,3,0,1,0,For NPC_wp312010,,,,,,
-16029,3,0,1,0,For NPC_wp306037,,,,,,
-16810,3,0,1,0,For NPC_Sword of Prince Ned,,,,,,
-16811,3,0,1,0,For NPC_Maylois Sword,,,,,,
-16813,3,0,1,0,For NPC_Gillian Great Sword,,,,,,
-16814,3,0,1,0,Berta Dagger for NPC,,,,,,
-16815,3,0,1,0,Yerhard Sword for NPC,,,,,,
-16837,3,0,1,0,For NPC_3.0 Iron Sword,,,,,,
-16838,3,0,1,0,For NPC_3.0 Landing Sword,,,,,,
-16839,3,0,1,0,3.0 Strong Hatchet for NPC,,,,,,
-16840,3,0,1,0,For NPC_3.0 Turay Sleepides,,,,,,
-16841,3,0,1,0,For NPC_3.0 Silver Rapier,,,,,,
-16842,3,0,1,0,For NPC_3.0 Morgenstern,,,,,,
-16843,3,0,1,0,3.0 White Wolf Bow for NPC,,,,,,
-16844,3,0,1,0,For NPC_3.0 Elf Stroke Bow,,,,,,
-16845,3,0,1,0,3.0 fluted bow for NPC,,,,,,
-16846,3,0,1,0,For NPC_3.0 Dacia Kinesis,,,,,,
-16847,3,0,1,0,3.0 slit dagger for NPC,,,,,,
-16848,3,0,1,0,3.0 Elf imitation dagger for NPC,,,,,,
-16849,3,0,1,0,For NPC_3.0 Great Sword,,,,,,
-16850,3,0,1,0,For NPC_3.0 Warblade,,,,,,
-16851,3,0,1,0,For NPC_3.0 Flamberge Cassadis,,,,,,
-16852,3,0,1,0,For NPC_3.0 Grap Victory,,,,,,
-18833,3,0,1,0,NPC_Survey Corps Weapons,,,,,,
-21198,3,0,1,0,For NPC_3.2_Mage sword A,,,,,,
-21199,3,0,1,0,For NPC_3.2_Mage sword B,,,,,,
+11820,3,0,1,64,For NPC_wp312010,,,,,,
+16029,3,0,1,192,For NPC_wp306037,,,,,,
+16810,3,0,1,64,For NPC_Sword of Prince Ned,,,,,,
+16811,3,0,1,64,For NPC_Maylois Sword,,,,,,
+16813,3,0,1,192,For NPC_Gillian Great Sword,,,,,,
+16814,3,0,1,128,Berta Dagger for NPC,,,,,,
+16815,3,0,1,64,Yerhard Sword for NPC,,,,,,
+16837,3,0,1,64,For NPC_3.0 Iron Sword,,,,,,
+16838,3,0,1,64,For NPC_3.0 Landing Sword,,,,,,
+16839,3,0,1,64,3.0 Strong Hatchet for NPC,,,,,,
+16840,3,0,1,64,For NPC_3.0 Turay Sleepides,,,,,,
+16841,3,0,1,64,For NPC_3.0 Silver Rapier,,,,,,
+16842,3,0,1,64,For NPC_3.0 Morgenstern,,,,,,
+16843,3,0,1,192,3.0 White Wolf Bow for NPC,,,,,,
+16844,3,0,1,192,For NPC_3.0 Elf Stroke Bow,,,,,,
+16845,3,0,1,192,3.0 fluted bow for NPC,,,,,,
+16846,3,0,1,128,For NPC_3.0 Dacia Kinesis,,,,,,
+16847,3,0,1,128,3.0 slit dagger for NPC,,,,,,
+16848,3,0,1,128,3.0 Elf imitation dagger for NPC,,,,,,
+16849,3,0,1,192,For NPC_3.0 Great Sword,,,,,,
+16850,3,0,1,192,For NPC_3.0 Warblade,,,,,,
+16851,3,0,1,192,For NPC_3.0 Flamberge Cassadis,,,,,,
+16852,3,0,1,192,For NPC_3.0 Grap Victory,,,,,,
+18833,3,0,1,128,NPC_Survey Corps Weapons,,,,,,
+21198,3,0,1,192,For NPC_3.2_Mage sword A,,,,,,
+21199,3,0,1,192,For NPC_3.2_Mage sword B,,,,,,
 21211,3,0,1,0,For NPC_3.1_Soneru Great Cane A ,,,,,,
 21212,3,0,1,0,For NPC_3.1_Sonnell Big Cane B,,,,,,
-23399,3,0,1,0,3.4_For_NPC_The_Water_Dragon_King_Single_handed_sword,,,,,,
-23401,3,0,1,0,3.4_NPC_Collaborative_Misial_Cane,,,,,,
-23402,3,0,1,0,3.4_NPC_Yami Leo_Single-handed sword,,,,,,
-10014,3,0,1,0,For human enemy_wp301000_4,,,,,,
-10015,3,0,1,0,For human enemies_wp301009_2,,,,,,
-10019,3,0,1,0,For human enemy_wp304000_1,,,,,,
-10020,3,0,1,0,For human enemy_wp304010_2,,,,,,
-10032,3,0,1,0,For human enemies_wp300008_4,,,,,,
-10036,3,0,1,0,For human enemies_wp304010_4,,,,,,
-10106,3,0,1,0,For NPC_wp301003,,,,,,
-10107,3,0,1,0,For NPC_wp301010,,,,,,
-10108,3,0,1,0,For NPC_wp301019,,,,,,
-10109,3,0,1,0,For NPC_wp301020,,,,,,
-10112,3,0,1,0,For NPC_wp304000,,,,,,
-10137,3,0,1,0,For NPC_wp301012,,,,,,
-10141,3,0,1,0,For NPC_wp304001,,,,,,
-11069,3,0,1,0,For NPC_wp301001,,,,,,
-11070,3,0,1,0,For NPC_wp301028,,,,,,
-11378,3,0,1,0,For NPC_wp301021,,,,,,
-11381,3,0,1,0,For NPC_wp301028,,,,,,
-11384,3,0,1,0,For human enemies_wp301021_28,,,,,,
-11387,3,0,1,0,For human enemies_wp304021_28,,,,,,
-16804,3,0,1,0,For NPC_3.0 Knights Shield_00,,,,,,
-16805,3,0,1,0,For NPC_3.0 Knights Shield_01,,,,,,
-16806,3,0,1,0,For NPC_3.0 Knights Shield_02,,,,,,
-16807,3,0,1,0,For NPC_3.0 Knights Shield_03,,,,,,
-16808,3,0,1,0,For NPC_3.0 Knights Shield_04,,,,,,
-16809,3,0,1,0,For NPC_3.0 Knights Shield_05,,,,,,
-16812,3,0,1,0,For NPC_Maylois Shield,,,,,,
-16835,3,0,1,0,For NPC_3.0 round shield,,,,,,
-16836,3,0,1,0,For NPC_3.0 Pertae,,,,,,
-16858,3,0,1,0,For NPC_Prince Ned shield,,,,,,
-21209,3,0,1,0,Human enemy_3.2_Megado soldier shield,,,,,,
-23400,3,0,1,0,3.4_NPC_Water_Dragon_King_Shield,,,,,,
-23403,3,0,1,0,3.4_NPC_Yami_Leo_Shield,,,,,,
+23399,3,0,1,64,3.4_For_NPC_The_Water_Dragon_King_Single_handed_sword,,,,,,
+23401,3,0,1,192,3.4_NPC_Collaborative_Misial_Cane,,,,,,
+23402,3,0,1,64,3.4_NPC_Yami Leo_Single-handed sword,,,,,,
+10014,3,0,1,128,For human enemy_wp301000_4,,,,,,
+10015,3,0,1,128,For human enemies_wp301009_2,,,,,,
+10019,3,0,1,64,For human enemy_wp304000_1,,,,,,
+10020,3,0,1,64,For human enemy_wp304010_2,,,,,,
+10032,3,0,1,64,For human enemies_wp300008_4,,,,,,
+10036,3,0,1,64,For human enemies_wp304010_4,,,,,,
+10106,3,0,1,128,For NPC_wp301003,,,,,,
+10107,3,0,1,128,For NPC_wp301010,,,,,,
+10108,3,0,1,128,For NPC_wp301019,,,,,,
+10109,3,0,1,128,For NPC_wp301020,,,,,,
+10112,3,0,1,64,For NPC_wp304000,,,,,,
+10137,3,0,1,128,For NPC_wp301012,,,,,,
+10141,3,0,1,64,For NPC_wp304001,,,,,,
+11069,3,0,1,128,For NPC_wp301001,,,,,,
+11070,3,0,1,128,For NPC_wp301028,,,,,,
+11378,3,0,1,128,For NPC_wp301021,,,,,,
+11381,3,0,1,128,For NPC_wp301028,,,,,,
+11384,3,0,1,128,For human enemies_wp301021_28,,,,,,
+11387,3,0,1,64,For human enemies_wp304021_28,,,,,,
+16804,3,0,1,128,For NPC_3.0 Knights Shield_00,,,,,,
+16805,3,0,1,128,For NPC_3.0 Knights Shield_01,,,,,,
+16806,3,0,1,128,For NPC_3.0 Knights Shield_02,,,,,,
+16807,3,0,1,128,For NPC_3.0 Knights Shield_03,,,,,,
+16808,3,0,1,128,For NPC_3.0 Knights Shield_04,,,,,,
+16809,3,0,1,128,For NPC_3.0 Knights Shield_05,,,,,,
+16812,3,0,1,128,For NPC_Maylois Shield,,,,,,
+16835,3,0,1,128,For NPC_3.0 round shield,,,,,,
+16836,3,0,1,128,For NPC_3.0 Pertae,,,,,,
+16858,3,0,1,128,For NPC_Prince Ned shield,,,,,,
+21209,3,0,1,128,Human enemy_3.2_Megado soldier shield,,,,,,
+23400,3,0,1,128,3.4_NPC_Water_Dragon_King_Shield,,,,,,
+23403,3,0,1,128,3.4_NPC_Yami_Leo_Shield,,,,,,
 10003,3,0,1,0,ah220030_0_0 for human enemy,,,,,,
 10004,3,0,1,0,ah220020_0_0 for human enemy,,,,,,
 10005,3,0,1,0,ah220006_0_0 for human enemy,,,,,,

--- a/Arrowgene.Ddon.Shared/Model/ItemSubCategory.cs
+++ b/Arrowgene.Ddon.Shared/Model/ItemSubCategory.cs
@@ -1,12 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Arrowgene.Ddon.Shared.Model
 {
-    public enum ItemSubCategory //For serverside use only.
+    public enum ItemSubCategory : ushort //For serverside use only.
     {
         UseNone = 1,
         UseThrowing = 2,
@@ -48,39 +42,39 @@ namespace Arrowgene.Ddon.Shared.Model
         MaterialPawnInspiration = 132,
         MaterialDragonAbility = 133,
 
-        //EquipSlot, offset by 200
-        EquipArmorHelm = 203,
-        EquipArmorBody = 204,
-        EquipClothingBody = 205,
-        EquipArmorArm = 206,
-        EquipArmorLeg = 207,
-        EquipClothingLeg = 208,
-        EquipOverwear = 209,
-        EquipJewelry = 210,
-        EquipLantern = 211,
-        EquipEnsemble = 212,
+        //WeaponCategory, offset by 200
+        WeaponHand = 200,
+        WeaponSword = 201,
+        WeaponShield = 202,
+        WeaponGreatsword = 203,
+        WeaponGreatshield = 204,
+        WeaponRod = 205,
+        WeaponDagger = 206,
+        WeaponBow = 207,
+        WeaponGauntlet = 208,
+        WeaponMagickBow = 209,
+        WeaponStaff = 211,
+        WeaponArchistaff = 212,
+        WeaponLance = 213,
+        WeaponMagickSword = 215,
 
-        //JewelrySubCategory, offset by 300
-        JewelryCommon = 326,
-        JewelryRing = 342,
-        JewelryBracelet = 358,
-        JewelryPierce = 374,
-        EmblemStone = 390,
-        
-        //WeaponCategory, offset by 400
-        WeaponHand = 400,
-        WeaponSword = 401,
-        WeaponShield = 402,
-        WeaponGreatsword = 403,
-        WeaponGreatshield = 404,
-        WeaponRod = 405,
-        WeaponDagger = 406,
-        WeaponBow = 407,
-        WeaponGauntlet = 408,
-        WeaponMagickBow = 409,
-        WeaponStaff = 411,
-        WeaponArchistaff = 412,
-        WeaponLance = 413,
-        WeaponMagickSword = 415,
+        //EquipSlot, offset by 300
+        EquipArmorHelm = 303,
+        EquipArmorBody = 304,
+        EquipClothingBody = 305,
+        EquipArmorArm = 306,
+        EquipArmorLeg = 307,
+        EquipClothingLeg = 308,
+        EquipOverwear = 309,
+        EquipJewelry = 310,
+        EquipLantern = 311,
+        EquipEnsemble = 312,
+
+        //JewelrySubCategory, offset by 400
+        JewelryCommon = 426,
+        JewelryRing = 442,
+        JewelryBracelet = 458,
+        JewelryPierce = 474,
+        EmblemStone = 490,
     }
 }


### PR DESCRIPTION
Address misordered Name and Subcategory in ClientItemInfoCsv, fix ItemSubCategory enum, fix bad ranks from incorrect hex pattern for high rank items in itemlist.csv.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
