### PR TITLE
fix: Fix exception related to subgroups

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -46,27 +46,34 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 RandomSeed = CryptoRandom.Instance.GetRandomUInt32(),
             };
 
-            client.Party.InstanceEnemyManager.SetInstanceSubgroupId(stageId, subGroupId);
             if (IsQuestControlled && quest != null)
             {
                 response.QuestId = (uint) quest.QuestId;
-                response.EnemyList = client.Party.QuestState.GetInstancedEnemies(quest, stageId, subGroupId).Select(enemy => new CDataLayoutEnemyData()
+
+                foreach (var enemy in client.Party.QuestState.GetInstancedEnemies(quest, stageId, subGroupId))
                 {
-                    PositionIndex = (byte)(enemy.Index),
-                    EnemyInfo = enemy.asCDataStageLayoutEnemyPresetEnemyInfoClient()
-                }).ToList();
+                    response.EnemyList.Add(new CDataLayoutEnemyData()
+                    {
+                        PositionIndex = enemy.Index,
+                        EnemyInfo = enemy.asCDataStageLayoutEnemyPresetEnemyInfoClient()
+                    });
+                    client.Party.InstanceEnemyManager.SetInstanceEnemy(stageId, enemy.Index, enemy);
+                }
             }
             else
             {
-                response.EnemyList = client.Party.InstanceEnemyManager.GetAssets(stageId, subGroupId).Select((enemy, index) => new CDataLayoutEnemyData()
+                foreach (var asset in client.Party.InstanceEnemyManager.GetAssets(stageId, subGroupId).Select((Enemy, Index) => new {Index, Enemy}))
                 {
-                    PositionIndex = (byte)index,
-                    EnemyInfo = enemy.asCDataStageLayoutEnemyPresetEnemyInfoClient()
-                })
-                .ToList();
+                    response.EnemyList.Add(new CDataLayoutEnemyData()
+                    {
+                        PositionIndex = (byte) asset.Index,
+                        EnemyInfo = asset.Enemy.asCDataStageLayoutEnemyPresetEnemyInfoClient()
+                    });
+                    client.Party.InstanceEnemyManager.SetInstanceEnemy(stageId, (byte) asset.Index, asset.Enemy);
+                }
             }
 
-            if (subGroupId > 0)
+            if (subGroupId > 0 && response.EnemyList.Count > 0)
             {
                 S2CInstanceEnemySubGroupAppearNtc subgroupNtc = new S2CInstanceEnemySubGroupAppearNtc()
                 {

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceTraningRoomSetEnemyHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceTraningRoomSetEnemyHandler.cs
@@ -23,6 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             client.Send(new S2CInstanceTraningRoomSetEnemyRes());
 
+            client.Party.InstanceEnemyManager.ResetEnemyNode(TrainingRoomLayout.AsStageId());
             client.Party.SendToAll(new S2CInstanceEnemyGroupResetNtc()
             {
                 LayoutId = TrainingRoomLayout

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -152,6 +152,15 @@ namespace Arrowgene.Ddon.GameServer.Party
             }
         }
 
+        public bool HasEnemiesInCurrentStageGroup(Quest quest, StageId stageId)
+        {
+            lock (ActiveQuests)
+            {
+                var questState = ActiveQuests[quest.QuestId];
+                return questState.QuestEnemies.ContainsKey(stageId);
+            }
+        }
+
         public bool HasEnemiesInCurrentStageGroup(Quest quest, StageId stageId, uint subGroupId)
         {
             lock (ActiveQuests)

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -387,6 +387,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     LayoutId = enemyGroup.StageId.ToStageLayoutId()
                 };
 
+                client.Party.InstanceEnemyManager.ResetEnemyNode(enemyGroup.StageId);
                 client.Party.SendToAll(resetNtc);
             }
         }


### PR DESCRIPTION
Fixed an exception which occurs the client requests enemies for a subgroup even when there are monsters are already populated in that node.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
