### PR TITLE
Support for different servers acting as channels

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/ServerCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/ServerCommand.cs
@@ -17,7 +17,7 @@ namespace Arrowgene.Ddon.Cli.Command
     {
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(ServerCommand));
 
-        private Setting _setting;
+        private readonly Setting _setting;
         private DdonLoginServer _loginServer;
         private DdonGameServer _gameServer;
         private DdonWebServer _webServer;
@@ -29,6 +29,12 @@ namespace Arrowgene.Ddon.Cli.Command
 
         public string Description =>
             $"Dragons Dogma Online Server. Ex.:{Environment.NewLine}server start{Environment.NewLine}server stop";
+
+
+        public ServerCommand(Setting setting)
+        {
+            _setting = setting;
+        }
 
 
         public CommandResultType Run(CommandParameter parameter)
@@ -83,22 +89,6 @@ namespace Arrowgene.Ddon.Cli.Command
             Logger.Info($"***{Environment.NewLine}");
 
             bool isService = parameter.Switches.Contains("--service");
-
-            if (_setting == null)
-            {
-                string settingPath = Path.Combine(Util.ExecutingDirectory(), "Files/Arrowgene.Ddon.config.json");
-                _setting = Setting.Load(settingPath);
-                if (_setting == null)
-                {
-                    _setting = new Setting();
-                    _setting.Save(settingPath);
-                    Logger.Info($"Created new settings and saved to:{settingPath}");
-                }
-                else
-                {
-                    Logger.Info($"Loaded settings from:{settingPath}");
-                }
-            }
 
             if (_database == null)
             {

--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of Arrowgene.Ddon.Cli
  *
  * Arrowgene.Ddon.Cli is a server implementation for the game "Dragons Dogma Online".
@@ -98,7 +98,8 @@ namespace Arrowgene.Ddon.Cli
 
             CommandParameter parameter = ParseParameter(arguments);
 
-            string settingPath = Path.Combine(Util.ExecutingDirectory(), "Files/Arrowgene.Ddon.config.json");
+            string settingArgument = parameter.SwitchMap.GetValueOrDefault("--config", "Files/Arrowgene.Ddon.config.json");                
+            string settingPath = Path.Combine(Util.ExecutingDirectory(), settingArgument);
             string settingLogMessage;
             _setting = Setting.Load(settingPath);
             if (_setting == null)

--- a/Arrowgene.Ddon.Cli/Setting.cs
+++ b/Arrowgene.Ddon.Cli/Setting.cs
@@ -30,6 +30,7 @@ namespace Arrowgene.Ddon.Cli
             File.WriteAllText(filePath, json);
         }
 
+        [DataMember(Order = 0)] public string LogPath { get; set; }
         [DataMember(Order = 10)] public WebServerSetting WebServerSetting { get; set; }
         [DataMember(Order = 20)] public GameServerSetting GameServerSetting { get; set; }
         [DataMember(Order = 30)] public LoginServerSetting LoginServerSetting { get; set; }
@@ -38,6 +39,7 @@ namespace Arrowgene.Ddon.Cli
 
         public Setting()
         {
+            LogPath = "Logs";
             WebServerSetting = new WebServerSetting();
             GameServerSetting = new GameServerSetting();
             LoginServerSetting = new LoginServerSetting();

--- a/Arrowgene.Ddon.GameServer/Handler/ClientChallengeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClientChallengeHandler.cs
@@ -19,6 +19,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, IPacket packet)
         {
+            client.SetChallengeCompleted(true);
+            
             Challenge.Response challenge = client.HandleChallenge(packet.Data);
             if (challenge.Error)
             {

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -339,6 +339,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SConnectionLoginReq.Serializer());
             Create(new C2SConnectionMoveInServerReq.Serializer());
             Create(new C2SConnectionMoveOutServerReq.Serializer());
+            Create(new C2SConnectionReserveServerReq.Serializer());
 
             Create(new C2SContextGetSetContextReq.Serializer());
             Create(new C2SContextMasterThrowReq.Serializer());
@@ -653,6 +654,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CConnectionLogoutRes.Serializer());
             Create(new S2CConnectionMoveInServerRes.Serializer());
             Create(new S2CConnectionMoveOutServerRes.Serializer());
