### PR TITLE
feat: Items not equipped are lost in BBM on homepoint

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -25,6 +25,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         private static readonly uint STACK_BOX_MAX = 999;
 
+        public static readonly List<StorageType> AllItemStorages = Enum.GetValues(typeof(StorageType)).Cast<StorageType>().ToList();
         public static readonly List<StorageType> ItemBagStorageTypes = new List<StorageType> { 
             StorageType.ItemBagConsumable, StorageType.ItemBagMaterial, StorageType.ItemBagEquipment, StorageType.ItemBagJob, 
             StorageType.KeyItems 
@@ -740,6 +741,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
             var results = new List<CDataItemUpdateResult>();
             foreach (var storageType in storageTypes)
             {
+                if (!character.Storage.HasStorage(storageType))
+                {
+                    continue;
+                }
+
                 for (int i = 0; i < character.Storage.GetStorage(storageType).Items.Count; i++)
                 {
                     ushort slotNo = (ushort)(i + 1);
@@ -752,10 +758,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     }
 
                     character.Storage.GetStorage(storageType).SetItem(null, 0, slotNo);
-                    if (connection != null)
-                    {
-                        _Server.Database.DeleteStorageItem(character.ContentCharacterId, storageType, slotNo, connection);
-                    }
+                    _Server.Database.DeleteStorageItem(character.ContentCharacterId, storageType, slotNo, connection);
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -60,7 +60,7 @@ namespace Arrowgene.Ddon.GameServer
             ClientLookup = new GameClientLookup();
             ChatLogHandler = new ChatLogHandler();
             ChatManager = new ChatManager(this, Router);
-            ItemManager = new ItemManager();
+            ItemManager = new ItemManager(this);
             CraftManager = new CraftManager(this);
             PartyManager = new PartyManager(this);
             ExpManager = new ExpManager(this, ClientLookup);

--- a/Arrowgene.Ddon.GameServer/Handler/BattleContentContentResetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/BattleContentContentResetHandler.cs
@@ -26,8 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CBattleContentContentResetRes Handle(GameClient client, C2SBattleContentContentResetReq request)
         {
             // Reset Inventory
-            var updateItemList = RemoveAllItemsFromInventory(client.Character, client.Character.Storage, ItemManager.ItemBagStorageTypes);
-            client.Character.Storage.Clear();
+            var updateItemList = Server.ItemManager.RemoveAllItemsFromInventory(client.Character, client.Character.Storage, ItemManager.ItemBagStorageTypes);
 
             // Flush Storage
             S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
@@ -80,27 +79,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             client.Send(ntc2);
 
             return new S2CBattleContentContentResetRes();
-        }
-
-        private List<CDataItemUpdateResult> RemoveAllItemsFromInventory(Character character, Storages storages, List<StorageType> storageTypes)
-        {
-            var results = new List<CDataItemUpdateResult>();
-            foreach (var storageType in storageTypes)
-            {
-                for (int i = 0; i < character.Storage.GetStorage(storageType).Items.Count; i++)
-                {
-                    ushort slotNo = (ushort)(i + 1);
-
-                    var storageItem = storages.GetStorage(storageType).GetItem(slotNo);
-                    if (storageItem != null)
-                    {
-                        results.Add(Server.ItemManager.CreateItemUpdateResult(null, storageItem.Item1, storageType, slotNo, 0, 0));
-                        results.Add(Server.ItemManager.CreateItemUpdateResult(null, storageItem.Item1, storageType, slotNo, 0, storageItem.Item2));
-                    }
-                }
-            }
-
-            return results;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterCharacterPenaltyReviveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterCharacterPenaltyReviveHandler.cs
@@ -1,15 +1,12 @@
-using System.Threading.Tasks;
-using System;
-using System.Threading;
-using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Server.Network;
-using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Network;
-using Arrowgene.Logging;
-using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.GameServer.Characters;
-using System.Collections.Generic;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {

--- a/Arrowgene.Ddon.Shared/Model/Storages.cs
+++ b/Arrowgene.Ddon.Shared/Model/Storages.cs
@@ -68,6 +68,17 @@ namespace Arrowgene.Ddon.Shared.Model
             }
         }
 
+        public void Clear(List<StorageType> storageTypes)
+        {
+            foreach (var (type, storage) in storages)
+            {
+                if (storageTypes.Contains(type))
+                {
+                    storage.Clear();
+                }
+            }
+        }
+
         public Equipment GetCharacterEquipment()
         {
             return new Equipment(GetStorage(StorageType.CharacterEquipment), 0);

--- a/Arrowgene.Ddon.Shared/Model/Storages.cs
+++ b/Arrowgene.Ddon.Shared/Model/Storages.cs
@@ -55,6 +55,11 @@ namespace Arrowgene.Ddon.Shared.Model
             return storages[storageType];
         }
 
+        public bool HasStorage(StorageType storageType)
+        {
+            return storages.ContainsKey(storageType);
+        }
+
         public void AddStorage(StorageType storageType, Storage storage)
         {
             storages[storageType] = storage;


### PR DESCRIPTION
Implemented a mechanic for BBM where if the player chooses to homepoint after dying inside the maze, any item which is not currently equipped to the character will be lost.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
