### PR TITLE
fix: Fix issue with pawn exp notification

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -486,6 +486,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 else if(characterToAddExpTo is Pawn)
                 {
                     S2CJobPawnJobExpUpNtc expNtc = new S2CJobPawnJobExpUpNtc();
+                    expNtc.PawnId = ((Pawn)characterToAddExpTo).PawnId;
                     expNtc.JobId = activeCharacterJobData.Job;
                     expNtc.AddExp = gainedExp + extraBonusExp;
                     expNtc.ExtraBonusExp = extraBonusExp;


### PR DESCRIPTION
Fixed an issue where the pawn ID got dropped from the EXP NTC which causes the pawn EXP gain to not show in the log.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
