### PR TITLE
Fix: Crests will now persist through Gear upgrades

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -642,6 +642,41 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             return amountFound >= num;
         }
+
+        public (bool IsGreatSuccess, byte RandomQuality) ItemChangeQuality(Item refineMaterialItem)
+        {
+            byte greatSuccessValue = 1;
+            byte greatSuccessOdds = 10;
+            bool isGreatSuccess;
+            byte RandomQuality = 1;
+
+            if (refineMaterialItem.ItemId == 8036 || refineMaterialItem.ItemId == 8068) // Quality Rocks (Tier2)
+            {
+                RandomQuality = 2;
+                greatSuccessValue = 3;
+            }
+            else if (refineMaterialItem.ItemId == 8052 || refineMaterialItem.ItemId == 8084) // WhiteDragon Rocks (Tier3)
+            {
+                RandomQuality = 2;
+                greatSuccessValue = 3;
+                greatSuccessOdds = 5;
+            }
+            else if (refineMaterialItem.ItemId == 8035 || refineMaterialItem.ItemId == 8067) // Standard Rocks (Tier1)
+            {
+                RandomQuality = 1;
+                greatSuccessValue = 2;
+            }
+
+            isGreatSuccess = Random.Shared.Next(greatSuccessOdds) == 0;
+
+            if (isGreatSuccess)
+            {
+                RandomQuality = greatSuccessValue;
+            }
+
+            return (isGreatSuccess, RandomQuality);
+        }
+
     }
 
     [Serializable]

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -643,7 +643,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return amountFound >= num;
         }
 
-        public (bool IsGreatSuccess, byte RandomQuality) ItemChangeQuality(Item? refineMaterialItem)
+        public (bool IsGreatSuccess, byte RandomQuality) ItemQualityCalculation(Item? refineMaterialItem)
         {
             byte greatSuccessValue = 1;
             byte greatSuccessOdds = 10;

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -643,28 +643,31 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return amountFound >= num;
         }
 
