### PR TITLE
Periodically check age of client pings

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ConnectionPingHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ConnectionPingHandler.cs
@@ -1,28 +1,24 @@
-﻿using Arrowgene.Buffers;
+﻿using System;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
-using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
-    public class ConnectionPingHandler : PacketHandler<GameClient>
+    // These requests are sent periodically by the client (every ~10 seconds)
+    // after successfully connecting to the server (client._challengeCompleted is true)
+    public class ConnectionPingHandler : PingRequestPacketHandler<GameClient, C2SConnectionPingReq, S2CConnectionPingRes>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ConnectionPingHandler));
-
 
         public ConnectionPingHandler(DdonGameServer server) : base(server)
         {
         }
 
-        public override PacketId Id => PacketId.C2S_CONNECTION_PING_REQ;
-
-        public override void Handle(GameClient client, IPacket packet)
+        public override S2CConnectionPingRes BuildPingResponse(GameClient client, DateTime now)
         {
-            IBuffer buffer = new StreamBuffer();
-            buffer.WriteUInt32(0, Endianness.Big);
-            buffer.WriteUInt32(0, Endianness.Big);
-            client.Send(new Packet(PacketId.S2C_CONNECTION_PING_RES, buffer.GetAllBytes()));
+            return new S2CConnectionPingRes();
         }
     }
 }

--- a/Arrowgene.Ddon.LoginServer/Handler/ClientPingHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientPingHandler.cs
@@ -1,28 +1,24 @@
 using System;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
-using Arrowgene.Ddon.Shared.Entity;
-using Arrowgene.Ddon.Shared.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.LoginServer.Handler
 {
-    public class ClientPingHandler : PacketHandler<LoginClient>
+    // These requests are sent periodically by the client (every ~10 seconds)
+    // after successfully connecting to the server (client._challengeCompleted is true)
+    public class ClientPingHandler : PingRequestPacketHandler<LoginClient, C2LPingReq, L2CPingRes>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ClientPingHandler));
-
 
         public ClientPingHandler(DdonLoginServer server) : base(server)
         {
         }
 
-        public override PacketId Id => PacketId.C2L_PING_REQ;
-
-        public override void Handle(LoginClient client, IPacket packet)
+        public override L2CPingRes BuildPingResponse(LoginClient client, DateTime now)
         {
-            client.PingTime = DateTime.UtcNow;
-            ServerRes res = new ServerRes(PacketId.L2C_PING_RES);
-            client.Send(res);
+            return new L2CPingRes();
         }
     }
 }

--- a/Arrowgene.Ddon.Server/DdonServer.cs
+++ b/Arrowgene.Ddon.Server/DdonServer.cs
@@ -87,6 +87,7 @@ namespace Arrowgene.Ddon.Server
         public void Stop()
         {
             _server.Stop();
+            _consumer.Dispose();
         }
 
         protected void AddHandler(IPacketHandler<TClient> packetHandler)

--- a/Arrowgene.Ddon.Server/Network/Consumer.cs
+++ b/Arrowgene.Ddon.Server/Network/Consumer.cs
@@ -8,7 +8,7 @@ using Arrowgene.Networking.Tcp.Server.AsyncEvent;
 
 namespace Arrowgene.Ddon.Server.Network
 {
-    public class Consumer<TClient> : ThreadedBlockingQueueConsumer where TClient : Client
+    public class Consumer<TClient> : ThreadedBlockingQueueConsumer, IDisposable where TClient : Client
     {
         private readonly ServerLogger Logger;
         private readonly Dictionary<PacketId, IPacketHandler<TClient>> _packetHandlerLookup;
@@ -160,6 +160,16 @@ namespace Arrowgene.Ddon.Server.Network
                     Logger.Exception(client, ex);
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            foreach (var handler in _packetHandlerLookup.Values)
+            {
+                handler.Dispose();
+            }
+
+            _fallbackPacketHandler?.Dispose();
         }
     }
 }

