### PR TITLE
Fix various crafting exp, rank & promotion-related bugs.

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -62,14 +62,23 @@ CREATE TABLE IF NOT EXISTS ddon_character
 
 CREATE TABLE IF NOT EXISTS ddon_pawn
 (
-    "pawn_id"             INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    "character_common_id" INTEGER                           NOT NULL,
-    "character_id"        INTEGER                           NOT NULL,
-    "name"                TEXT                              NOT NULL,
-    "hm_type"             SMALLINT                          NOT NULL,
-    "pawn_type"           SMALLINT                          NOT NULL,
-    "training_points"     INTEGER                           NOT NULL,
-    "available_training"  INTEGER                           NOT NULL,
+    "pawn_id"                     INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "character_common_id"         INTEGER                           NOT NULL,
+    "character_id"                INTEGER                           NOT NULL,
+    "name"                        TEXT                              NOT NULL,
+    "hm_type"                     SMALLINT                          NOT NULL,
+    "pawn_type"                   SMALLINT                          NOT NULL,
+    "training_points"             INTEGER                           NOT NULL,
+    "available_training"          INTEGER                           NOT NULL,
+    "craft_rank"                  INTEGER                           NOT NULL,
+    "craft_rank_limit"            INTEGER                           NOT NULL,
+    "craft_exp"                   INTEGER                           NOT NULL,
+    "craft_points"                INTEGER                           NOT NULL,
+    "production_speed_level"      INTEGER                           NOT NULL,
+    "equipment_enhancement_level" INTEGER                           NOT NULL,
+    "equipment_quality_level"     INTEGER                           NOT NULL,
+    "consumable_quantity_level"   INTEGER                           NOT NULL,
+    "cost_performance_level"      INTEGER                           NOT NULL,
     CONSTRAINT fk_pawn_character_common_id FOREIGN KEY ("character_common_id") REFERENCES ddon_character_common ("character_common_id") ON DELETE CASCADE,
     CONSTRAINT fk_character_character_id FOREIGN KEY ("character_id") REFERENCES ddon_character ("character_id") ON DELETE CASCADE
 );
@@ -646,14 +655,14 @@ CREATE TABLE IF NOT EXISTS "ddon_pawn_craft_progress"
     "great_success"          BOOLEAN NOT NULL,
     "bonus_exp"              INTEGER NOT NULL,
     "additional_quantity"    INTEGER NOT NULL,
-    FOREIGN KEY ("craft_character_id") REFERENCES "ddon_character" ("character_id"),
-    FOREIGN KEY ("craft_lead_pawn_id") REFERENCES "ddon_pawn" ("pawn_id")
+    FOREIGN KEY ("craft_character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE,
+    FOREIGN KEY ("craft_lead_pawn_id") REFERENCES "ddon_pawn" ("pawn_id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS "ddon_binary_data"
 (
-    "character_id"      INTEGER  NOT NULL,
-    "binary_data"       BLOB     NOT NULL,
+    "character_id" INTEGER NOT NULL,
+    "binary_data"  BLOB    NOT NULL,
     CONSTRAINT pk_binary_data PRIMARY KEY (character_id),
-    CONSTRAINT fk_binary_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character"("character_id") ON DELETE CASCADE
+    CONSTRAINT fk_binary_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );

--- a/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
@@ -127,7 +127,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             return Math.Clamp(
                 productionSpeedLevels.Select(level => level * ProductionSpeedIncrementPerLevel + ProductionSpeedMinimumPerPawn).Sum() *
-                _server.Setting.ServerSetting.AdditionalProductionSpeedFactor, 0, 100);
+                _server.Setting.GameLogicSetting.AdditionalProductionSpeedFactor, 0, 100);
         }
 
         public uint CalculateRecipeProductionSpeed(uint recipeTime, List<uint> productionSpeedLevels)
@@ -280,7 +280,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             return Math.Clamp(
                 costPerformanceLevels.Select(level => level * CostPerformanceIncrementPerLevel + CostPerformanceMinimumPerPawn).Sum() *
-                _server.Setting.ServerSetting.AdditionalCostPerformanceFactor, 0, 100);
+                _server.Setting.GameLogicSetting.AdditionalCostPerformanceFactor, 0, 100);
         }
 
         /// <summary>
@@ -335,14 +335,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return pawn.CraftData.PawnCraftSkillList.Find(skill => skill.Type == craftSkillType).Level;
         }
 