-        public (bool IsGreatSuccess, byte RandomQuality) ItemChangeQuality(Item refineMaterialItem)
+        public (bool IsGreatSuccess, byte RandomQuality) ItemChangeQuality(Item? refineMaterialItem)
         {
             byte greatSuccessValue = 1;
             byte greatSuccessOdds = 10;
             bool isGreatSuccess;
-            byte RandomQuality = 1;
+            byte RandomQuality = 0;
 
-            if (refineMaterialItem.ItemId == 8036 || refineMaterialItem.ItemId == 8068) // Quality Rocks (Tier2)
+            if (refineMaterialItem != null)
             {
-                RandomQuality = 2;
-                greatSuccessValue = 3;
-            }
-            else if (refineMaterialItem.ItemId == 8052 || refineMaterialItem.ItemId == 8084) // WhiteDragon Rocks (Tier3)
-            {
-                RandomQuality = 2;
-                greatSuccessValue = 3;
-                greatSuccessOdds = 5;
-            }
-            else if (refineMaterialItem.ItemId == 8035 || refineMaterialItem.ItemId == 8067) // Standard Rocks (Tier1)
-            {
-                RandomQuality = 1;
-                greatSuccessValue = 2;
+                if (refineMaterialItem.ItemId == 8036 || refineMaterialItem.ItemId == 8068) // Quality Rocks (Tier2)
+                {
+                    RandomQuality = 2;
+                    greatSuccessValue = 3;
+                }
+                else if (refineMaterialItem.ItemId == 8052 || refineMaterialItem.ItemId == 8084) // WhiteDragon Rocks (Tier3)
+                {
+                    RandomQuality = 2;
+                    greatSuccessValue = 3;
+                    greatSuccessOdds = 5;
+                }
+                else if (refineMaterialItem.ItemId == 8035 || refineMaterialItem.ItemId == 8067) // Standard Rocks (Tier1)
+                {
+                    RandomQuality = 1;
+                    greatSuccessValue = 2;
+                }
             }
 
             isGreatSuccess = Random.Shared.Next(greatSuccessOdds) == 0;

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -101,7 +101,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (CanPlusValue == true)
             {
-                var (isGreatSuccess, randomQuality) = _itemManager.ItemChangeQuality(RefineMaterialItem);
+                var (isGreatSuccess, randomQuality) = _itemManager.ItemQualityCalculation(RefineMaterialItem);
                 IsGreatSuccess = isGreatSuccess;
                 RandomQuality = randomQuality;
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -37,6 +37,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override void Handle(GameClient client, StructurePacket<C2SCraftStartCraftReq> packet)
         {       
             bool CanPlusValue = false;
+            bool IsGreatSuccess = false;
             CDataMDataCraftRecipe recipe = Server.AssetRepository.CraftingRecipesAsset
                 .SelectMany(recipes => recipes.RecipeList)
                 .Where(recipe => recipe.RecipeID == packet.Structure.RecipeID)
@@ -63,7 +64,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             string RefineMaterialUID = packet.Structure.RefineMaterialUID;
             var RefineMaterialItem = Server.Database.SelectStorageItemByUId(RefineMaterialUID);
             byte RandomQuality = 0;
-            int D100 =  Random.Shared.Next(100);
 
             ushort AddStatusID = packet.Structure.Unk0;
             CDataAddStatusParam AddStat = new CDataAddStatusParam()
@@ -96,45 +96,42 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     return;
                 }
             }
-            
-            // Check if a refinematerial is set
-            if (!string.IsNullOrEmpty(RefineMaterialUID))
-            {
-                if (RefineMaterialItem.ItemId == 8036 || RefineMaterialItem.ItemId == 8068 ) // Checking if its one of the better rocks because they augment the odds of +3.
-                {
-                    D100 += 40;
-                }
-                else if (RefineMaterialItem.ItemId == 8052 || RefineMaterialItem.ItemId == 8084)
-                {
-                    D100 += 60;
-                };
-                List<CDataItemUpdateResult> updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
-                updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
-                D100 += 10;
-            }
 
             if (CanPlusValue == true)
             {
-                var thresholds = new (int Threshold, int Quality)[]
+                byte GreatSuccessValue = 1;
+                byte GreatSuccessOdds = 10;
+
+                if (!string.IsNullOrEmpty(RefineMaterialUID)) // Check if a refinematerial is set
                 {
-                    (100, 3),
-                    (90, 2),
-                    (70, 1),
-                    (0, 0)  // This should always be the last one to catch all remaining cases
-                };
-                RandomQuality = (byte)thresholds.First(t => D100 >= t.Threshold).Quality;
+                    RandomQuality = 1;
+                    if (RefineMaterialItem.ItemId == 8036 || RefineMaterialItem.ItemId == 8068 ) // Checking if its one of the better rocks because they augment the odds of +3.
+                    {
+                        RandomQuality = 2; // Quality rocks gurantee a minimum, standard is 1, Quality and WhiteDragon are 2.
+                        GreatSuccessValue = 3; // Quality Rocks determine the highest you can roll, standard is +2, Quality and WhiteDragon are +3. (Max requires greatsuccess)
+                    }
+                    else if (RefineMaterialItem.ItemId == 8052 || RefineMaterialItem.ItemId == 8084)
+                    {
+                        RandomQuality = 2;
+                        GreatSuccessValue = 3;
+                        GreatSuccessOdds = 5; // WhiteDragon Rocks have better odds of GreatSuccess.
+                    };
+
+                    List<CDataItemUpdateResult> updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
+                    updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                }
+
+                IsGreatSuccess = Random.Shared.Next(GreatSuccessOdds) == 0;
+
+                if (IsGreatSuccess)
+                {
+                    RandomQuality = GreatSuccessValue;
+                }
             };
 
+
+
             // TODO: Refactor to generate the actual item here,
-            // TODO: Quality is an innate principle, we need to check if the newly generated item belongs to certain subcats,found in ItemSubCategory,
-            // Weapons & Armor can have quality, but subweapons (shield/red), lantern and jewelry cannot, even though the client does support it, its not meant to happen.
-            // So we will have to filter them out.
-
-            //TODO: There are 3 tiers of quality up items, we need to handle those appropriately. Looks like they don't get sent in the request in a special way,
-            // So we'll need todo a direct ItemID comparison to know which one we're getting.
-            
-
-
             // TODO: Calculate final craft price with the discounts from the craft pawns
             uint finalCraftCost = recipe.Cost * packet.Structure.CreateCount;
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -101,12 +101,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (CanPlusValue == true)
             {
-                if (!string.IsNullOrEmpty(RefineMaterialUID)) // Check if a refinematerial is set
-                {
-                    var (isGreatSuccess, randomQuality) = _itemManager.ItemChangeQuality(RefineMaterialItem);
-                    IsGreatSuccess = isGreatSuccess;
-                    RandomQuality = randomQuality;
+                var (isGreatSuccess, randomQuality) = _itemManager.ItemChangeQuality(RefineMaterialItem);
+                IsGreatSuccess = isGreatSuccess;
+                RandomQuality = randomQuality;
 
+                if (!string.IsNullOrEmpty(RefineMaterialUID))
+                {
                     List<CDataItemUpdateResult> updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
                     updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
                 }

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
@@ -48,10 +48,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     var updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, DyeUId, 1);
                     updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
                 }
