### PR TITLE
Fix showing the item bag on enemy kill

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -55,18 +55,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
             else
             {
                 enemyKilled = client.Party.InstanceEnemyManager.GetAssets(StageId.FromStageLayoutId(layoutId), (byte) subGroupId)[(int)packet.Structure.SetId];
-                List<InstancedGatheringItem> instancedGatheringItems = client.InstanceDropItemManager.GetAssets(layoutId, packet.Structure.SetId);
-                if (instancedGatheringItems.Count > 0)
-                {
-                    client.Party.SendToAll(new S2CInstancePopDropItemNtc()
+                foreach (var partyMemberClient in client.Party.Clients)
+                {    
+                    List<InstancedGatheringItem> instancedGatheringItems = partyMemberClient.InstanceDropItemManager.GetAssets(layoutId, packet.Structure.SetId);
+                    if (instancedGatheringItems.Count > 0)
                     {
-                        LayoutId = packet.Structure.LayoutId,
-                        SetId = packet.Structure.SetId,
-                        MdlType = enemyKilled.DropsTable.MdlType,
-                        PosX = packet.Structure.DropPosX,
-                        PosY = packet.Structure.DropPosY,
-                        PosZ = packet.Structure.DropPosZ
-                    });
+                        partyMemberClient.Party.SendToAll(new S2CInstancePopDropItemNtc()
+                        {
+                            LayoutId = packet.Structure.LayoutId,
+                            SetId = packet.Structure.SetId,
+                            MdlType = enemyKilled.DropsTable.MdlType,
+                            PosX = packet.Structure.DropPosX,
+                            PosY = packet.Structure.DropPosY,
+                            PosZ = packet.Structure.DropPosZ
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
Before, if you werent the context leader and your roll had 0 items, youd still see the bag but get no items And if your roll had items but the leader didnt, you wouldnt see the bag, therefore be unable to get your items

This PR fixes it

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