-        public static bool IsCraftRankLimitPromotionRecipe(Pawn pawn, uint recipeId)
+        public static bool IsCraftRankLimitPromotionRecipe(uint recipeId)
         {
-            return craftRankLimitPromotionRecipes.ContainsKey(pawn.CraftData.CraftRank) && craftRankLimitPromotionRecipes[pawn.CraftData.CraftRank] == recipeId;
+            return craftRankLimitPromotionRecipes.ContainsValue(recipeId);
         }
 
         public static void PromotePawnRankLimit(Pawn pawn)
         {
-            pawn.CraftData.CraftRankLimit = craftRankLimits[pawn.CraftData.CraftRankLimit];
+            if (craftRankLimitPromotionRecipes.ContainsKey(pawn.CraftData.CraftRank))
+            {
+                pawn.CraftData.CraftRankLimit = craftRankLimits[pawn.CraftData.CraftRankLimit];
+            }
         }
 
         public static bool CanPawnRankUp(Pawn pawn)
@@ -353,39 +356,49 @@ namespace Arrowgene.Ddon.GameServer.Characters
         public static uint CalculatePawnRankUp(Pawn pawn)
         {
             uint rankUps = 0;
-            for (int i = (int)pawn.CraftData.CraftRank; i < pawn.CraftData.CraftRankLimit; i++)
+
+            if (CanPawnRankUp(pawn))
             {
-                if (pawn.CraftData.CraftExp >= craftRankExpLimit[i])
+                for (int i = (int)pawn.CraftData.CraftRank; i < pawn.CraftData.CraftRankLimit; i++)
                 {
-                    rankUps++;
-                }
-                else
-                {
-                    break;
+                    if (pawn.CraftData.CraftExp >= craftRankExpLimit[i])
+                    {
+                        rankUps++;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
             return rankUps;
         }
 
-        public static void HandlePawnRankUp(GameClient client, Pawn leadPawn)
+        public static void HandlePawnRankUpNtc(GameClient client, Pawn leadPawn)
         {
+            S2CCraftCraftRankUpNtc rankUpNtc = new S2CCraftCraftRankUpNtc
+            {
+                PawnId = leadPawn.PawnId,
+                CraftRank = leadPawn.CraftData.CraftRank
+            };
+            
             uint rankUps = CalculatePawnRankUp(leadPawn);
             if (rankUps > 0)
             {
                 uint rankUpDelta = Math.Clamp(leadPawn.CraftData.CraftRank + rankUps, leadPawn.CraftData.CraftRank, PawnCraftRankMaxLimit) - leadPawn.CraftData.CraftRank;
+                
                 leadPawn.CraftData.CraftRank += rankUpDelta;
                 leadPawn.CraftData.CraftPoint += rankUpDelta;
-                leadPawn.CraftData.CraftExp = Math.Clamp(leadPawn.CraftData.CraftExp, 0, craftRankExpLimit[(int)leadPawn.CraftData.CraftRank]);
-                S2CCraftCraftRankUpNtc rankUpNtc = new S2CCraftCraftRankUpNtc
-                {
-                    PawnId = leadPawn.PawnId,
-                    CraftRank = leadPawn.CraftData.CraftRank,
-                    AddCraftPoints = rankUpDelta,
-                    TotalCraftPoint = leadPawn.CraftData.CraftPoint
-                };
-                client.Send(rankUpNtc);
+
+                rankUpNtc.AddCraftPoints = rankUpDelta;
+                rankUpNtc.CraftRank = leadPawn.CraftData.CraftRank;
+                rankUpNtc.TotalCraftPoint = leadPawn.CraftData.CraftPoint;
+                
+                leadPawn.CraftData.CraftExp = Math.Clamp(leadPawn.CraftData.CraftExp, 0, craftRankExpLimit[(int)leadPawn.CraftData.CraftRankLimit-1]);
             }
+
+            client.Send(rankUpNtc);
         }
 
         public static bool CanPawnExpUp(Pawn pawn)
@@ -393,26 +406,37 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return pawn.CraftData.CraftRank < pawn.CraftData.CraftRankLimit;
         }
 
-        public static void HandlePawnExpUp(GameClient client, Pawn leadPawn, uint exp, uint bonusExp)
+        public static void HandlePawnExpUpNtc(GameClient client, Pawn leadPawn, uint exp, uint bonusExp)
         {
-            uint expUp = 0;
-            uint bonusExpUp = 0;
-            if (CanPawnExpUp(leadPawn))
-            {
-                expUp = exp;
-                bonusExpUp = bonusExp;
-            }
-
             S2CCraftCraftExpUpNtc expNtc = new S2CCraftCraftExpUpNtc()
             {
                 PawnId = leadPawn.PawnId,
-                AddExp = expUp,
-                ExtraBonusExp = bonusExpUp,
-                TotalExp = expUp + bonusExpUp,
                 CraftRankLimit = leadPawn.CraftData.CraftRankLimit
             };
-            leadPawn.CraftData.CraftExp += expNtc.TotalExp;
+            
+            if (CanPawnExpUp(leadPawn))
+            {
+                expNtc.AddExp = exp;
+                expNtc.ExtraBonusExp = bonusExp;
+                expNtc.TotalExp = exp + bonusExp;
+                
+                leadPawn.CraftData.CraftExp += expNtc.TotalExp;
+                
+                leadPawn.CraftData.CraftExp = Math.Clamp(leadPawn.CraftData.CraftExp, 0, craftRankExpLimit[(int)leadPawn.CraftData.CraftRankLimit]);
+            }
+
             client.Send(expNtc);
+        }
+
+        public Pawn FindPawn(GameClient client, uint pawnId, bool fallbackToDatabase=false)
+        {
+            Pawn pawn = client.Character.Pawns.Find(p => p.PawnId == pawnId);
+            if (pawn == null)
+            {
+                pawn = _server.Database.SelectPawn(pawnId);
+            }
+
+            return pawn;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/GameServerSetting.cs
+++ b/Arrowgene.Ddon.GameServer/GameServerSetting.cs
@@ -7,6 +7,7 @@ namespace Arrowgene.Ddon.GameServer
     public class GameServerSetting
     {
         [DataMember(Order = 1)] public ServerSetting ServerSetting { get; set; }
+        [DataMember(Order = 2)] public GameLogicSetting GameLogicSetting { get; set; }
 
         public GameServerSetting()
         {
@@ -15,11 +16,16 @@ namespace Arrowgene.Ddon.GameServer
             ServerSetting.Name = "Game";
             ServerSetting.ServerPort = 52000;
             ServerSetting.ServerSocketSettings.Identity = "Game";
+            
+            GameLogicSetting = new GameLogicSetting();
+            GameLogicSetting.AdditionalProductionSpeedFactor = 1.0;
+            GameLogicSetting.AdditionalCostPerformanceFactor = 1.0;
         }
 
         public GameServerSetting(GameServerSetting setting)
         {
             ServerSetting = new ServerSetting(setting.ServerSetting);
+            GameLogicSetting = new GameLogicSetting(setting.GameLogicSetting);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
@@ -1,14 +1,11 @@
+using System;
+using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -45,7 +42,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 relativeSlotNo = EquipManager.DeterminePawnEquipSlot(relativeSlotNo);
                 result.CurrentEquip.EquipSlot.CharacterId = 0;
                 result.CurrentEquip.EquipSlot.PawnId = pawnId;
-
             }
 
             if (storageType == StorageType.CharacterEquipment || storageType == StorageType.PawnEquipment)
@@ -77,24 +73,30 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 });
 
                 // Consume the crest
-                updateCharacterItemNtc.UpdateItemList.AddRange(Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, element.ItemUId, 1));
+                updateCharacterItemNtc.UpdateItemList.AddRange(
+                    Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, element.ItemUId, 1));
             }