-                catch (NotEnoughItemsException e)
+                catch (NotEnoughItemsException)
                 {
-                    Logger.Exception(e);
-                    return new S2CCraftStartEquipColorChangeRes();
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_ITEM_NUM, "Client Item Desync has Occurred.");
                 }
             }
 
@@ -103,7 +102,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                Logger.Error($"Item with UID {equipItemUID} not found in {storageType}");
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_STORAGE_TYPE, $"Item with UID {equipItemUID} not found in {storageType}");
             }
             

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
@@ -43,8 +43,16 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (!string.IsNullOrEmpty(DyeUId))
             {
-                var updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, DyeUId, 1);
-                updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                try
+                {
+                    var updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, DyeUId, 1);
+                    updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                }
+                catch (NotEnoughItemsException e)
+                {
+                    Logger.Exception(e);
+                    return new S2CCraftStartEquipColorChangeRes();
+                }
             }
 
             //Applying the Dye

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipColorChangeHandler.cs
@@ -28,7 +28,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             uint charid = client.Character.CharacterId;
             string equipItemUID = request.EquipItemUID;
             List<CDataCraftColorant> colorList = request.CraftColorantList;
-            Item equipItem = Server.Database.SelectStorageItemByUId(equipItemUID);
+            var ramItem = character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, equipItemUID);
+            var equipItem = ramItem.Item2.Item2;
             byte color = request.Color;
             List<CDataCraftColorant> colorlist = new List<CDataCraftColorant>(); // this is probably for consuming the dye
             uint craftpawnid = request.CraftMainPawnID;

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -69,10 +69,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var updateResults = _itemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, craftMaterial.ItemUId, craftMaterial.ItemNum);
                 updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
                 }
-                catch (NotEnoughItemsException e)
+                catch (NotEnoughItemsException)
                 {
-                    Logger.Exception(e);
-                    return new S2CCraftStartEquipGradeUpRes();
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_ITEM_NUM, "Client Item Desync has Occurred.");
                 }
             }
 
@@ -173,7 +172,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                Logger.Error($"Item with UID {equipItemUID} not found in {storageType}");
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_STORAGE_TYPE, $"Item with UID {equipItemUID} not found in {storageType}");
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -68,8 +68,16 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // Removes crafting materials
             foreach (var craftMaterial in request.CraftMaterialList)
             {
-                var updateResults = _itemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, craftMaterial.ItemUId, craftMaterial.ItemNum);
-                updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                try
+                {
+                    var updateResults = _itemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, craftMaterial.ItemUId, craftMaterial.ItemNum);
+                    updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                }
+                catch (NotEnoughItemsException e)
+                {
+                    Logger.Exception(e);
+                    return new S2CCraftStartEquipGradeUpRes();
+                }
             }
 
             // Subtract less Gold if support pawn is used and add slightly more points

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -100,23 +100,20 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 canContinue = false;
             }
             bool DoUpgrade = currentTotalEquipPoint >= requiredPoints;
