### PR TITLE
Setting revival timer to 12:00 AM JST to align with original server.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CharacterGetReviveChargeableTimeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterGetReviveChargeableTimeHandler.cs
@@ -22,9 +22,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if(Server.LastRevivalPowerRechargeTime.ContainsKey(client.Character.CharacterId))
             {
-                DateTime lastRechargeTime = Server.LastRevivalPowerRechargeTime[client.Character.CharacterId];
-                DateTime nextRechargeTime = lastRechargeTime.Add(DdonGameServer.RevivalPowerRechargeTimeSpan);
-                TimeSpan remainTimeSpan = nextRechargeTime - DateTime.UtcNow;
+                // Refresh revival at 12:00AM JST
+                DateTime utcNow = DateTime.UtcNow;
+                TimeZoneInfo jstZone = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+                DateTime jstNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, jstZone);
+                DateTime nextMidnightJST = new DateTime(jstNow.Year, jstNow.Month, jstNow.Day, 0, 0, 0, jstNow.Kind).AddDays(1);
+                TimeSpan remainTimeSpan = nextMidnightJST - jstNow;
                 res.RemainTime = (uint) Math.Max(0, remainTimeSpan.TotalSeconds);
             }
             else


### PR DESCRIPTION
Resolves #190

Changes the revival timer from a set 24 hour duration to always refreshing at 12:00 AM JST.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
