### PR TITLE
feat: Implement pawn catchup system

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -13,6 +13,7 @@ using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.GameServer.Party;
 using System.IO;
 using System.Text;
+using System.Buffers.Text;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -772,9 +773,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
             double multiplier = 0;
             foreach (var tier in _GameSettings.AdjustPartyEnemyExpTiers)
             {
-                if (range >= tier.Item1 && range <= tier.Item2)
+                if (range >= tier.MinLv && range <= tier.MaxLv)
                 {
-                    multiplier = tier.Item3;
+                    multiplier = tier.ExpMultiplier;
                     break;
                 }
             }
@@ -800,9 +801,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
             double multiplier = 0;
             foreach (var tier in _GameSettings.AdjustTargetLvEnemyExpTiers)
             {
-                if (range >= tier.Item1 && range <= tier.Item2)
+                if (range >= tier.MinLv && range <= tier.MaxLv)
                 {
-                    multiplier = tier.Item3;
+                    multiplier = tier.ExpMultiplier;
                     break;
                 }
             }
@@ -825,6 +826,94 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 multiplier = Math.Min(partyRangeMultiplier, targetMultiplier);
             }
             
+            return (uint)(multiplier * baseExpAmount);
+        }
+
+        private uint GetMaxAllowedPartyRange()
+        {
+            if (_GameSettings.AdjustPartyEnemyExpTiers.Count == 0)
+            {
+                return 0;
+            }
+
+            uint min = _GameSettings.AdjustPartyEnemyExpTiers[0].MinLv;
+            uint max = _GameSettings.AdjustPartyEnemyExpTiers[0].MaxLv;
+
+            foreach (var tier in _GameSettings.AdjustPartyEnemyExpTiers)
+            {
+                min = Math.Min(min, tier.MinLv);
+                max = Math.Max(max, tier.MaxLv);
+            }
+
+            return max - min;
+        }
+
+        public bool RequiresPawnCatchup(GameMode gameMode, PartyGroup party, Pawn pawn)
+        {
+            if (!_GameSettings.EnablePawnCatchup || gameMode == GameMode.BitterblackMaze)
+            {
+                return false;
+            }
+
+            foreach (var client in party.Clients)
+            {
+                if (pawn.CharacterId == client.Character.CharacterId)
+                {
+                    if (pawn.ActiveCharacterJobData.Lv >= client.Character.ActiveCharacterJobData.Lv)
+                    {
+                        return false;
+                    }
+                    else if (client.Character.ActiveCharacterJobData.Lv - pawn.ActiveCharacterJobData.Lv > _GameSettings.PawnCatchupLvDiff)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private double CalculatePawnCatchupTargetLvMultiplier(GameMode gameMode, Pawn pawn, uint targetLv)
+        {
+            if (!_GameSettings.AdjustTargetLvEnemyExp || gameMode == GameMode.BitterblackMaze)
+            {
+                return 1.0;
+            }
+
+            if (pawn.ActiveCharacterJobData.Lv <= targetLv)
+            {
+                return 1.0;
+            }
+
+            var range = pawn.ActiveCharacterJobData.Lv - targetLv;
+
+            double multiplier = 0;
+            foreach (var tier in _GameSettings.AdjustTargetLvEnemyExpTiers)
+            {
+                if (range >= tier.MinLv && range <= tier.MaxLv)
+                {
+                    multiplier = tier.ExpMultiplier;
+                    break;
+                }
+            }
+
+            return multiplier;
+        }
+
+        public uint GetAdjustedPawnExp(GameMode gameMode, RewardSource source, PartyGroup party, Pawn pawn, uint baseExpAmount, uint targetLv)
+        {
+            if (!_GameSettings.EnablePawnCatchup || gameMode == GameMode.BitterblackMaze)
+            {
+                return baseExpAmount;
+            }
+
+            var targetMultiplier = CalculatePawnCatchupTargetLvMultiplier(gameMode, pawn, targetLv);
+            var multiplier = _GameSettings.PawnCatchupMultiplier * targetMultiplier;
+
             return (uint)(multiplier * baseExpAmount);
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -200,6 +200,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     {
                         _gameServer.PPManager.AddPlayPoint(memberClient, gainedPP, 1);
                     }
+
+                    if (gainedExp > 0)
+                    {
+                        _gameServer.ExpManager.AddExp(memberClient, memberCharacter, gainedExp, RewardSource.Enemy);
+                    }
                 }
                 else if(member is PawnPartyMember)
                 {
@@ -213,15 +218,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         // and non-rented pawns
                         continue;
                     }
+
+                    uint pawnExp = gainedExp;
+                    if (_gameServer.ExpManager.RequiresPawnCatchup(client.GameMode, client.Party, pawn))
+                    {
+                        pawnExp = _gameServer.ExpManager.GetAdjustedPawnExp(client.GameMode, RewardSource.Enemy, client.Party, pawn, enemyKilled.GetDroppedExperience(), enemyKilled.Lv);
+                    }
+
+                    if (pawnExp > 0)
+                    {
+                        _gameServer.ExpManager.AddExp(memberClient, memberCharacter, pawnExp, RewardSource.Enemy);
+                    }
                 }
                 else
                 {
                     throw new Exception("Unknown member type");
-                }
-
-                if (gainedExp > 0)
-                {
-                    _gameServer.ExpManager.AddExp(memberClient, memberCharacter, gainedExp, RewardSource.Enemy);
                 }
             }
         }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -52,11 +52,11 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 6)] public bool AdjustPartyEnemyExp { get; set; }
 
         /// <summary>
