### PR TITLE
Add checks around EXP rewards

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
@@ -30,6 +30,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             public double PawnEnemyExpBonus = 0.0;
             public double WorldQuestExpBonus = 0.0;
             public double EnemyPlayPointBonus = 0.0;
+            public bool DisablePartyExpAdjustment = false;
         };
 
         private void ApplyCourseEffects(uint courseId)
@@ -55,6 +56,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             break;
                         case GPCourseId.EnemyPpUp:
                             _CourseBonus.EnemyPlayPointBonus += (effect.Param0 / 100.0);
+                            break;
+                        case GPCourseId.DisablePartyAdjustEnemyExp:
+                            _CourseBonus.DisablePartyExpAdjustment = true;
                             break;
                     }
                 }
@@ -84,6 +88,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             break;
                         case GPCourseId.EnemyPpUp:
                             _CourseBonus.EnemyPlayPointBonus -= (effect.Param0 / 100.0);
+                            break;
+                        case GPCourseId.DisablePartyAdjustEnemyExp:
+                            _CourseBonus.DisablePartyExpAdjustment = false;
                             break;
                     }
                 }
@@ -187,6 +194,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
             lock (_CourseBonus)
             {
                 return _CourseBonus.EnemyPlayPointBonus;
+            }
+        }
+
+        public bool DisablePartyExpAdjustment()
+        {
+            lock (_CourseBonus)
+            {
+                return _CourseBonus.DisablePartyExpAdjustment;
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -132,7 +132,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 uint bo = enemyKilled.BloodOrbs;
                 uint ho = enemyKilled.HighOrbs;
-                uint gainedExp = enemyKilled.GetDroppedExperience();
+                uint gainedExp = _gameServer.ExpManager.GetAdjustedExp(client.GameMode, RewardSource.Enemy, client.Party, enemyKilled.GetDroppedExperience(), enemyKilled.Lv);
 
                 uint gainedPP = enemyKilled.GetDroppedPlayPoints();
 

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Arrowgene.Ddon.Server
@@ -45,6 +46,28 @@ namespace Arrowgene.Ddon.Server
         /// </summary>
         [DataMember(Order = 5)] public byte CraftConsumableProductionTimesMax { get; set; }
 
+        /// <summary>
+        /// Configures if party exp is adjusted based on level differences of members.
+        /// </summary>
+        [DataMember(Order = 6)] public bool AdjustPartyEnemyExp { get; set; }
+
+        /// <summary>
+        /// List of the inclusive ranges of (minlv, maxlv, percent). Percent is a value from 0.0 - 1.0
+        /// which is multipled into the base exp amount to determine the adjusted exp.
+        /// </summary>
+        [DataMember(Order = 7)] public List<(uint, uint, double)> AdjustPartyEnemyExpTiers { get; set; }
+
+        /// <summary>
+        /// Configures if exp is adjusted based on level differences of members vs target level.
+        /// </summary>
+        [DataMember(Order = 8)] public bool AdjustTargetLvEnemyExp { get; set; }
+
+        /// <summary>
+        /// List of the inclusive ranges of (minlv, maxlv, percent). Percent is a value from 0.0 - 1.0
+        /// which is multipled into the base exp amount to determine the adjusted exp.
+        /// </summary>
+        [DataMember(Order = 9)] public List<(uint, uint, double)> AdjustTargetLvEnemyExpTiers { get; set; }
+
         public GameLogicSetting()
         {
             AdditionalProductionSpeedFactor = 1.0;
@@ -53,6 +76,26 @@ namespace Arrowgene.Ddon.Server
             RookiesRingBonus = 1.0;
             NaiveLobbyContextHandling = true;
             CraftConsumableProductionTimesMax = 10;
+
+            AdjustPartyEnemyExp = true;
+            AdjustPartyEnemyExpTiers = new List<(uint, uint, double)>()
+            {
+                (0, 2, 1.0),
+                (3, 4, 0.9),
+                (5, 6, 0.8),
+                (7, 8, 0.6),
+                (9, 10, 0.5),
+            };
+
+            AdjustTargetLvEnemyExp = true;
+            AdjustTargetLvEnemyExpTiers = new List<(uint, uint, double)>()
+            {
+                (0, 2, 1.0),
+                (3, 4, 0.9),
+                (5, 6, 0.8),
+                (7, 8, 0.6),
+                (9, 10, 0.5),
+            };
         }
 
         public GameLogicSetting(GameLogicSetting setting)
@@ -63,6 +106,10 @@ namespace Arrowgene.Ddon.Server
             RookiesRingBonus = setting.RookiesRingBonus;
             NaiveLobbyContextHandling = setting.NaiveLobbyContextHandling;
             CraftConsumableProductionTimesMax = setting.CraftConsumableProductionTimesMax;
+            AdjustPartyEnemyExp = setting.AdjustPartyEnemyExp;
+            AdjustPartyEnemyExpTiers = setting.AdjustPartyEnemyExpTiers;
+            AdjustTargetLvEnemyExp = setting.AdjustTargetLvEnemyExp;
+            AdjustTargetLvEnemyExpTiers = setting.AdjustTargetLvEnemyExpTiers;
         }
 
         // Note: method is called after the object is completely deserialized - constructors are skipped.

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -52,8 +52,9 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 6)] public bool AdjustPartyEnemyExp { get; set; }
 
         /// <summary>
-        /// List of the inclusive ranges of (minlv, maxlv, percent). Percent is a value from 0.0 - 1.0
-        /// which is multipled into the base exp amount to determine the adjusted exp.
+        /// List of the inclusive ranges of (minlv, maxlv, ExpMultiplier). ExpMultiplier is a value
+        /// from (0.0 - 1.0) which is multipled into the base exp amount to determine the adjusted exp.
+        /// The minlv and maxlv determine the relative level range that this multiplier should be applied to.
         /// </summary>
         [DataMember(Order = 7)] public List<(uint, uint, double)> AdjustPartyEnemyExpTiers { get; set; }
 
@@ -63,8 +64,9 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 8)] public bool AdjustTargetLvEnemyExp { get; set; }
 
         /// <summary>
-        /// List of the inclusive ranges of (minlv, maxlv, percent). Percent is a value from 0.0 - 1.0
-        /// which is multipled into the base exp amount to determine the adjusted exp.
+        /// List of the inclusive ranges of (minlv, maxlv, ExpMultiplier). ExpMultiplier is a value from
+        /// (0.0 - 1.0) which is multipled into the base exp amount to determine the adjusted exp.
+        /// The minlv and maxlv determine the relative level range that this multiplier should be applied to.
         /// </summary>
         [DataMember(Order = 9)] public List<(uint, uint, double)> AdjustTargetLvEnemyExpTiers { get; set; }
 


### PR DESCRIPTION
- Added a check based on the level distribution of party members as described in the DDON wiki.
- Added a check based on the maximum level of the target enemy when compared to the maximum level of a party member.
- Added options to enable/disable both features.
- Added options to configure the level ranges and EXP rate rewarded for both options.
- Added support for course effect which temporarily disables these
  checks.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
