### PR TITLE
Feature/partial and backwards compatible settings definitions

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/DbMigrationCommand.cs
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.Cli.Command
         {
            
             string settingPath = Path.Combine(Util.ExecutingDirectory(), "Files/Arrowgene.Ddon.config.json");
-            Setting settings = Setting.Load(settingPath);
+            Setting settings = Setting.LoadFromFile(settingPath);
             if (settings == null)
             {
                 return CommandResultType.Exit;

--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -101,7 +101,7 @@ namespace Arrowgene.Ddon.Cli
             string settingArgument = parameter.SwitchMap.GetValueOrDefault("--config", "Files/Arrowgene.Ddon.config.json");                
             string settingPath = Path.Combine(Util.ExecutingDirectory(), settingArgument);
             string settingLogMessage;
-            _setting = Setting.Load(settingPath);
+            _setting = Setting.LoadFromFile(settingPath);
             if (_setting == null)
             {
                 _setting = new Setting();

--- a/Arrowgene.Ddon.Cli/Setting.cs
+++ b/Arrowgene.Ddon.Cli/Setting.cs
@@ -1,34 +1,19 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.Serialization;
 using Arrowgene.Ddon.Database;
 using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.LoginServer;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.WebServer;
+using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.Cli
 {
     [DataContract]
     public class Setting
     {
-        public static Setting Load(string filePath)
-        {
-            FileInfo f = new FileInfo(filePath);
-            if (!f.Exists)
-            {
-                return null;
-            }
-
-            string json = File.ReadAllText(f.FullName);
-            Setting setting = JsonContractSerializer.Deserialize<Setting>(json);
-            return setting;
-        }
-
-        public void Save(string filePath)
-        {
-            string json = JsonContractSerializer.Serialize(this);
-            File.WriteAllText(filePath, json);
-        }
+        private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(Setting));
 
         [DataMember(Order = 0)] public string LogPath { get; set; }
         [DataMember(Order = 10)] public WebServerSetting WebServerSetting { get; set; }
@@ -37,6 +22,7 @@ namespace Arrowgene.Ddon.Cli
         [DataMember(Order = 40)] public DatabaseSetting DatabaseSetting { get; set; }
         [DataMember(Order = 50)] public string AssetPath { get; set; }
 
+        // Note: constructor is not called during deserialization.
         public Setting()
         {
             LogPath = "Logs";
@@ -47,13 +33,96 @@ namespace Arrowgene.Ddon.Cli
             AssetPath = Path.Combine(Util.ExecutingDirectory(), "Files/Assets");
         }
 
+        // Note: constructor is not called during deserialization.
         public Setting(Setting setting)
         {
+            LogPath = setting.LogPath;
             WebServerSetting = new WebServerSetting(setting.WebServerSetting);
             GameServerSetting = new GameServerSetting(setting.GameServerSetting);
             LoginServerSetting = new LoginServerSetting(setting.LoginServerSetting);
             DatabaseSetting = new DatabaseSetting(setting.DatabaseSetting);
             AssetPath = setting.AssetPath;
+        }
+
+        // Note: method is called after the object is completely deserialized. Use it instead of the constructror.
+        [OnDeserialized]
+        void OnDeserialized(StreamingContext context)
+        {
+            LogPath ??= "Logs";
+            WebServerSetting ??= new WebServerSetting();
+            GameServerSetting ??= new GameServerSetting();
+            LoginServerSetting ??= new LoginServerSetting();
+            DatabaseSetting ??= new DatabaseSetting();
+            AssetPath ??= Path.Combine(Util.ExecutingDirectory(), "Files/Assets");
+        }
+
+        public static Setting Deserialize(string json)
+        {
+            Setting settings;
+            try
+            {
+                settings = JsonContractSerializer.Deserialize<Setting>(json);
+            }
+            catch (Exception ex)
+            {
+                Logger.Exception(ex);
+                throw;
+            }
+
+            return settings;
+        }
+
+        public static string Serialize(Setting setting)
+        {
+            string json = null;
+            try
+            {
+                json = JsonContractSerializer.Serialize(setting);
+            }
+            catch (Exception ex)
+            {
+                Logger.Exception(ex);
+                throw;
+            }
+
+            return json;
+        }
+
+        public static Setting Load(string json)
+        {
+            Setting setting = Deserialize(json);
+            return setting;
+        }
+
+        public static Setting LoadFromFile(FileInfo file)
+        {
+            if (!file.Exists)
+            {
+                return null;
+            }
+
+            return Load(File.ReadAllText(file.FullName));
+        }
+
+        public static Setting LoadFromFile(string filePath)
+        {
+            return LoadFromFile(new FileInfo(filePath));
+        }
+
+        public static void Save(string filePath, Setting setting)
+        {
+            string json = Serialize(setting);
+            File.WriteAllText(filePath, json);
+        }
+
+        public void Save(string filePath)
+        {
+            Save(filePath, this);
+        }
+
+        public void Save(FileInfo file)
+        {
+            Save(file.FullName, this);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/GameServerSetting.cs
+++ b/Arrowgene.Ddon.GameServer/GameServerSetting.cs
@@ -16,16 +16,27 @@ namespace Arrowgene.Ddon.GameServer
             ServerSetting.Name = "Game";
             ServerSetting.ServerPort = 52000;
             ServerSetting.ServerSocketSettings.Identity = "Game";
-            
+
             GameLogicSetting = new GameLogicSetting();
-            GameLogicSetting.AdditionalProductionSpeedFactor = 1.0;
-            GameLogicSetting.AdditionalCostPerformanceFactor = 1.0;
         }
 
         public GameServerSetting(GameServerSetting setting)
         {
             ServerSetting = new ServerSetting(setting.ServerSetting);
             GameLogicSetting = new GameLogicSetting(setting.GameLogicSetting);
+        }
+
+        // Note: method is called after the object is completely deserialized - constructors are skipped.
+        [OnDeserialized]
+        void OnDeserialized(StreamingContext context)
+        {
+            ServerSetting ??= new ServerSetting();
+            ServerSetting.Id = 10;
+            ServerSetting.Name = "Game";
+            ServerSetting.ServerPort = 52000;
+            ServerSetting.ServerSocketSettings.Identity = "Game";
+
+            GameLogicSetting ??= new GameLogicSetting();
         }
     }
 }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -25,6 +25,14 @@ namespace Arrowgene.Ddon.Server
 
         public GameLogicSetting(GameLogicSetting setting)
         {
+            AdditionalProductionSpeedFactor = setting.AdditionalProductionSpeedFactor;
+            AdditionalCostPerformanceFactor = setting.AdditionalCostPerformanceFactor;
+        }
+
+        // Note: method is called after the object is completely deserialized - constructors are skipped.
+        [OnDeserialized]
+        void OnDeserialized(StreamingContext context)
+        {
         }
     }
 }