--- a/Arrowgene.Ddon.Server/Network/IPacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/IPacketHandler.cs
@@ -1,8 +1,9 @@
-﻿using Arrowgene.Ddon.Shared.Network;
+﻿using System;
+using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Server.Network
 {
-    public interface IPacketHandler<TClient> where TClient : Client
+    public interface IPacketHandler<TClient> : IDisposable where TClient : Client
     {
         void Handle(TClient client, IPacket packet);
         PacketId Id { get; }

--- a/Arrowgene.Ddon.Server/Network/PacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/PacketHandler.cs
@@ -16,5 +16,7 @@ namespace Arrowgene.Ddon.Server.Network
 
         public abstract PacketId Id { get; }
         public abstract void Handle(TClient client, IPacket packet);
+
+        public virtual void Dispose() {}
     }
 }

--- a/Arrowgene.Ddon.Server/Network/PingRequestPacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/PingRequestPacketHandler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Timers;
+using Arrowgene.Ddon.Shared.Entity;
+
+namespace Arrowgene.Ddon.Server.Network
+{
+    public abstract class PingRequestPacketHandler<TClient, TReqStruct, TResStruct> : RequestPacketHandler<TClient, TReqStruct, TResStruct>
+        where TClient : Client
+        where TReqStruct : class, IPacketStructure, new()
+        where TResStruct : ServerResponse, new()
+    {
+
+        private static readonly double TIMER_INTERVAL_MS = 60000; // 1 minute
+
+        private readonly Timer TimeoutCheckTimer;
+
+        protected PingRequestPacketHandler(DdonServer<TClient> server) : base(server)
+        {
+            TimeoutCheckTimer = new Timer(TIMER_INTERVAL_MS);
+            TimeoutCheckTimer.AutoReset = true;
+            TimeoutCheckTimer.Elapsed += (sender, e) =>
+            {
+                DateTime now = DateTime.UtcNow;
+                foreach (var client in server.ClientLookup.GetAll())
+                {
+                    if ((now - client.PingTime).TotalMilliseconds > TIMER_INTERVAL_MS * 2)
+                    {
+                        // Try messaging the client to ensure it is still alive
+                        // If the client is dead, the send will fail and it'll be cleaned up
+                        var pingRes = BuildPingResponse(client, now);
+                        client.Send(pingRes);
+                    }
+                }
+            };
+            TimeoutCheckTimer.Start();
+
+            // TODO: Find out a good place to dispose TimeoutCheckTimer
+        }
+
+        public override TResStruct Handle(TClient client, TReqStruct request)
+        {
+            DateTime now = DateTime.UtcNow;
+            client.PingTime = now;
+            return BuildPingResponse(client, now);
+        }
+
+        public abstract TResStruct BuildPingResponse(TClient client, DateTime now);
+
+        public override void Dispose()
+        {
+            TimeoutCheckTimer.Dispose();
+        }
+    }
+
+}

--- a/Arrowgene.Ddon.Server/Network/StructurePacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/StructurePacketHandler.cs
@@ -1,28 +1,23 @@
-using Arrowgene.Ddon.Database;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Server.Network
 {
-    public abstract class StructurePacketHandler<TClient, TReqStruct> : IPacketHandler<TClient>
+    public abstract class StructurePacketHandler<TClient, TReqStruct> : PacketHandler<TClient>
         where TClient : Client
         where TReqStruct : class, IPacketStructure, new()
     {
-        protected StructurePacketHandler(DdonServer<TClient> server)
+        protected StructurePacketHandler(DdonServer<TClient> server) : base(server)
         {
-            Server = server;
-            Database = server.Database;
             // Create a instance to obtain PacketId information.
             Id = new TReqStruct().Id;
         }
 
-        public PacketId Id { get; }
-        protected DdonServer<TClient> Server { get; }
-        protected IDatabase Database { get; }
-
+        public override PacketId Id { get; }
+        
         public abstract void Handle(TClient client, StructurePacket<TReqStruct> packet);
 
-        public void Handle(TClient client, IPacket packet)
+        public override void Handle(TClient client, IPacket packet)
         {
             Handle(client, new StructurePacket<TReqStruct>(packet));
         }

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -310,6 +310,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2LDecideCharacterIdReq.Serializer());
             Create(new C2LGetErrorMessageListReq.Serializer());
             Create(new C2LLoginReq.Serializer());
+            Create(new C2LPingReq.Serializer());
             Create(new C2SActionSetPlayerActionHistoryReq.Serializer());
             Create(new C2SAreaGetAreaBaseInfoListReq.Serializer());
 
@@ -372,6 +373,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SConnectionLoginReq.Serializer());
             Create(new C2SConnectionMoveInServerReq.Serializer());
             Create(new C2SConnectionMoveOutServerReq.Serializer());
