### PR TITLE
Fix: Augment removal bug

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillSetOffAbilityHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillSetOffAbilityHandler.cs
@@ -32,7 +32,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             return new S2CSkillSetOffAbilityRes()
             {
-                SlotNo = packet.SlotNo
+                SlotNo = (byte)(client.Character.EquippedAbilitiesDictionary[client.Character.Job]
+                .Where(x => x != null)
+                .Count()+1)
             };
         }
     }


### PR DESCRIPTION
Fixes a minor bug where removing an augment at Archibald would actually remove that augment and the one after it. The augment UI wouldn't reflect that fact (because it lies as easily as it breathes), but the character status UI would show the true augment loadout.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