-        /// List of the inclusive ranges of (minlv, maxlv, ExpMultiplier). ExpMultiplier is a value
+        /// List of the inclusive ranges of (MinLv, Maxlv, ExpMultiplier). ExpMultiplier is a value
         /// from (0.0 - 1.0) which is multipled into the base exp amount to determine the adjusted exp.
         /// The minlv and maxlv determine the relative level range that this multiplier should be applied to.
         /// </summary>
-        [DataMember(Order = 7)] public List<(uint, uint, double)> AdjustPartyEnemyExpTiers { get; set; }
+        [DataMember(Order = 7)] public List<(uint MinLv, uint MaxLv, double ExpMultiplier)> AdjustPartyEnemyExpTiers { get; set; }
 
         /// <summary>
         /// Configures if exp is adjusted based on level differences of members vs target level.
@@ -64,11 +64,11 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 8)] public bool AdjustTargetLvEnemyExp { get; set; }
 
         /// <summary>
-        /// List of the inclusive ranges of (minlv, maxlv, ExpMultiplier). ExpMultiplier is a value from
+        /// List of the inclusive ranges of (MinLv, Maxlv, ExpMultiplier). ExpMultiplier is a value from
         /// (0.0 - 1.0) which is multipled into the base exp amount to determine the adjusted exp.
         /// The minlv and maxlv determine the relative level range that this multiplier should be applied to.
         /// </summary>
-        [DataMember(Order = 9)] public List<(uint, uint, double)> AdjustTargetLvEnemyExpTiers { get; set; }
+        [DataMember(Order = 9)] public List<(uint MinLv, uint MaxLv, double ExpMultiplier)> AdjustTargetLvEnemyExpTiers { get; set; }
 
         /// <summary>
         /// The number of real world minutes that make up an in-game day.
@@ -87,6 +87,22 @@ namespace Arrowgene.Ddon.Server
         /// </summary>
         [DataMember(Order = 12)] public List<(uint MeanLength, uint Weight)> WeatherStatistics { get; set; }
 
+        /// <summary>
+        /// Configures if the Pawn Exp Catchup mechanic is enabled. This mechanic still rewards the player pawn EXP when the pawn is outside
+        /// the allowed level range and a lower level than the owner.
+        /// </summary>
+        [DataMember(Order = 13)] public bool EnablePawnCatchup { get; set; }
+
+        /// <summary>
+        /// If the flag EnablePawnCatchup=true, this is the multiplier value used when calculating exp to catch the pawns level back up to the player.
+        /// </summary>
+        [DataMember(Order = 14)] public double PawnCatchupMultiplier { get; set; }
+
+        /// <summary>
+        /// If the flag EnablePawnCatchup=true, this is the range of level that the pawn falls behind the player before the catchup mechanic kicks in.
+        /// </summary>
+        [DataMember(Order = 15)] public uint PawnCatchupLvDiff { get; set; }
+
         public GameLogicSetting()
         {
             AdditionalProductionSpeedFactor = 1.0;
@@ -97,7 +113,7 @@ namespace Arrowgene.Ddon.Server
             CraftConsumableProductionTimesMax = 10;
 
             AdjustPartyEnemyExp = true;
-            AdjustPartyEnemyExpTiers = new List<(uint, uint, double)>()
+            AdjustPartyEnemyExpTiers = new List<(uint MinLv, uint MaxLv, double ExpMultiplier)>()
             {
                 (0, 2, 1.0),
                 (3, 4, 0.9),
@@ -107,7 +123,7 @@ namespace Arrowgene.Ddon.Server
             };
 
             AdjustTargetLvEnemyExp = true;
-            AdjustTargetLvEnemyExpTiers = new List<(uint, uint, double)>()
+            AdjustTargetLvEnemyExpTiers = new List<(uint MinLv, uint MaxLv, double ExpMultiplier)>()
             {
                 (0, 2, 1.0),
                 (3, 4, 0.9),
@@ -115,6 +131,10 @@ namespace Arrowgene.Ddon.Server
                 (7, 8, 0.6),
                 (9, 10, 0.5),
             };
+
+            EnablePawnCatchup = true;
+            PawnCatchupMultiplier = 1.5;
+            PawnCatchupLvDiff = 5;
 
             GameClockTimescale = 90;
 
@@ -142,6 +162,9 @@ namespace Arrowgene.Ddon.Server
             GameClockTimescale = setting.GameClockTimescale;
             WeatherSequenceLength = setting.WeatherSequenceLength;
             WeatherStatistics = setting.WeatherStatistics;
+            EnablePawnCatchup = setting.EnablePawnCatchup;
+            PawnCatchupMultiplier = setting.PawnCatchupMultiplier;
+            PawnCatchupLvDiff = setting.PawnCatchupLvDiff;
         }
 
         // Note: method is called after the object is completely deserialized - constructors are skipped.
@@ -167,6 +190,10 @@ namespace Arrowgene.Ddon.Server
             if (GameClockTimescale <= 0)
             {
                 GameClockTimescale = 90;
+            }
+            if (PawnCatchupMultiplier < 0)
+            {
+                PawnCatchupMultiplier = 1.0;
             }
         }
     }


### PR DESCRIPTION
When a pawn is outside the valid party level range and the player is a higher level than the pawn, the pawn will gain exp at a boosted rate to help get it back closer to the players level range.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