+            Create(new S2CConnectionReserveServerRes.Serializer());
+            
             Create(new S2CContextGetAllPlayerContextNtc.Serializer());
             Create(new S2CContextGetLobbyPlayerContextNtc.Serializer());
             Create(new S2CContextGetPartyMypawnContextNtc.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SConnectionReserveServerReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SConnectionReserveServerReq.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SConnectionReserveServerReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CONNECTION_RESERVE_SERVER_REQ;
+
+        public C2SConnectionReserveServerReq()
+        {
+            ReserveInfoList = new List<CDataCommonU32>();
+        }
+
+        public ushort GameServerUniqueID { get; set; }
+        public byte Type { get; set; }
+        public byte RotationServerID { get; set; }
+        public List<CDataCommonU32> ReserveInfoList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SConnectionReserveServerReq>
+        {
+            public override void Write(IBuffer buffer, C2SConnectionReserveServerReq obj)
+            {
+                WriteUInt16(buffer, obj.GameServerUniqueID);
+                WriteByte(buffer, obj.Type);
+                WriteByte(buffer, obj.RotationServerID);
+                WriteEntityList<CDataCommonU32>(buffer, obj.ReserveInfoList);
+            }
+
+            public override C2SConnectionReserveServerReq Read(IBuffer buffer)
+            {
+                C2SConnectionReserveServerReq obj = new C2SConnectionReserveServerReq();
+                obj.GameServerUniqueID = ReadUInt16(buffer);
+                obj.Type = ReadByte(buffer);
+                obj.RotationServerID = ReadByte(buffer);
+                obj.ReserveInfoList = ReadEntityList<CDataCommonU32>(buffer);
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CConnectionReserveServerRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CConnectionReserveServerRes.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CConnectionReserveServerRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CONNECTION_RESERVE_SERVER_RES;
+
+        public S2CConnectionReserveServerRes()
+        {
+            ReserveInfoList = new List<CDataCommonU32>();
+        }
+
+        public ushort GameServerUniqueID { get; set; }
+        public List<CDataCommonU32> ReserveInfoList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CConnectionReserveServerRes>
+        {
+            public override void Write(IBuffer buffer, S2CConnectionReserveServerRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteUInt16(buffer, obj.GameServerUniqueID);
+                WriteEntityList<CDataCommonU32>(buffer, obj.ReserveInfoList);
+            }
+
+            public override S2CConnectionReserveServerRes Read(IBuffer buffer)
+            {
+                S2CConnectionReserveServerRes obj = new S2CConnectionReserveServerRes();
+                ReadServerResponse(buffer, obj);
+                obj.GameServerUniqueID = ReadUInt16(buffer);
+                obj.ReserveInfoList = ReadEntityList<CDataCommonU32>(buffer);
+                return obj;
+            }
+        }
+    }
+}


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/8da9ca30-b77b-4c3f-ac41-1c2b3b2c45ed)

This PR adds support for the following:
- Specifying the log directory path in the config file
- Specifying the config file path with command line arguments
- Adding DB entries for connections in different servers when the client requests it

These three features combined allow running multiple instances of the server, sharing assets and database, with the client being able to switch between them using the ingame World Select option by doing the following:
1. Create a copy of the config file (Files/Arrowgene.Ddon.config.json), naming it, for example, Arrowgene.DDon.config-2.json
2. Editing the config file to have a different LogPath directory, for example, "Logs-2"
3. Editing the ports 52000, 52099 and 52100 to different values, for example, 42000, 42099 and 42100
4. Editing the GameServerSetting.ServerSetting.Id to a different value. In this example, 20
5. Editing the LoginServerSetting.ServerSetting.Id to a different value. In this example, 2
6. Adding a new entry in the shared asset file GameServerList.csv, with the new server with its ID and ports, and a name to easily identify it.

```csv
#Id,Name,Brief,TrafficName,TrafficLevel,MaxLoginNum,IpAddress,Port,IsHide
10,Local Host,Brief,Traffic Name,0,1000,127.0.0.1,52000,false
20,Local Host 2,Brief,Traffic Name,0,1000,127.0.0.1,42000,false
```

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
