### PR TITLE
Escape gmd.csv path fields

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
@@ -260,7 +260,7 @@ namespace Arrowgene.Ddon.Cli.Command
 
                             if (string.IsNullOrEmpty(newMsg))
                             {
-                                Logger.Error(
+                                Logger.Info(
                                     $"csv message is empty, skipping (ArcPath:{arcPath}, GmdPath:{gmdPath}, Key:{entry.Key}. Msg:{entry.Msg})");
                                 continue;
                             }

--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -184,19 +184,6 @@ namespace Arrowgene.Ddon.Client
             return new FileIndexSearch();
         }
 
-        /// <summary>
-        /// Path inside .arc files use `\` to separate directories.
-        /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        public static string ToArcPath(string path)
-        {
-            path = path.Replace('/', '\\');
-            path = path.Replace(Path.DirectorySeparatorChar, '\\');
-            path = path.Replace(Path.AltDirectorySeparatorChar, '\\');
-            return path;
-        }
-
         private readonly List<ArcFile> _files;
 
         public ArcArchive()
@@ -590,7 +577,7 @@ namespace Arrowgene.Ddon.Client
             public string ArcPath
             {
                 get => _arcPath;
-                set => _arcPath = ToArcPath(value);
+                set => _arcPath = Util.ToArcPath(value);
             }
 
             public bool Match(FileIndex fileIndex)

--- a/Arrowgene.Ddon.Shared/Csv/GmdCsv.cs
+++ b/Arrowgene.Ddon.Shared/Csv/GmdCsv.cs
@@ -40,8 +40,8 @@ namespace Arrowgene.Ddon.Shared.Csv
             string key = properties[1];
             string msgJp = properties[2];
             string msgEn = properties[3];
-            string gmdPath = properties[4];
-            string arcPath = properties[5];
+            string gmdPath = Util.ToArcPath(properties[4]); // Normalize paths
+            string arcPath = Util.ToArcPath(properties[5]); // Normalize paths
             string arcName = properties[6];
             if (!uint.TryParse(properties[7], out uint readIndex)) return null;
 

--- a/Arrowgene.Ddon.Shared/Util.cs
+++ b/Arrowgene.Ddon.Shared/Util.cs
@@ -433,5 +433,18 @@ namespace Arrowgene.Ddon.Shared
 
             return dst;
         }
+
+        /// <summary>
+        /// Path inside .arc files use `\` to separate directories.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string ToArcPath(string path)
+        {
+            path = path.Replace('/', '\\');
+            path = path.Replace(Path.DirectorySeparatorChar, '\\');
+            path = path.Replace(Path.AltDirectorySeparatorChar, '\\');
+            return path;
+        }
     }
 }


### PR DESCRIPTION
To allow patching on linux, the gmd.csv has to have the paths to the arc files using forward slashes, which work both on windows and linux.
However, after naively replacing all slashes to forward slahes in the csv, since arc files internally have their archived file paths using backward slashes, when comparing fields using a simple string comparison, the patcher couldn't find the files contained in the arc.
To work around this, paths read from the csv are normalized into using backward slashes.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