-            
+
             if (DoUpgrade)
             {
+                equipItem.ItemId = gearupgradeID;
                 currentTotalEquipPoint = 0;
+                equipItem.EquipPoints = currentTotalEquipPoint;
                 Server.Database.UpdateItemEquipPoints(equipItemUID, currentTotalEquipPoint);
-            }
-
-            equipItem.ItemId = gearupgradeID;
-            equipItem.EquipPoints = currentTotalEquipPoint;
-
-            if (DoUpgrade)
-            {
                 UpdateCharacterItem(client, equipItemUID, equipItem, charid, updateCharacterItemNtc, CurrentEquipInfo);
                 res = CreateUpgradeResponse(equipItemUID, gearupgradeID, gradeuplist, EquipRank, goldRequired, IsGreatSuccess, CurrentEquipInfo, equipItem.ItemId, canContinue, dummydata);
             }
             else
             {
+                equipItem.ItemId = equipItem.ItemId;
+                equipItem.EquipPoints = currentTotalEquipPoint;
                 res = CreateEquipPointResponse(equipItemUID, addEquipPoint, currentTotalEquipPoint, goldRequired, IsGreatSuccess, CurrentEquipInfo, canContinue, dummydata);
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -23,9 +23,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CCraftStartEquipGradeUpRes Handle(GameClient client, C2SCraftStartEquipGradeUpReq request)
         {
-            Character character = client.Character;
             string equipItemUID = request.EquipItemUID;
-            Item equipItem = Server.Database.SelectStorageItemByUId(equipItemUID);
+            Character character = client.Character;
+            var ramItem = character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, equipItemUID);
+            var equipItem = ramItem.Item2.Item2;
             uint charid = client.Character.CharacterId;
             uint craftpawnid = request.CraftMainPawnID;
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -62,23 +62,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             
             if (!string.IsNullOrEmpty(RefineMaterialUID))
             {
-                equipItem.PlusValue = 1;
-                GreatSuccessValue = 2;
-                byte GreatSuccessOdds = 10;
-
-                if (RefineMaterialItem.ItemId == 8036 || RefineMaterialItem.ItemId == 8068 ) // Quality Rocks (Tier2)
-                {
-                    equipItem.PlusValue = 2; // Quality rocks gurantee a minimum, standard is 1, Quality and WhiteDragon are 2.
-                    GreatSuccessValue = 3; // Quality Rocks determine the highest you can roll, standard is +2, Quality and WhiteDragon are +3. (Max requires greatsuccess)
-                }
-                else if (RefineMaterialItem.ItemId == 8052 || RefineMaterialItem.ItemId == 8084) // WhiteDragon Rocks (Tier3)
-                {
-                    equipItem.PlusValue = 2;
-                    GreatSuccessValue = 3;
-                    GreatSuccessOdds = 5; // WhiteDragon Rocks have better odds of GreatSuccess.
-                }
-
-                IsGreatSuccess = Random.Shared.Next(GreatSuccessOdds) == 0;
+                var (isGreatSuccess, randomQuality) = _itemManager.ItemChangeQuality(RefineMaterialItem);
+                IsGreatSuccess = isGreatSuccess;
+                RandomQuality = randomQuality;
 
                 try
                 {
@@ -89,11 +75,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_ITEM_NUM, "Client Item Desync has Occurred.");
                 }
-            }
-
-            if (IsGreatSuccess)
-            {
-                RandomQuality = GreatSuccessValue;
             }
 
             // TODO: figuring out what this is

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -78,8 +78,16 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     D100 += 60;
                 };
-                updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
-                updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                try
+                {
+                    updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
+                    updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
+                }
+                catch (NotEnoughItemsException e)
+                {
+                    Logger.Exception(e);
+                    return new S2CCraftStartQualityUpRes();
+                }
             }
 
             var thresholds = new (int Threshold, int Quality)[]

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -62,7 +62,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             
             if (!string.IsNullOrEmpty(RefineMaterialUID))
             {
-                var (isGreatSuccess, randomQuality) = _itemManager.ItemChangeQuality(RefineMaterialItem);
+                var (isGreatSuccess, randomQuality) = _itemManager.ItemQualityCalculation(RefineMaterialItem);
                 IsGreatSuccess = isGreatSuccess;
                 RandomQuality = randomQuality;
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -83,10 +83,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
                     updateCharacterItemNtc.UpdateItemList.AddRange(updateResults);
                 }
-                catch (NotEnoughItemsException e)
+                catch (NotEnoughItemsException)
                 {
-                    Logger.Exception(e);
-                    return new S2CCraftStartQualityUpRes();
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_ITEM_NUM, "Client Item Desync has Occurred.");
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -32,12 +32,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var ramItem = character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, equipItemUID);
             var equipItem = ramItem.Item2.Item2;
             uint craftpawnid = request.CraftMainPawnID;
-            bool IsGreatSuccess = Random.Shared.Next(10) == 0;
+            bool IsGreatSuccess = false;
             string RefineMaterialUID = request.RefineUID;
             var RefineMaterialItem = Server.Database.SelectStorageItemByUId(RefineMaterialUID);
             ushort AddStatusID = request.AddStatusID;
             byte RandomQuality = 0;
-            int D100 =  Random.Shared.Next(100);
+            byte GreatSuccessValue = 0;
             List<CDataItemUpdateResult> updateResults;
             S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc();  
 
