### PR TITLE
Amended and Rewritten Revive Timer (12:00AM JST)

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CharacterChargeRevivePointHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterChargeRevivePointHandler.cs
@@ -18,8 +18,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             client.Character.StatusInfo.RevivePoint = 3;
             Server.Database.UpdateStatusInfo(client.Character);
-
-            Server.LastRevivalPowerRechargeTime[client.Character.CharacterId] = DateTime.UtcNow;
+            DateTime utcNow = DateTime.UtcNow;
+            TimeZoneInfo jstZone = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+            DateTime jstNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, jstZone);
+            Server.LastRevivalPowerRechargeTime[client.Character.CharacterId] = jstNow;
 
             client.Send(new S2CCharacterChargeRevivePointRes() {
                 RevivePoint = client.Character.StatusInfo.RevivePoint


### PR DESCRIPTION
Rewrote code to factor in JST in both `CharacterChargeRevivePointHandler` and `LastRevivalPowerRechargeTime` to solve #190 again.

Thanks for all your assistance and patience, Laith and co!

# Testing:

**Joined server after server start, with full revives:**
No revival option, as full revives are present.

**Expended revives:**
Given revival option, and told 'You have refreshed today already' on second attempt with NPC.

**Expended revives again:**
'You have refreshed today already'.

**Shifted server time to next day, no server restart, character relog, full revives:**
No revival option, as full revives are present, as expected.

**Expended revives:**
Given revival option, and told 'You have refreshed today already' on second attempt with NPC.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