-            
+
             updateCharacterItemNtc.UpdateType = ItemNoticeType.StartAttachElement;
             updateCharacterItemNtc.UpdateWalletList.Add(Server.WalletManager.RemoveFromWallet(client.Character, WalletType.Gold, totalCost));
             updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 1, 1));
             client.Send(updateCharacterItemNtc);
 
-            // TODO: Store saved pawn exp
-            S2CCraftCraftExpUpNtc expNtc = new S2CCraftCraftExpUpNtc()
+            Pawn leadPawn = Server.CraftManager.FindPawn(client, request.CraftMainPawnId);
+            if (CraftManager.CanPawnExpUp(leadPawn))
             {
-                PawnId = request.CraftMainPawnId,
-                AddExp = totalExp,
-                ExtraBonusExp = 0,
-                TotalExp = totalExp,
-                CraftRankLimit = 0
-            };
-            client.Send(expNtc);
+                CraftManager.HandlePawnExpUpNtc(client, leadPawn, totalExp, 0);
+                if (CraftManager.CanPawnRankUp(leadPawn))
+                {
+                    CraftManager.HandlePawnRankUpNtc(client, leadPawn);
+                }
+                Server.Database.UpdatePawnBaseInfo(leadPawn);
+            }
+            else
+            {
+                // Mandatory to send otherwise the UI gets stuck.
+                CraftManager.HandlePawnExpUpNtc(client, leadPawn, 0, 0);
+            }
 
             return result;
         }

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -74,15 +74,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
-            List<uint> pawnIds = new List<uint> { request.CraftMainPawnID };
-            pawnIds.AddRange(request.CraftSupportPawnIDList.Select(p => p.PawnId));
+            Pawn leadPawn = Server.CraftManager.FindPawn(client, request.CraftMainPawnID);
+            List<Pawn> pawns = new List<Pawn> { leadPawn };
+            pawns.AddRange(request.CraftSupportPawnIDList.Select(p => Server.CraftManager.FindPawn(client, p.PawnId, true)));
             List<uint> productionSpeedLevels = new List<uint>();
             List<uint> consumableQuantityLevels = new List<uint>();
             List<uint> costPerformanceLevels = new List<uint>();
