### PR TITLE
Fix EXP bonus popup text

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -408,7 +408,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     S2CJobCharacterJobExpUpNtc expNtc = new S2CJobCharacterJobExpUpNtc();
                     expNtc.JobId = activeCharacterJobData.Job;
-                    expNtc.AddExp = gainedExp;
+                    expNtc.AddExp = gainedExp + extraBonusExp;
                     expNtc.ExtraBonusExp = extraBonusExp;
                     expNtc.TotalExp = activeCharacterJobData.Exp;
                     expNtc.Type = type; // TODO: Figure out
@@ -418,7 +418,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     S2CJobPawnJobExpUpNtc expNtc = new S2CJobPawnJobExpUpNtc();
                     expNtc.JobId = activeCharacterJobData.Job;
-                    expNtc.AddExp = gainedExp;
+                    expNtc.AddExp = gainedExp + extraBonusExp;
                     expNtc.ExtraBonusExp = extraBonusExp;
                     expNtc.TotalExp = activeCharacterJobData.Exp;
                     expNtc.Type = type; // TODO: Figure out


### PR DESCRIPTION
Changed the way the text pops up for bonus exp to reflect how it was in the original game.

![image](https://github.com/user-attachments/assets/5c57466f-4013-4b4a-a19f-e79417f3215b)

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
