### PR TITLE
Fix: Storage stacking bug

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -546,7 +546,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                     uint newDstItemNum = ((oldDstItemNum + itemsToMove) > stackLimit) ? stackLimit : (oldDstItemNum + itemsToMove);
                     uint movedItemNum = newDstItemNum - oldDstItemNum;
-                    if (newDstItemNum == stackLimit) toSlotNo = 0;
+                    if (newDstItemNum == stackLimit) toSlotNo = 0; //Stack filled, so roll over into the next found stack/empty slot.
 
                     if (movedItemNum == 0)
                     {

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -546,6 +546,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                     uint newDstItemNum = ((oldDstItemNum + itemsToMove) > stackLimit) ? stackLimit : (oldDstItemNum + itemsToMove);
                     uint movedItemNum = newDstItemNum - oldDstItemNum;
+                    if (newDstItemNum == stackLimit) toSlotNo = 0;
+
                     if (movedItemNum == 0)
                     {
                         // if we move 0 items, this code will get stuck in an infinite loop


### PR DESCRIPTION
Fixes an issue with the item handling when adding to a large stack of items. Because of deferred updating of stack counts, combined with the rollover logic to handle excess amounts, you'd get weird cases where 950 + 50 = 951, rather than 999 in one stack and 1 in another. The missing amount would be permanently lost, which is annoying even if you probably won't miss it if you have 999 of any one item.

Now when you're done "filling" a stack, you should revert to the "no target slot" behavior and dump into the next valid slot/stack.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