-
-            foreach (uint pawnId in pawnIds)
+            foreach (Pawn pawn in pawns)
             {
-                Pawn pawn = client.Character.Pawns.Find(p => p.PawnId == pawnId) ?? Server.Database.SelectPawn(pawnId);
                 productionSpeedLevels.Add(CraftManager.GetPawnProductionSpeedLevel(pawn));
                 consumableQuantityLevels.Add(CraftManager.GetPawnConsumableQuantityLevel(pawn));
                 costPerformanceLevels.Add(CraftManager.GetPawnCostPerformanceLevel(pawn));
@@ -118,16 +117,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 consumableAdditionalQuantity = request.CreateCount * craftCalculationResult.CalculatedValue;
                 isGreatSuccessConsumableQuantity = craftCalculationResult.IsGreatSuccess;
             }
-            
-            // TODO: check if course bonus provides exp bonus for crafting
-            // TODO: calculate bonus EXP now that remaining time is 0
-            // TODO: Decide whether bonus exp should be calculated when craft is started vs. received
-            bool expBonus = false;
-            uint bonusExp = 0;
-            if (expBonus)
-            {
-                bonusExp = recipe.Exp * request.CreateCount;
-            }
 
             CraftProgress craftProgress = new CraftProgress
             {
@@ -137,26 +126,43 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 CraftSupportPawnId2 = request.CraftSupportPawnIDList.ElementAtOrDefault(1)?.PawnId ?? 0,
                 CraftSupportPawnId3 = request.CraftSupportPawnIDList.ElementAtOrDefault(2)?.PawnId ?? 0,
                 RecipeId = request.RecipeID,
-                Exp = recipe.Exp * request.CreateCount,
                 NpcActionId = NpcActionType.NpcActionSmithy,
                 ItemId = recipe.ItemID,
                 Unk0 = request.Unk0,
                 // TODO: implement mechanism to deduct time periodically
                 RemainTime = Server.CraftManager.CalculateRecipeProductionSpeed(recipe.Time, productionSpeedLevels),
-                ExpBonus = expBonus,
-                CreateCount = request.CreateCount,
+                CreateCount = recipe.Num * request.CreateCount,
                 PlusValue = plusValue,
                 GreatSuccess = isGreatSuccessEquipmentQuality || isGreatSuccessConsumableQuantity,
-                BonusExp = bonusExp,
                 AdditionalQuantity = consumableAdditionalQuantity
             };