@@ -56,28 +56,30 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 ItemUId = equipItemUID,
             };
-            // TODO: figuring out what this is
-            // I've tried plugging Crest IDs & Equipment ID/RandomQuality n such, and just random numbers Unk0 - Unk4 just don't seem to change anything.
-            CDataS2CCraftStartQualityUpResUnk0 dummydata = new CDataS2CCraftStartQualityUpResUnk0()
-            {
-                IsGreatSuccess = IsGreatSuccess
-            };
 
             // TODO: Revisit AdditionalStatus down the line. It appears it might be apart of a larger system involving craig? 
             // Definitely a potential huge rabbit hole that I think we should deal with in a different PR.
-
-            //TODO: There are 3 tiers, and the lowest tier can't become +3, and the highest has better chance of +3, so we need to do a direct ID comparison,
-            // So a total of 6 IDs? for armor and weapons. 3 each.
+            
             if (!string.IsNullOrEmpty(RefineMaterialUID))
             {
-                if (RefineMaterialItem.ItemId == 8036 || RefineMaterialItem.ItemId == 8068 ) // Checking if its one of the better rocks because they augment the odds of +3.
+                equipItem.PlusValue = 1;
+                GreatSuccessValue = 2;
+                byte GreatSuccessOdds = 10;
+
+                if (RefineMaterialItem.ItemId == 8036 || RefineMaterialItem.ItemId == 8068 ) // Quality Rocks (Tier2)
                 {
-                    D100 += 40;
+                    equipItem.PlusValue = 2; // Quality rocks gurantee a minimum, standard is 1, Quality and WhiteDragon are 2.
+                    GreatSuccessValue = 3; // Quality Rocks determine the highest you can roll, standard is +2, Quality and WhiteDragon are +3. (Max requires greatsuccess)
                 }
-                else if (RefineMaterialItem.ItemId == 8052 || RefineMaterialItem.ItemId == 8084)
+                else if (RefineMaterialItem.ItemId == 8052 || RefineMaterialItem.ItemId == 8084) // WhiteDragon Rocks (Tier3)
                 {
-                    D100 += 60;
-                };
+                    equipItem.PlusValue = 2;
+                    GreatSuccessValue = 3;
+                    GreatSuccessOdds = 5; // WhiteDragon Rocks have better odds of GreatSuccess.
+                }
+
+                IsGreatSuccess = Random.Shared.Next(GreatSuccessOdds) == 0;
+
                 try
                 {
                     updateResults = Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, RefineMaterialUID, 1);
@@ -89,28 +91,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
-            var thresholds = new (int Threshold, int Quality)[]
-            {   
-                (85, 2),
-                (45, 1),
-                (0, 0)
-            };
-
-            RandomQuality = (byte)thresholds.First(t => D100 >= t.Threshold).Quality;
-            if (D100 > 150)
-            {
-                IsGreatSuccess = true;
-            }
             if (IsGreatSuccess)
             {
-                RandomQuality = 3;
+                RandomQuality = GreatSuccessValue;
             }
 
-            if (equipItem.PlusValue > RandomQuality)
+            // TODO: figuring out what this is
+            // I've tried plugging Crest IDs & Equipment ID/RandomQuality n such, and just random numbers Unk0 - Unk4 just don't seem to change anything.
+            CDataS2CCraftStartQualityUpResUnk0 dummydata = new CDataS2CCraftStartQualityUpResUnk0()
             {
-                RandomQuality = equipItem.PlusValue;
-                // Wiki's say you can't lower quality.
-            }
+                IsGreatSuccess = IsGreatSuccess
+            };
 
             // Updating the item.
             equipItem.ItemId = equipItem.ItemId;

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartQualityUpHandler.cs
@@ -28,8 +28,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CCraftStartQualityUpRes Handle(GameClient client, C2SCraftStartQualityUpReq request)
         {  
             string equipItemUID = request.ItemUID;
-            var equipItem = Server.Database.SelectStorageItemByUId(equipItemUID);
             Character character = client.Character;
+            var ramItem = character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, equipItemUID);
+            var equipItem = ramItem.Item2.Item2;
             uint craftpawnid = request.CraftMainPawnID;
             bool IsGreatSuccess = Random.Shared.Next(10) == 0;
             string RefineMaterialUID = request.RefineUID;


### PR DESCRIPTION
Crests were not persisting if your gear would change quality/enhance/dye, now they do.

This also tweaks Quality RNG behaviour to be more accurate to Live.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
