### PR TITLE
Hotfix: Stamps, again.

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_stamp_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_stamp_sqlite.sql
@@ -1,7 +1,7 @@
 CREATE TABLE ddon_stamp_bonus
 (
     "character_id"    		  INTEGER PRIMARY KEY NOT NULL,
-    "last_stamp"      	      DATETIME  	NOT NULL,
+    "last_stamp_time"      	  DATETIME  	NOT NULL,
     "consecutive_stamp"       INTEGER       NOT NULL,
     "total_stamp"             INTEGER       NOT NULL,
     CONSTRAINT fk_stamp_bonus_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -564,7 +564,7 @@ CREATE TABLE IF NOT EXISTS "ddon_character_playpoint_data" (
 CREATE TABLE IF NOT EXISTS "ddon_stamp_bonus"
 (
     "character_id"    		  INTEGER PRIMARY KEY NOT NULL,
-    "last_stamp"      		  DATETIME            NOT NULL,
+    "last_stamp_time"      		  DATETIME            NOT NULL,
     "consecutive_stamp"       INTEGER             NOT NULL,
     "total_stamp"             INTEGER             NOT NULL,
     CONSTRAINT fk_stamp_bonus_character_id FOREIGN KEY ("character_id") REFERENCES ddon_character ("character_id") ON DELETE CASCADE

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbStampBonus.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbStampBonus.cs
@@ -10,7 +10,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     {
         private static readonly string[] CDataStampFields = new string[]
         {
-            "character_id", "last_stamp", "consecutive_stamp", "total_stamp"
+            "character_id", "last_stamp_time", "consecutive_stamp", "total_stamp"
         };
         private readonly string SqlInsertCharacterStamp = $"INSERT INTO \"ddon_stamp_bonus\" ({BuildQueryField(CDataStampFields)}) VALUES ({BuildQueryInsert(CDataStampFields)});";
         private static readonly string SqlUpdateCharacterStamp = $"UPDATE \"ddon_stamp_bonus\" SET {BuildQueryUpdate(CDataStampFields)} WHERE \"character_id\" = @character_id;";
@@ -42,7 +42,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private void AddParameter(TCom command, uint id, CharacterStampBonus stampData)
         {
             AddParameter(command, "character_id", id);
-            AddParameter(command, "last_stamp", stampData.LastStamp);
+            AddParameter(command, "last_stamp_time", stampData.LastStamp);
             AddParameter(command, "consecutive_stamp", stampData.ConsecutiveStamp);
             AddParameter(command, "total_stamp", stampData.TotalStamp);
         }
@@ -50,7 +50,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private CharacterStampBonus ReadCharacterStampData(TReader reader)
         {
             CharacterStampBonus stampData = new CharacterStampBonus();
-            stampData.LastStamp = GetDateTime(reader, "last_stamp");
+            stampData.LastStamp = GetDateTime(reader, "last_stamp_time");
             stampData.ConsecutiveStamp = GetUInt16(reader, "consecutive_stamp");
             stampData.TotalStamp = GetUInt16(reader, "total_stamp");
 


### PR DESCRIPTION
Had the schema wrong and fixed the migration to match the schema rather than the other way around.

Many apologies.

Restores the migration to what was originally presented, and then updates the *schema* to properly match that.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