+
+            // TODO: check if course bonus provides exp bonus for crafting & calculate bonus EXP
+            // TODO: Decide whether bonus exp should be calculated when craft is started vs. received
+            bool expBonus = false;
+            if (CraftManager.CanPawnExpUp(leadPawn))
+            {
+                craftProgress.Exp = recipe.Exp * request.CreateCount;
+                craftProgress.ExpBonus = expBonus;
+                if (expBonus)
+                {
+                    craftProgress.BonusExp = craftProgress.Exp * 2;
+                }
+            }
+            else
+            {
+                craftProgress.Exp = 0;
+                craftProgress.ExpBonus = false;
+                craftProgress.BonusExp = 0;
+            }
+
             Server.Database.InsertPawnCraftProgress(craftProgress);
 
             // Subtract craft price
             CDataUpdateWalletPoint updateWalletPoint = Server.WalletManager.RemoveFromWallet(client.Character, WalletType.Gold,
                 Server.CraftManager.CalculateRecipeCost(recipe.Cost, costPerformanceLevels) * request.CreateCount);
             updateCharacterItemNtc.UpdateWalletList.Add(updateWalletPoint);
-            
+
             client.Send(updateCharacterItemNtc);
             return new S2CCraftStartCraftRes();
         }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.Serialization;
+
+namespace Arrowgene.Ddon.Server
+{
+    [DataContract]
+    public class GameLogicSetting
+    {
+        /// <summary>
+        /// Additional factor to change how long crafting a recipe will take to finish.
+        /// </summary>
+        [DataMember(Order = 0)]
+        public double AdditionalProductionSpeedFactor { get; set; } = 1.0;
+
+        /// <summary>
+        /// Additional factor to change how much a recipe will cost.
+        /// </summary>
+        [DataMember(Order = 1)]
+        public double AdditionalCostPerformanceFactor { get; set; } = 1.0;
+
+        public GameLogicSetting()
+        {
+            AdditionalProductionSpeedFactor = 1.0;
+            AdditionalCostPerformanceFactor = 1.0;
+        }
+
+        public GameLogicSetting(GameLogicSetting setting)
+        {
+        }
+    }
+}

--- a/Arrowgene.Ddon.Server/ServerSetting.cs
+++ b/Arrowgene.Ddon.Server/ServerSetting.cs
@@ -30,16 +30,6 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 26)] public bool LogIncomingPacketStructure { get; set; }
         [DataMember(Order = 27)] public bool LogOutgoingPacketStructure { get; set; }
         [DataMember(Order = 100)] public AsyncEventSettings ServerSocketSettings { get; set; }
-        
-        // TODO: Create a new Game/Logic/Settings wrapper instead of combining low-level server settings with high-level functional settings.
-        /// <summary>
-        /// Additional factor to change how long crafting a recipe will take to finish.
-        /// </summary>
-        [DataMember(Order = 1000)] public double AdditionalProductionSpeedFactor { get; set; }
-        /// <summary>
-        /// Additional factor to change how much a recipe will cost.
-        /// </summary>
-        [DataMember(Order = 1001)] public double AdditionalCostPerformanceFactor { get; set; }
 
         public ServerSetting()
         {
@@ -57,8 +47,6 @@ namespace Arrowgene.Ddon.Server
             LogIncomingPacketPayload = false;
             ServerSocketSettings = new AsyncEventSettings();
             ServerSocketSettings.MaxUnitOfOrder = 1;
-            AdditionalProductionSpeedFactor = 1.0;
-            AdditionalCostPerformanceFactor = 1.0;
         }
 
         public ServerSetting(ServerSetting setting)

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CCraftCraftRankUpNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CCraftCraftRankUpNtc.cs
@@ -1,5 +1,4 @@
 using Arrowgene.Buffers;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
@@ -13,9 +12,9 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
         }
 
         public uint PawnId { get; set; }
-        public uint CraftRank {  get; set; }
-        public uint AddCraftPoints {  get; set; }
-        public uint TotalCraftPoint {  get; set; }
+        public uint CraftRank { get; set; }
+        public uint AddCraftPoints { get; set; }
+        public uint TotalCraftPoint { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CCraftCraftRankUpNtc>
         {
@@ -39,4 +38,3 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
         }
     }
 }
