### PR TITLE
fix: Fix issue with equip in BBM

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,6 +23,27 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         private readonly DdonGameServer Server;
         private readonly Dictionary<uint, HashSet<GameClient>> HubMembers;
+
+        public HashSet<GameClient> GetClientsInHub(StageId stageId)
+        {
+            return GetClientsInHub(stageId.Id);
+        }
+
+        public HashSet<GameClient> GetClientsInHub(uint stageId)
+        {
+            if (Server.Setting.GameLogicSetting.NaiveLobbyContextHandling)
+            {
+                return Server.ClientLookup.GetAll().Distinct().ToHashSet();
+            }
+            else
+            {
+                if (!HubMembers.ContainsKey(stageId))
+                {
+                    return new HashSet<GameClient>();
+                }
+                return HubMembers[stageId];
+            }
+        }
 
         // The server maintains an authoritative list of who's in each hub stage.
         // Hub stages are defined in StageManager.HubStageIds.

--- a/Arrowgene.Ddon.GameServer/Handler/BattleContentContentResetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/BattleContentContentResetHandler.cs
@@ -10,6 +10,7 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -54,12 +55,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // Add back equipment
             client.Character.Equipment = client.Character.Storage.GetCharacterEquipment();
 
-            // Set current job back to level 1 stats
-            var jobResults = Server.JobManager.SetJob(client, client.Character, client.Character.Job);
-            client.Send((S2CJobChangeJobNtc) jobResults.jobNtc);
-
             // Reset EXP
             Server.ExpManager.ResetExpData(client, client.Character);
+
+            // Set current job back to level 1 stats
+            var jobResults = Server.JobManager.SetJob(client, client.Character, client.Character.Job);
+            foreach (var otherClient in Server.ClientLookup.GetAll())
+            {
+                otherClient.Send((S2CJobChangeJobNtc)jobResults.jobNtc);
+            }
+            client.Send((S2CJobChangeJobNtc)jobResults.jobNtc);
+            client.Send((S2CItemUpdateCharacterItemNtc)jobResults.itemNtc);
 
             // Reset progress
             client.Character.BbmProgress.StartTime = 0;

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetGatheringItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetGatheringItemHandler.cs
@@ -80,6 +80,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         connection);
                 });
                 client.Send(equipResult.itemNtc);
+
+                // TODO: Can this be optimized? So only players who need to see
+                //       get the update?
+                foreach (var otherClient in Server.ClientLookup.GetAll())
+                {
+                    otherClient.Send(equipResult.equipNtc);
+                }
             }
         }
     }


### PR DESCRIPTION
- Fixed an issue where gear equipped from the box was not reflected visually in other party member clients.
- Fixed an issue where when the player reset their progress, their level and gear was not reflected properly to other players.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
