### PR TITLE
fix: Fix some oddities with character

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -395,6 +395,14 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             common.StatusInfo.RevivePoint = GetByte(reader, "revive_point");
             common.StatusInfo.HP = GetUInt32(reader, "hp");
             common.StatusInfo.WhiteHP = GetUInt32(reader, "white_hp");
+
+            if (common.StatusInfo.HP == 0 || common.StatusInfo.WhiteHP == 0)
+            {
+                // TODO: Figure out why this is happening
+                Logger.Error($"Unexpected: Character CommonId={common.CommonId} has a health value of 0 stored in the DB");
+                common.StatusInfo.HP = 760;
+                common.StatusInfo.WhiteHP = 760;
+            }
         }
 
         private void AddParameter(TCom command, CharacterCommon common)

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -13,6 +13,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public static readonly uint BASE_HEALTH = 760U;
         public static readonly uint BASE_STAMINA = 450U;
+        public static readonly uint BBM_BASE_HEALTH = 990U;
+        public static readonly uint BBM_BASE_STAMINA = 589U;
+
         public static readonly uint DEFAULT_RING_COUNT = 1;
         public static readonly uint BASE_ABILITY_COST_AMOUNT = 15;
 

--- a/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
@@ -45,7 +45,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             uint id = client.Character.CharacterId;
-            HashSet<GameClient> targetClients = new HashSet<GameClient>();
+            HashSet<GameClient> targetClients = new HashSet<GameClient>()
+            {
+                client
+            };
             HashSet<GameClient> gatherClients = new HashSet<GameClient>();
 
             if (HubMembers.ContainsKey(previousStageId))

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
@@ -458,6 +458,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             Server.CharacterManager.UpdateCharacterExtendedParams(bbmCharacter, true);
+
+            bbmCharacter.GreenHp = CharacterManager.BBM_BASE_HEALTH;
+            bbmCharacter.WhiteHp = CharacterManager.BBM_BASE_HEALTH;
             if (!Database.CreateCharacter(bbmCharacter))
             {
                 return null;


### PR DESCRIPTION
Attempt to fix an issue where the player sometimes is "dead" when they log in, join parties or switch to some hub area. It seems that the HP is being saved as 0 sometimes in the DB. So when the context gets updated the player is dead, unable to select any menu options.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