-

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -1387,8 +1387,8 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId C2S_CRAFT_CRAFT_SKILL_ANALYZE_REQ = new PacketId(30, 17, 1, "C2S_CRAFT_CRAFT_SKILL_ANALYZE_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_CRAFT_CRAFT_SKILL_ANALYZE_RES = new PacketId(30, 17, 2, "S2C_CRAFT_CRAFT_SKILL_ANALYZE_RES", ServerType.Game, PacketSource.Server); // クラフトスキル分析に
         public static readonly PacketId S2C_CRAFT_FINISH_CRAFT_NTC = new PacketId(30, 18, 16, "S2C_CRAFT_FINISH_CRAFT_NTC", ServerType.Game, PacketSource.Server, "S2C_CRAFT_30_18_16_NTC");
-        public static readonly PacketId S2C_CRAFT_CRAFT_EXP_UP_NTC = new PacketId(30, 19, 16, "S2C_CRAFT_CRAFT_EXP_UP_NTC", ServerType.Game, PacketSource.Server, "S2C_CRAFT_30_19_16_NTC"); // S2C_CRAFT_EXP_UP_NOTICE
-        public static readonly PacketId S2C_CRAFT_CRAFT_RANK_UP_NTC = new PacketId(30, 20, 16, "S2C_CRAFT_CRAFT_RANK_UP_NTC", ServerType.Game, PacketSource.Server, "S2C_CRAFT_30_20_16_NTC"); // S2C_CRAFT_RANK_UP_NOTICE
+        public static readonly PacketId S2C_CRAFT_CRAFT_EXP_UP_NTC = new PacketId(30, 19, 16, "S2C_CRAFT_CRAFT_EXP_UP_NTC", ServerType.Game, PacketSource.Server, "S2C_CRAFT_30_19_16_NTC");
+        public static readonly PacketId S2C_CRAFT_CRAFT_RANK_UP_NTC = new PacketId(30, 20, 16, "S2C_CRAFT_CRAFT_RANK_UP_NTC", ServerType.Game, PacketSource.Server, "S2C_CRAFT_30_20_16_NTC");
         public static readonly PacketId S2C_CRAFT_30_21_16_NTC = new PacketId(30, 21, 16, "S2C_CRAFT_30_21_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_CRAFT_30_22_16_NTC = new PacketId(30, 22, 16, "S2C_CRAFT_30_22_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_CRAFT_30_23_16_NTC = new PacketId(30, 23, 16, "S2C_CRAFT_30_23_16_NTC", ServerType.Game, PacketSource.Server);

--- a/Arrowgene.Ddon.Test/GameServer/Characters/CraftManagerTest.cs
+++ b/Arrowgene.Ddon.Test/GameServer/Characters/CraftManagerTest.cs
@@ -22,7 +22,7 @@ public class CraftManagerTest
     public void GetCraftingTimeReductionRate_ShouldReturnCorrectValue()
     {
         List<uint> productionSpeedLevels = new List<uint> { 10, 20, 30 };
-        _mockServer.Setting.ServerSetting.AdditionalProductionSpeedFactor = 1.0;
+        _mockServer.Setting.GameLogicSetting.AdditionalProductionSpeedFactor = 1.0;
 
         double result = _craftManager.GetCraftingTimeReductionRate(productionSpeedLevels);
 
@@ -34,7 +34,7 @@ public class CraftManagerTest
     {
         List<uint> productionSpeedLevels = new List<uint> { 70, 70, 70, 70 };
         const uint recipeTime = 100;
-        _mockServer.Setting.ServerSetting.AdditionalProductionSpeedFactor = 1.0;
+        _mockServer.Setting.GameLogicSetting.AdditionalProductionSpeedFactor = 1.0;
 
         uint result = _craftManager.CalculateRecipeProductionSpeed(recipeTime, productionSpeedLevels);
 
@@ -46,7 +46,7 @@ public class CraftManagerTest
     {
         List<uint> productionSpeedLevels = new List<uint> { 70, 70, 70, 70 };
         const uint recipeTime = 100;
-        _mockServer.Setting.ServerSetting.AdditionalProductionSpeedFactor = 100;
+        _mockServer.Setting.GameLogicSetting.AdditionalProductionSpeedFactor = 100;
 
         uint result = _craftManager.CalculateRecipeProductionSpeed(recipeTime, productionSpeedLevels);
 


### PR DESCRIPTION
Fixes
- No exp from crests.
- Recipes with inherent multiple items being crafted only returning no. of queued creations instead of no. of queued creations times inherent no.
- Promotion pop up wrongly shown after promotion.
- Menu getting stuck at item retrieval after rank max has been reached.
- Cascade on delete missing for new databases.
- Pawn craft skill & exp-related columns missing for new databases.

Enhancements:
- Move craft skill configs to a new settings section

Open points:
- C2S_PAWN_DELETE_MYPAWN_REQ missing implementation 
- Migration for cascade on delete for existing DBs

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