+            Create(new C2SConnectionPingReq.Serializer());
             Create(new C2SConnectionReserveServerReq.Serializer());
 
             Create(new C2SContextGetSetContextReq.Serializer());
@@ -637,6 +639,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new L2CLoginRes.Serializer());
             Create(new L2CLoginWaitNumNtc.Serializer());
             Create(new L2CNextConnectionServerNtc.Serializer());
+            Create(new L2CPingRes.Serializer());
+            
             Create(new L2CGpCourseGetInfoRes.Serializer());
 
             Create(new S2CActionSetPlayerActionHistoryRes.Serializer());
@@ -719,6 +723,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CConnectionLogoutRes.Serializer());
             Create(new S2CConnectionMoveInServerRes.Serializer());
             Create(new S2CConnectionMoveOutServerRes.Serializer());
+            Create(new S2CConnectionPingRes.Serializer());
             Create(new S2CConnectionReserveServerRes.Serializer());
             
             Create(new S2CContextGetAllPlayerContextNtc.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2LPingReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2LPingReq.cs
@@ -1,0 +1,24 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2LPingReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2L_PING_REQ;
+
+        public class Serializer : PacketEntitySerializer<C2LPingReq>
+        {
+            public override void Write(IBuffer buffer, C2LPingReq obj)
+            {
+            }
+
+            public override C2LPingReq Read(IBuffer buffer)
+            {
+                C2LPingReq obj = new C2LPingReq();
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SConnectionPingReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SConnectionPingReq.cs
@@ -1,0 +1,28 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SConnectionPingReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CONNECTION_PING_REQ;
+
+        public C2SConnectionPingReq()
+        {   
+        }
+
+        public class Serializer : PacketEntitySerializer<C2SConnectionPingReq>
+        {
+            public override void Write(IBuffer buffer, C2SConnectionPingReq obj)
+            {
+            }
+
+            public override C2SConnectionPingReq Read(IBuffer buffer)
+            {
+                C2SConnectionPingReq obj = new C2SConnectionPingReq();
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/L2CPingRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/L2CPingRes.cs
@@ -1,0 +1,31 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class L2CPingRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.L2C_PING_RES;
+
+        public L2CPingRes()
+        {            
+        }
+
+
+        public class Serializer : PacketEntitySerializer<L2CPingRes>
+        {
+            public override void Write(IBuffer buffer, L2CPingRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override L2CPingRes Read(IBuffer buffer)
+            {
+                L2CPingRes obj = new L2CPingRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CConnectionPingRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CConnectionPingRes.cs
@@ -1,0 +1,29 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CConnectionPingRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CONNECTION_PING_RES;
+
+        public S2CConnectionPingRes()
+        {
+        }
+
+        public class Serializer : PacketEntitySerializer<S2CConnectionPingRes>
+        {
+            public override void Write(IBuffer buffer, S2CConnectionPingRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CConnectionPingRes Read(IBuffer buffer)
+            {
+                S2CConnectionPingRes obj = new S2CConnectionPingRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}


### PR DESCRIPTION
To prevent half-connected sockets, both the login and game server's ping handlers now use a timer to periodically check if the last ping has been too long ago. If it has been, the server will try sending a packet to the client, if the packet goes through, the client is still alive and no further action is needed;
if the packet doesn't go through, the client is dead, the write will fail, and it'll be cleaned up.

This will (hopefully) solve the S-6008 error, where the server thinks the user is still connected to the server and therefore prevents new connections from them

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