--- a/Arrowgene.Ddon.Server/ServerSetting.cs
+++ b/Arrowgene.Ddon.Server/ServerSetting.cs
@@ -65,5 +65,13 @@ namespace Arrowgene.Ddon.Server
             LogIncomingPacketPayload = setting.LogIncomingPacketPayload;
             ServerSocketSettings = new AsyncEventSettings(setting.ServerSocketSettings);
         }
+
+        // Note: method is called after the object is completely deserialized - constructors are skipped.
+        [OnDeserialized]
+        void OnDeserialized(StreamingContext context)
+        {
+            ServerSocketSettings ??= new AsyncEventSettings();
+            ServerSocketSettings.MaxUnitOfOrder = 1;
+        }
     }
 }

--- a/Arrowgene.Ddon.Shared/JsonContractSerializer.cs
+++ b/Arrowgene.Ddon.Shared/JsonContractSerializer.cs
@@ -36,6 +36,7 @@ namespace Arrowgene.Ddon.Shared
             catch (Exception exception)
             {
                 Debug.WriteLine(exception.ToString());
+                throw;
             }
             finally
             {
@@ -70,6 +71,7 @@ namespace Arrowgene.Ddon.Shared
             catch (Exception exception)
             {
                 Debug.WriteLine(exception.ToString());
+                throw;
             }
             finally
             {

--- a/Arrowgene.Ddon.Test/GameServer/SettingTest.cs
+++ b/Arrowgene.Ddon.Test/GameServer/SettingTest.cs
@@ -1,0 +1,72 @@
+using Arrowgene.Ddon.Cli;
+using Xunit;
+
+namespace Arrowgene.Ddon.Test.GameServer
+{
+    public class SettingTests
+    {
+        [Fact]
+        public void Serialize_DefaultSetting_ObjectShouldMatchJson()
+        {
+            Setting setting = new Setting();
+
+            string json = Setting.Serialize(setting);
+
+            Assert.Contains("\"LogPath\": \"Logs\"", json);
+            Assert.Contains("\"GameLogicSetting\":", json);
+            Assert.Contains("\"AdditionalProductionSpeedFactor\": 1", json);
+            Assert.Contains("\"AdditionalCostPerformanceFactor\": 1", json);
+        }
+
+        [Fact]
+        public void Deserialize_ValidJson_ShouldReturnCorrectObject()
+        {
+            string json = @"{
+                ""LogPath"": ""Logs"",
+                ""AssetPath"": ""C:\\Assets"",
+                ""GameServerSetting"": {
+                    ""ServerSetting"": {
+                        ""Id"": 10,
+                        ""Name"": ""Game""
+                    },
+                    ""GameLogicSetting"": {
+                        ""AdditionalProductionSpeedFactor"": 1.5,
+                        ""AdditionalCostPerformanceFactor"": 1.2
+                    }
+                }
+            }";
+
+            Setting setting = Setting.Deserialize(json);
+
+            Assert.Equal("Logs", setting.LogPath);
+            Assert.Equal("C:\\Assets", setting.AssetPath);
+            Assert.Equal(1.5, setting.GameServerSetting.GameLogicSetting.AdditionalProductionSpeedFactor);
+            Assert.Equal(1.2, setting.GameServerSetting.GameLogicSetting.AdditionalCostPerformanceFactor);
+        }
+
+        [Fact]
+        public void Deserialize_MissingFields_ShouldAssignDefaultValues()
+        {
+            string json = "{\"LogPath\": \"Logs\"}";
+
+            Setting setting = Setting.Deserialize(json);
+
+            Assert.Equal("Logs", setting.LogPath);
+            Assert.NotNull(setting.GameServerSetting);
+            Assert.Equal(1.0, setting.GameServerSetting.GameLogicSetting.AdditionalProductionSpeedFactor);
+        }
+
+        [Fact]
+        public void RoundTrip_SerializeAndDeserialize_ShouldMaintainObjectState()
+        {
+            Setting originalSetting = new Setting();
+            originalSetting.GameServerSetting.GameLogicSetting.AdditionalProductionSpeedFactor = 2.0;
+
+            string json = Setting.Serialize(originalSetting);
+            Setting deserializedSetting = Setting.Deserialize(json);
+
+            Assert.Equal(2.0, deserializedSetting.GameServerSetting.GameLogicSetting.AdditionalProductionSpeedFactor);
+            Assert.Equal(originalSetting.LogPath, deserializedSetting.LogPath);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
* Partial settings blocks ensure backwards compatibility and if people are fine with a majority of the defaults they don't necessarily need to maintain all of them

Changes
* Make use of OnDeserialized decorator in all settings classes to initialize nullable objects and apply defaults that are already present in constructors (regular serialization ignores constructors)
* Improve testability of the Settings class
* Add some basic unit tests for Settings
* Ensure JsonContractSerializer actually throws exceptions instead of silently ignoring them

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
