### PR TITLE
fix: Fix issue where pawn skills can't be previewed

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/PawnGetRegisteredPawnDataHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnGetRegisteredPawnDataHandler.cs
@@ -40,7 +40,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 break;
             }
 
-            res.PawnInfo = pawn.AsCDataPawnInfo();
+            GameStructure.CDataPawnInfo(res.PawnInfo, pawn);
 
             return res;
         }

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnInfo.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPawnInfo.cs
@@ -56,7 +56,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public byte ShareRange { get; set; }
         public uint Likability { get; set; }
         public byte[] TrainingStatus { get; set; }
-        public CData_772E80 Unk1 { get; set; }
+        public CData_772E80 Unk1 { get; set; } // Dragon abilities?
         public List<CDataSpSkill> SpSkillList { get; set; }
 
         public class Serializer : EntitySerializer<CDataPawnInfo>

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Linq;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 
 namespace Arrowgene.Ddon.Shared.Model
@@ -73,13 +74,27 @@ namespace Arrowgene.Ddon.Shared.Model
                 Version = 0,
                 MaxHp = StatusInfo.MaxHP,
                 MaxStamina = StatusInfo.MaxStamina,
+                JewelrySlotNum = JewelrySlotNum,
                 JobId = ActiveCharacterJobData.Job,
                 CharacterJobDataList = CharacterJobDataList,
                 CharacterEquipDataList = new List<CDataCharacterEquipData>() { new CDataCharacterEquipData { Equips = Equipment.AsCDataEquipItemInfo(EquipType.Performance) } },
                 CharacterEquipViewDataList = new List<CDataCharacterEquipData>() { new CDataCharacterEquipData { Equips = Equipment.AsCDataEquipItemInfo(EquipType.Visual) } },
+                CharacterEquipJobItemList = EquipmentTemplate.JobItemsAsCDataEquipJobItem(ActiveCharacterJobData.Job),
                 HideEquipHead = HideEquipHead,
                 HideEquipLantern = HideEquipLantern,
                 PawnType = PawnType,
+                ContextAbilityList = EquippedAbilitiesDictionary[ActiveCharacterJobData.Job]
+                    .Select((ability, index) => ability?
+                    .AsCDataContextAcquirementData((byte)(index + 1)))
+                    .Where(ability => ability != null)
+                    .ToList(),
+                ContextNormalSkillList = LearnedNormalSkills.Select(normalSkill => new CDataContextNormalSkillData(normalSkill)).ToList(),
+                ContextSkillList = EquippedCustomSkillsDictionary[ActiveCharacterJobData.Job]
+                        .Select((skill, index) => skill?.AsCDataContextAcquirementData((byte)(index + 1)))
+                        .Where(skill => skill != null)
+                        .ToList(),
+                ExtendParam = ExtendedParams,
+                // TODO: Add rest of fileds so full structure can be populated here
             };
         }
     }


### PR DESCRIPTION
Fixed an issue where the pawn skills were not visible when looking at the skills before hiring.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
