### PR TITLE
Feature/account verification

### DIFF
--- a/Arrowgene.Ddon.WebServer/AccountRoute.cs
+++ b/Arrowgene.Ddon.WebServer/AccountRoute.cs
@@ -52,7 +52,7 @@ namespace Arrowgene.Ddon.WebServer
                 if (AccountID.Trim().Length == 0)
                 {
                     Error = true;
-                    Message = "AccountID cannot be empty";
+                    Message = "Account ID cannot be empty";
                     return;
                 }
 
@@ -61,7 +61,7 @@ namespace Arrowgene.Ddon.WebServer
                 if (Regex.IsMatch(AccountID, @"\s"))
                 {
                     Error = true;
-                    Message = "AccountID cannot contain spaces";
+                    Message = "Account ID cannot contain spaces";
                     return;
                 }
 

--- a/Arrowgene.Ddon.WebServer/AccountRoute.cs
+++ b/Arrowgene.Ddon.WebServer/AccountRoute.cs
@@ -47,7 +47,7 @@ namespace Arrowgene.Ddon.WebServer
                 AccountID = username;
                 Password = password;
 
-                // Very simple data checks on the parameters. Anything further would require refactoring.
+                // Very simple data checks on the parameters.
 
                 if (AccountID.Trim().Length == 0)
                 {
@@ -71,8 +71,6 @@ namespace Arrowgene.Ddon.WebServer
                     Message = "Password cannot be empty";
                     return;
                 }
-
-                // Disallow whitespace.
 
                 if (Regex.IsMatch(Password, @"\s"))
                 {
@@ -102,16 +100,6 @@ namespace Arrowgene.Ddon.WebServer
             switch (req.Action)
             {
                 case "login":
-
-                    // !!!
-                    // This will prevent any current users logging in who have any of the disallowed inputs.
-                    // I recommend only running the check on account creation to ensure happy people.
-
-                    if (accountCheck.Error)
-                    {
-                        res.Error = accountCheck.Message;
-                        break;
-                    }
 
                     string token = CreateToken(req.Account, req.Password);
                     if (token == null)

--- a/Arrowgene.Ddon.WebServer/AccountRoute.cs
+++ b/Arrowgene.Ddon.WebServer/AccountRoute.cs
@@ -36,20 +36,19 @@ namespace Arrowgene.Ddon.WebServer
 
         private class AccountVerification
         {
-
             public bool Error { get; set; }
             public string Message { get; set; }
-            public string AccountID { get; set; }
+            public string Username { get; set; }
             public string Password { get; set; }
 
             public AccountVerification(string username, string password)
             {
-                AccountID = username;
+                Username = username;
                 Password = password;
 
                 // Very simple data checks on the parameters.
 
-                if (AccountID.Trim().Length == 0)
+                if (Username.Trim().Length == 0)
                 {
                     Error = true;
                     Message = "Account ID cannot be empty";
@@ -58,7 +57,7 @@ namespace Arrowgene.Ddon.WebServer
 
                 // Disallow any whitespace.
 
-                if (Regex.IsMatch(AccountID, @"\s"))
+                if (Regex.IsMatch(Username, @"\s"))
                 {
                     Error = true;
                     Message = "Account ID cannot contain spaces";


### PR DESCRIPTION
#225 

Seen that this is outstanding I thought it'd be worth having a crack at. This will prevent any new servers from having the unfortunate empty field user. It also prevents rogue whitespace from being used either intentionally or unintentionally to cut down on junk accounts that have been lost due to accidental input.

---
## Valid input
- "username"
- "bob"
- "fred"
- "iWouldLoveAPizzaRightNow"

## Invalid input
- ""
- " ddonIsTheBest"
- "baduser "
- "OH NO the cat is about to walk on my kel[pl[lxc 54e54re\aAQSDs"

---
# Note

The original issue spec asked for this to be applied to login too, however this would then prevent any existing accounts that didn't follow these rules to not be able to log in and become upset. Although the ask in #225 mentioned applying this to login, I have decided to leave this out for now, but happy to put this in if that is the executive decision. If left out, this would apply to all future users only.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
