### PR TITLE
Remove stale connections

### DIFF
--- a/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
@@ -102,11 +102,18 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                 List<Connection> connections = Database.SelectConnectionsByAccountId(account.Id);
                 if (connections.Count > 0)
                 {
-                    // todo check connection age?
-                    Logger.Error(client, $"Already logged in");
-                    res.Error = 1;
-                    client.Send(res);
-                    return;
+                    if (connections[0].ServerId == Server.Id && Server.ClientLookup.GetClientByAccountId(account.Id) == null)
+                    {
+                        // Remove stale connection
+                        Database.DeleteConnectionsByAccountId(account.Id);
+                    }
+                    else
+                    {
+                        Logger.Error(client, $"Already logged in");
+                        res.Error = 1;
+                        client.Send(res);
+                        return;
+                    }
                 }
                 
                 // Order Important,


### PR DESCRIPTION
When on login, the server finds an existing connection in the ddon_connection table of the DB, it'll check if there's a client for that account already in the server.
If there isn't, the ddon_connection entry will be deleted, allowing the user to log in.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
