### PR TITLE
refactor: Replace VariantId with QuestScheduleId

### DIFF
--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -34,7 +34,17 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ContentWithTargetPath Remove="files\database\script\migration_quest_variant_refactor.sql" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Shared\Arrowgene.Ddon.Shared.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="Files\Database\Script\migration_quest_variant_refactor.sql">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -14,7 +14,7 @@ namespace Arrowgene.Ddon.Database
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-        public const uint Version = 20;
+        public const uint Version = 21;
 
         public static IDatabase Build(DatabaseSetting settings)
         {

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_quest_variant_refactor.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_quest_variant_refactor.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "ddon_priority_quests"
+    RENAME COLUMN "quest_id" to "quest_schedule_id";
+
+ALTER TABLE "ddon_reward_box" 
+    RENAME COLUMN "quest_id" to "quest_schedule_id";
+
+ALTER TABLE "ddon_reward_box"
+    DROP "variant_quest_id";
+
+ALTER TABLE "ddon_quest_progress"
+    RENAME COLUMN "quest_id" to "quest_schedule_id";
+
+ALTER TABLE "ddon_quest_progress"
+    DROP "variant_quest_id";

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -536,13 +536,12 @@ CREATE TABLE IF NOT EXISTS "ddon_reward_box"
 (
     "uniq_reward_id"       INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "character_common_id"  INTEGER                           NOT NULL,
-    "quest_id"             INTEGER                           NOT NULL,
+    "quest_schedule_id"    INTEGER                           NOT NULL,
     "num_random_rewards"   INTEGER                           NOT NULL,
     "random_reward0_index" INTEGER                           NOT NULL,
     "random_reward1_index" INTEGER                           NOT NULL,
     "random_reward2_index" INTEGER                           NOT NULL,
     "random_reward3_index" INTEGER                           NOT NULL,
-    "variant_quest_id"     INTEGER                           NOT NULL DEFAULT 0,
     CONSTRAINT "fk_ddon_reward_box_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
 );
 
@@ -550,9 +549,8 @@ CREATE TABLE IF NOT EXISTS "ddon_quest_progress"
 (
     "character_common_id" INTEGER NOT NULL,
     "quest_type"          INTEGER NOT NULL,
-    "quest_id"            INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
     "step"                INTEGER NOT NULL,
-    "variant_quest_id"          INTEGER NOT NULL,  
     CONSTRAINT "fk_ddon_quest_progress_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
 );
 
@@ -568,7 +566,7 @@ CREATE TABLE IF NOT EXISTS "ddon_completed_quests"
 CREATE TABLE IF NOT EXISTS "ddon_priority_quests"
 (
     "character_common_id" INTEGER NOT NULL,
-    "quest_id"            INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
     CONSTRAINT "fk_ddon_priority_quests_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -433,16 +433,16 @@ namespace Arrowgene.Ddon.Database
         );
 
         // Quest Progress
-        bool InsertQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step, uint variantId=0);
-        bool UpdateQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step);
-        bool RemoveQuestProgress(uint characterCommonId, QuestId questId, QuestType questType);
+        bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step);
+        bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step);
+        bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType);
         List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType);
-        QuestProgress GetQuestProgressById(uint characterCommonId, QuestId questId);
+        QuestProgress GetQuestProgressById(uint characterCommonId, uint questScheduleId);
 
         // Quest Priority
-        bool InsertPriorityQuest(uint characterCommonId, QuestId questId);
-        List<QuestId> GetPriorityQuests(uint characterCommonId);
-        bool DeletePriorityQuest(uint characterCommonId, QuestId questId);
+        bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId);
+        List<uint> GetPriorityQuestScheduleIds(uint characterCommonId);
+        bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId);
 
         // System mail
         long InsertSystemMailAttachment(SystemMailAttachment attachment);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private readonly int MAX_RANDOM_REWARDS = 4;
         protected static readonly string[] RewardBoxFields = new string[]
         {
-            /* uniq_reward_id */  "character_common_id", "quest_id", "num_random_rewards", "random_reward0_index", "random_reward1_index", "random_reward2_index", "random_reward3_index", "variant_quest_id"
+            /* uniq_reward_id */  "character_common_id", "quest_schedule_id", "num_random_rewards", "random_reward0_index", "random_reward1_index", "random_reward2_index", "random_reward3_index"
         };
 
         private readonly string SqlInsertRewardBoxItems = $"INSERT INTO \"ddon_reward_box\" ({BuildQueryField(RewardBoxFields)}) VALUES ({BuildQueryInsert(RewardBoxFields)});";
@@ -37,9 +37,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return ExecuteNonQuery(conn, SqlInsertRewardBoxItems, command =>
             {
                 AddParameter(command, "character_common_id", commonId);
-                AddParameter(command, "quest_id", (uint) rewards.QuestId);
+                AddParameter(command, "quest_schedule_id", rewards.QuestScheduleId);
                 AddParameter(command, "num_random_rewards", rewards.NumRandomRewards);
-                AddParameter(command, "variant_quest_id", rewards.VariantId);
 
                 int i;
                 for(i = 0; i < rewards.NumRandomRewards; i++)
@@ -101,9 +100,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             QuestBoxRewards obj = new QuestBoxRewards();
             obj.UniqRewardId = GetUInt32(reader, "uniq_reward_id");
             obj.CharacterCommonId = GetUInt32(reader, "character_common_id");
-            obj.QuestId = (QuestId) GetUInt32(reader, "quest_id");
             obj.NumRandomRewards = GetInt32(reader, "num_random_rewards");
-            obj.VariantId = GetUInt32(reader, "variant_quest_id");
+            obj.QuestScheduleId = GetUInt32(reader, "quest_schedule_id");
 
             for (int i = 0; i < obj.NumRandomRewards; i++)
             {

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlPriorityQuests.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlPriorityQuests.cs
@@ -20,38 +20,38 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         /* ddon_completed_quests */
         protected static readonly string[] PriorityQuestFields = new string[]
         {
-            "character_common_id", "quest_id"
+            "character_common_id", "quest_schedule_id"
         };
 
         private readonly string SqlInsertIfNotExistPriorityQuestId = $"INSERT INTO \"ddon_priority_quests\" ({BuildQueryField(PriorityQuestFields)}) SELECT " +
                                                                          $"{BuildQueryInsert(PriorityQuestFields)} WHERE NOT EXISTS (SELECT 1 FROM \"ddon_priority_quests\" WHERE " +
-                                                                         $"\"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id);";
+                                                                         $"\"character_common_id\" = @character_common_id AND \"quest_schedule_id\" = @quest_schedule_id);";
         private readonly string SqlSelectPriorityQuests = $"SELECT {BuildQueryField(PriorityQuestFields)} FROM \"ddon_priority_quests\" WHERE \"character_common_id\" = @character_common_id;";
-        private readonly string SqlDeletePriorityQuest = $"DELETE FROM \"ddon_priority_quests\" WHERE \"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id;";
+        private readonly string SqlDeletePriorityQuest = $"DELETE FROM \"ddon_priority_quests\" WHERE \"character_common_id\" = @character_common_id AND \"quest_schedule_id\" = @quest_schedule_id;";
 
-        public bool InsertPriorityQuest(uint characterCommonId, QuestId questId)
+        public bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId)
         {
             using TCon connection = OpenNewConnection();
-            return InsertPriorityQuest(connection, characterCommonId, questId);
+            return InsertPriorityQuest(connection, characterCommonId, questScheduleId);
         }
 
-        public bool InsertPriorityQuest(TCon connection, uint characterCommonId, QuestId questId)
+        public bool InsertPriorityQuest(TCon connection, uint characterCommonId, uint questScheduleId)
         {
             return ExecuteNonQuery(connection, SqlInsertIfNotExistPriorityQuestId, command =>
             {
                 AddParameter(command, "character_common_id", characterCommonId);
-                AddParameter(command, "quest_id", (uint)questId);
+                AddParameter(command, "quest_schedule_id", questScheduleId);
             }) == 1;
         }
 
-        public List<QuestId> GetPriorityQuests(uint characterCommonId)
+        public List<uint> GetPriorityQuestScheduleIds(uint characterCommonId)
         {
             using TCon connection = OpenNewConnection();
             return GetPriorityQuests(connection, characterCommonId);
         }
-        public List<QuestId> GetPriorityQuests(TCon connection, uint characterCommonId)
+        public List<uint> GetPriorityQuests(TCon connection, uint characterCommonId)
         {
-            List<QuestId> results = new List<QuestId>();
+            List<uint> results = new List<uint>();
             ExecuteInTransaction(conn =>
             {
                 ExecuteReader(conn, SqlSelectPriorityQuests,
@@ -60,25 +60,25 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                     }, reader => {
                         while (reader.Read())
                         {
-                            results.Add((QuestId)GetUInt32(reader, "quest_id"));
+                            results.Add(GetUInt32(reader, "quest_schedule_id"));
                         }
                     });
             });
             return results;
         }
 
-        public bool DeletePriorityQuest(uint characterCommonId, QuestId questId)
+        public bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId)
         {
             using TCon connection = OpenNewConnection();
-            return DeletePriorityQuest(connection, characterCommonId, questId);
+            return DeletePriorityQuest(connection, characterCommonId, questScheduleId);
         }
 
-        public bool DeletePriorityQuest(TCon connection, uint characterCommonId, QuestId questId)
+        public bool DeletePriorityQuest(TCon connection, uint characterCommonId, uint questScheduleId)
         {
             return ExecuteNonQuery(connection, SqlDeletePriorityQuest, command =>
             {
                 AddParameter(command, "@character_common_id", characterCommonId);
-                AddParameter(command, "quest_id", (uint)questId);
+                AddParameter(command, "quest_schedule_id", questScheduleId);
             }) == 1;
         }
     }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestProgress.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestProgress.cs
@@ -12,23 +12,18 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         /* ddon_quest_progress */
         protected static readonly string[] QuestProgressFields = new string[]
         {
-            "character_common_id", "quest_type", "quest_id", "step", "variant_quest_id"
-        };
-
-        protected static readonly string[] QuestProgressFieldsUpdate = new string[]
-        {
-            "character_common_id", "quest_type", "quest_id", "step"
+            "character_common_id", "quest_type", "quest_schedule_id", "step"
         };
 
         private readonly string SqlInsertQuestProgress = $"INSERT INTO \"ddon_quest_progress\" ({BuildQueryField(QuestProgressFields)}) VALUES ({BuildQueryInsert(QuestProgressFields)});";
-        private readonly string SqlDeleteQuestProgress = $"DELETE FROM \"ddon_quest_progress\" WHERE \"character_common_id\"=@character_common_id AND \"quest_type\"=@quest_type AND \"quest_id\"=@quest_id;";
+        private readonly string SqlDeleteQuestProgress = $"DELETE FROM \"ddon_quest_progress\" WHERE \"character_common_id\"=@character_common_id AND \"quest_type\"=@quest_type AND \"quest_schedule_id\"=@quest_schedule_id;";
 
-        private readonly string SqlUpdateQuestProgress = $"UPDATE \"ddon_quest_progress\" SET \"step\"=@step WHERE \"character_common_id\"=@character_common_id AND \"quest_type\"=@quest_type AND \"quest_id\"=@quest_id;";
+        private readonly string SqlUpdateQuestProgress = $"UPDATE \"ddon_quest_progress\" SET \"step\"=@step WHERE \"character_common_id\"=@character_common_id AND \"quest_type\"=@quest_type AND \"quest_schedule_id\"=@quest_schedule_id;";
 
         private readonly string SqlSelectQuestProgressByType = $"SELECT {BuildQueryField(QuestProgressFields)} FROM \"ddon_quest_progress\" WHERE +" +
                                                                $"\"character_common_id\" = @character_common_id AND \"quest_type\" = @quest_type;";
         private readonly string SqlSelectQuestProgressById = $"SELECT {BuildQueryField(QuestProgressFields)} FROM \"ddon_quest_progress\" WHERE +" +
-                                                               $"\"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id;";
+                                                               $"\"character_common_id\" = @character_common_id AND \"quest_schedule_id\" = @quest_schedule_id;";
         private readonly string SqlSelectAllQuestProgress = $"SELECT {BuildQueryField(QuestProgressFields)} FROM \"ddon_quest_progress\" WHERE +" +
                                                                $"\"character_common_id\" = @character_common_id;";
 
@@ -93,13 +88,13 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         }
 
 
-        public QuestProgress GetQuestProgressById(uint characterCommonId, QuestId questId)
+        public QuestProgress GetQuestProgressById(uint characterCommonId, uint questScheduleId)
         {
             using TCon connection = OpenNewConnection();
-            return GetQuestProgressById(connection, characterCommonId, questId);
+            return GetQuestProgressById(connection, characterCommonId, questScheduleId);
         }
 
-        public QuestProgress GetQuestProgressById(TCon connection, uint characterCommonId, QuestId questId)
+        public QuestProgress GetQuestProgressById(TCon connection, uint characterCommonId, uint questScheduleId)
         {
             QuestProgress result = null;
             ExecuteInTransaction(connection =>
@@ -108,7 +103,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                     command =>
                     {
                         AddParameter(command, "@character_common_id", characterCommonId);
-                        AddParameter(command, "@quest_id", (uint)questId);
+                        AddParameter(command, "@quest_schedule_id", questScheduleId);
                     },
                     reader =>
                     {
@@ -121,53 +116,51 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return result;
         }
 
-        public bool RemoveQuestProgress(uint characterCommonId, QuestId questId, QuestType questType)
+        public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType)
         {
             using TCon connection = OpenNewConnection();
-            return RemoveQuestProgress(connection, characterCommonId, questId, questType);
+            return RemoveQuestProgress(connection, characterCommonId, questScheduleId, questType);
         }
 
-        public bool RemoveQuestProgress(TCon connection, uint characterCommonId, QuestId questId, QuestType questType)
+        public bool RemoveQuestProgress(TCon connection, uint characterCommonId, uint questScheduleId, QuestType questType)
         {
             return ExecuteNonQuery(connection, SqlDeleteQuestProgress, command =>
             {
                 AddParameter(command, "character_common_id", characterCommonId);
                 AddParameter(command, "quest_type", (uint)questType);
-                AddParameter(command, "quest_id", (uint)questId);
+                AddParameter(command, "quest_schedule_id", questScheduleId);
             }) == 1;
         }
 
-        public bool InsertQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step, uint variantId=0)
+        public bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step)
         {
             using TCon connection = OpenNewConnection();
-            return InsertQuestProgress(connection, characterCommonId, questId, questType, step, variantId);
+            return InsertQuestProgress(connection, characterCommonId, questScheduleId, questType, step);
         }
 
-        public bool InsertQuestProgress(TCon connection, uint characterCommonId, QuestId questId, QuestType questType, uint step, uint variantId=0)
+        public bool InsertQuestProgress(TCon connection, uint characterCommonId, uint questScheduleId, QuestType questType, uint step)
         {
                 return ExecuteNonQuery(connection, SqlInsertQuestProgress, command =>
                 {
                     AddParameter(command, "character_common_id", characterCommonId);
-                    AddParameter(command, "quest_id", (uint)questId);
+                    AddParameter(command, "quest_schedule_id", questScheduleId);
                     AddParameter(command, "quest_type", (uint)questType);
                     AddParameter(command, "step", (uint)step);
-                    AddParameter(command, "variant_quest_id", variantId);
-
                 }) == 1;
         }
 
-        public bool UpdateQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step)
+        public bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step)
         {
             using TCon connection = OpenNewConnection();
-            return UpdateQuestProgress(connection, characterCommonId, questId, questType, step);
+            return UpdateQuestProgress(connection, characterCommonId, questScheduleId, questType, step);
         }
 
-        public bool UpdateQuestProgress(TCon connection, uint characterCommonId, QuestId questId, QuestType questType, uint step)
+        public bool UpdateQuestProgress(TCon connection, uint characterCommonId, uint questScheduleId, QuestType questType, uint step)
         {
             return ExecuteNonQuery(connection, SqlUpdateQuestProgress, command =>
             {
                 AddParameter(command, "character_common_id", characterCommonId);
-                AddParameter(command, "quest_id", (uint)questId);
+                AddParameter(command, "quest_schedule_id", questScheduleId);
                 AddParameter(command, "quest_type", (uint)questType);
                 AddParameter(command, "step", (uint)step);
             }) == 1; ;
@@ -177,10 +170,9 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         {
             QuestProgress obj = new QuestProgress();
             obj.CharacterCommonId = GetUInt32(reader, "character_common_id");
-            obj.QuestId = (QuestId)GetUInt32(reader, "quest_id");
+            obj.QuestScheduleId = GetUInt32(reader, "quest_schedule_id");
             obj.QuestType = (QuestType)GetUInt32(reader, "quest_type");
             obj.Step = GetUInt32(reader, "step");
-            obj.VariantId = GetUInt32(reader, "variant_quest_id");
             return obj;
         }
     }

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000021_QuestVarientRefactorMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000021_QuestVarientRefactorMigration.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class QuestVarientRefactorMigration : IMigrationStrategy
+    {
+        public uint From => 20;
+        public uint To => 21;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public QuestVarientRefactorMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(DatabaseSetting, "Script/migration_quest_variant_refactor.sql");
+            db.Execute(conn, adaptedSchema);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
@@ -1,13 +1,10 @@
-using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.GameServer.Utils;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
-using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters
@@ -538,14 +535,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
         private static readonly ulong BOARD_CATEGORY_RECRUITMENT = 0x9_00000000;
         private static readonly ulong BOARD_CATEGORY_EXM         = 0x4_00000000;
 
-        public static ulong QuestIdToExmBoardId(uint questId)
+        public static ulong QuestScheduleIdToExmBoardId(uint questScheduleId)
         {
-            return (ulong)(questId | BOARD_CATEGORY_EXM);
-        }
-
-        public static ulong QuestIdToExmBoardId(QuestId questId)
-        {
-            return QuestIdToExmBoardId((uint) questId);
+            return (ulong)(questScheduleId | BOARD_CATEGORY_EXM);
         }
 
         public static bool BoardIdIsExm(ulong boardId)

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -7,8 +7,6 @@ using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters
@@ -21,222 +19,135 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
         }
 
-        private static Dictionary<QuestId, Quest> gQuests = new Dictionary<QuestId, Quest>();
-        private static readonly Dictionary<QuestId, Dictionary<uint, Quest>> variantQuests = new();
-        private static readonly HashSet<QuestId> AvailableVariantQuests = new();
-        private static Dictionary<uint, List<Quest>> gTutorialQuests = new Dictionary<uint, List<Quest>>();
-        private static Dictionary<QuestAreaId, List<Quest>> gWorldQuests = new Dictionary<QuestAreaId, List<Quest>>();
+        /**
+         * @note gQuests contains a map of <QuestScheduleId:QuestId>.
+         * @note gVarientQuests maps QuestId:HashSet<QuestScheduleId>.
+         * 
+         * A QuestScheduleId should always get us back to a unique quest object.
+         * A QuestId can return us a list of related QuestScheduleIds which all use the same QuestId.
+         */
+        private static Dictionary<uint, Quest> gQuests = new Dictionary<uint, Quest>();
+        private static readonly Dictionary<QuestId, List<Quest>> gVariantQuests = new();
 
-        public static HashSet<QuestId> GetAllVariantQuestIds()
-        {
-            return AvailableVariantQuests;
-        }
+        private static Dictionary<uint, HashSet<uint>> gTutorialQuests = new Dictionary<uint, HashSet<uint>>();
+        private static Dictionary<QuestAreaId, HashSet<QuestId>> gWorldQuests = new Dictionary<QuestAreaId, HashSet<QuestId>>();
 
         public static void LoadQuests(AssetRepository assetRepository)
         {
-            // TODO: Quests should probably operate on the distribuition ID instead of quest id so the global list can still contain all quests
-            // TODO: Then quests can be distributed to different lists for faster lookup (like world by area id or tutorial by stageno)
-
-            // Load Quests defined in files
+            // TODO: Quests should probably operate on the QuestScheduleID instead of QuestId so the global list can still contain all quests
+            // TODO: Then quests can be distributed to different lists for faster lookup (like world by area id or personal by stageno)
             foreach (var questAsset in assetRepository.QuestAssets.Quests)
             {
-                // Separate all variant quests to its own dictionary for separate handling.
-                // This also ensures these quests are not in gQuests before processing.
-                if (questAsset.VariantId != 0 && !gQuests.ContainsKey(questAsset.QuestId))
+                gQuests[questAsset.QuestScheduleId] = GenericQuest.FromAsset(questAsset);
+
+                var quest = gQuests[questAsset.QuestScheduleId];
+                if (!quest.Enabled)
                 {
-                    Quest alternateQuest = GenericQuest.FromAsset(questAsset);
-                    alternateQuest.IsVariantQuest = true;
-                    alternateQuest.VariantId = (uint)questAsset.VariantId;
-
-                    // Add an entry to the dictionary if it doesn't exist then add the variant id and quest
-                    if (!variantQuests.ContainsKey(questAsset.QuestId))
-                    {
-                        variantQuests[alternateQuest.QuestId] = new Dictionary<uint, Quest>();
-                        variantQuests[questAsset.QuestId].Add(alternateQuest.VariantId, alternateQuest);
-                        continue;
-                    }
-
-                    // Add quest id and quest
-                    variantQuests[questAsset.QuestId].Add(alternateQuest.VariantId, alternateQuest);
+                    continue;
                 }
-                else
+
+                if (!gVariantQuests.ContainsKey(quest.QuestId))
                 {
-                    gQuests[questAsset.QuestId] = GenericQuest.FromAsset(questAsset);
-
-                    var quest = gQuests[questAsset.QuestId];
-                    if (!quest.Enabled)
-                    {
-                        continue;
-                    }
-
-                    if (quest.QuestType == QuestType.Tutorial)
-                    {
-                        uint stageNo = (uint)StageManager.ConvertIdToStageNo(quest.StageId);
-                        if (!gTutorialQuests.ContainsKey(stageNo))
-                        {
-                            gTutorialQuests[stageNo] = new List<Quest>();
-                        }
-                        gTutorialQuests[stageNo].Add(quest);
-                    }
-                    else if (quest.QuestType == QuestType.World)
-                    {
-                        if (!gWorldQuests.ContainsKey(quest.QuestAreaId))
-                        {
-                            gWorldQuests[quest.QuestAreaId] = new List<Quest>();
-                        }
-                        gWorldQuests[quest.QuestAreaId].Add(quest);
-                    }
+                    gVariantQuests[quest.QuestId] = new List<Quest>();
                 }
-            }
+                gVariantQuests[quest.QuestId].Add(quest);
 
-            var variantQuestKeys = variantQuests.Keys.ToArray();
-            for (int i = 0; i < variantQuestKeys.Length; i++)
-            {
-                // Store of all variant ids under the generic quest id
-                HashSet<uint> allVariantQuestIds = new();
-
-                // Create a reliable source of all variant quests, also checks if they are unique
-                AvailableVariantQuests.Add(variantQuestKeys[i]);
-
-                Logger.Info($"Quest Group Listed: {variantQuestKeys[i]}");
-                var variantIds = variantQuests[variantQuestKeys[i]].Keys.ToArray();
-
-                for (int j = 0; j < variantIds.Length; j++)
+                if (quest.QuestType == QuestType.Tutorial)
                 {
-                    Logger.Info($"Variant entry: {variantIds[j]}");
-
-                    // Ensure variant ids are unique.
-                    try
+                    uint stageNo = (uint)StageManager.ConvertIdToStageNo(quest.StageId);
+                    if (!gTutorialQuests.ContainsKey(stageNo))
                     {
-                        allVariantQuestIds.Add(variantIds[j]);
+                        gTutorialQuests[stageNo] = new HashSet<uint>();
                     }
-                    catch (Exception)
+                    gTutorialQuests[stageNo].Add(quest.QuestScheduleId);
+                }
+                else if (quest.QuestType == QuestType.World)
+                {
+                    if (!gWorldQuests.ContainsKey(quest.QuestAreaId))
                     {
-                        Logger.Error($"Multiple quests are using variant id {variantIds[j]}. Please ensure all are unique.");
-                        throw;
+                        gWorldQuests[quest.QuestAreaId] = new HashSet<QuestId>();
                     }
+                    gWorldQuests[quest.QuestAreaId].Add(quest.QuestId);
                 }
             }
         }
 
-        /**
-         * @brief Should only be called when loading additional quests from file.
-         */
-        public static void AddQuest(Quest quest)
+        public static HashSet<uint> GetQuestsByType(QuestType type)
         {
-            gQuests[quest.QuestId] = quest;
-        }
-
-        public static List<KeyValuePair<QuestId, Quest>> GetQuestsByType(QuestType type)
-        {
-            List<KeyValuePair<QuestId, Quest>> results = new List<KeyValuePair<QuestId, Quest>>();
+            HashSet<uint> results = new HashSet<uint>();
 
             // TODO: We probably need to optimize this as more quests are added
-            foreach (var quest in gQuests)
+            foreach (var (scheduleId, quest) in gQuests)
             {
-                if (quest.Value.QuestType == type)
-                {
-                    results.Add(quest);
-                }
-            }
-
-            // Go over the variant quest collection, get a single quest per questId regardless of the variant id
-
-            foreach (var quests in variantQuests)
-            {
-                QuestId questId = quests.Key;
-                Quest quest = variantQuests[questId].First().Value;
-
                 if (quest.QuestType == type)
                 {
-                    results.Add(new KeyValuePair<QuestId, Quest>(questId, quest));
+                    results.Add(quest.QuestScheduleId);
                 }
             }
 
             return results;
         }
 
-        public static List<Quest> GetWorldQuestsByAreaId(QuestAreaId areaId)
+        public static HashSet<QuestId> GetWorldQuestIdsByAreaId(QuestAreaId areaId)
         {
             if (!gWorldQuests.ContainsKey(areaId))
             {
-                return new List<Quest>();
+                return new HashSet<QuestId>();
             }
 
             return gWorldQuests[areaId];
         }
 
-        public static List<QuestId> GetWorldQuestIdsByAreaId(QuestAreaId areaId)
-        {
-            if (!gWorldQuests.ContainsKey(areaId))
-            {
-                return new List<QuestId>();
-            }
-
-            return gWorldQuests[areaId].Select(x => x.QuestId).ToList();
-        }
-
         public static Quest GetQuestByBoardId(ulong boardId)
         {
             uint questId = BoardManager.GetQuestIdFromBoardId(boardId);
-            return GetQuest(questId);
+            return GetQuestByScheduleId(questId);
         }
 
-        public static List<Quest> GetTutorialQuestsByStageNo(uint stageNo)
+        public static HashSet<uint> GetTutorialQuestsByStageNo(uint stageNo)
         {
             if (!gTutorialQuests.ContainsKey(stageNo))
             {
-                return new List<Quest>();
+                return new HashSet<uint>();
             }
 
             return gTutorialQuests[stageNo];
         }
 
-        public static uint GetRandomVariantId(QuestId baseQuest)
+        public static bool IsVariantQuest(QuestId baseQuestId)
         {
-            // Get random index value to choose a quest version.
-            int randomIndex = Random.Shared.Next(variantQuests[baseQuest].Count);
-
-            uint variantId = variantQuests[baseQuest].ElementAt(randomIndex).Key;
-
-            return variantId;
+            return gVariantQuests.ContainsKey(baseQuestId);
         }
 
-        public static Quest GetRewardQuest(QuestId questId, uint variantId)
+        public static Quest GetQuestByScheduleId(uint questScheduleId)
         {
-            return GetQuest(questId, variantId);
-        }
-
-        public static Quest GetQuest(QuestId questId, uint variantId = 0)
-        {
-            // If a variant is specified, return the variant quest.
-            if (variantId != 0)
-            {
-                return variantQuests[questId][variantId];
-            }
-
-            if (!gQuests.ContainsKey(questId))
+            if (!gQuests.ContainsKey(questScheduleId))
             {
                 return null;
             }
 
-            return gQuests[questId];
+            return gQuests[questScheduleId];
         }
 
-        public static Quest GetQuest(uint questId)
+        public static List<Quest> GetQuestsByQuestId(QuestId questId)
         {
-            return GetQuest((QuestId)questId);
+            if (gVariantQuests.ContainsKey(questId))
+            {
+                return gVariantQuests[questId];
+            }
+            return new List<Quest>();
         }
 
-        public static bool IsQuestEnabled(uint questId)
+        public static Quest RollQuestForQuestId(QuestId questId)
         {
-            var quest = GetQuest(questId);
+            var quests = GetQuestsByQuestId(questId);
+            return quests[Random.Shared.Next(0, quests.Count)];
+        }
+
+        public static bool IsQuestEnabled(uint questScheduleId)
+        {
+            var quest = GetQuestByScheduleId(questScheduleId);
             return (quest == null) ? false : quest.Enabled;
-        }
-
-        public static bool IsQuestEnabled(QuestId questId)
-        {
-            return IsQuestEnabled((uint)questId);
         }
 
         public class LayoutFlag

--- a/Arrowgene.Ddon.GameServer/Chat/Command/Commands/FinishQuestCommand.cs
+++ b/Arrowgene.Ddon.GameServer/Chat/Command/Commands/FinishQuestCommand.cs
@@ -12,7 +12,7 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
         public override AccountStateType AccountState => AccountStateType.User;
 
         public override string Key => "finishquest";
-        public override string HelpText => "usage: `/finishquest [questid]` - Finish quests.";
+        public override string HelpText => "usage: `/finishquest [questScheduleId]` - Finish quests.";
 
         private DdonGameServer _server;
 
@@ -29,11 +29,11 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
                 return;
             }
 
-            QuestId? questId = null;
+            uint questScheduleId = 0;
             // Try by id
-            if (uint.TryParse(command[0], out uint parsedQuestId))
+            if (uint.TryParse(command[0], out uint parsedQuestScheduleId))
             {
-                questId = (QuestId)parsedQuestId;
+                questScheduleId = parsedQuestScheduleId;
             }
             else
             {
@@ -41,8 +41,7 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
                 return;
             }
 
-            Quest quest = QuestManager.GetQuest((QuestId)questId);
-
+            Quest quest = QuestManager.GetQuestByScheduleId(parsedQuestScheduleId);
             if (quest is null)
             {
                 responses.Add(ChatResponse.CommandError(client, $"Invalid questId \"{command[0]}\". This quest does not exist."));
@@ -50,10 +49,10 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
             }
 
             //Super jank. Leaves lots of red icons over peoples heads, but doesn't immediately require relogs.
-            client.Party.QuestState.CompletePartyQuestProgress(_server, client.Party, quest.QuestId);
+            client.Party.QuestState.CompletePartyQuestProgress(_server, client.Party, quest.QuestScheduleId);
             S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
             {
-                QuestScheduleId = (uint)quest.QuestId,
+                QuestScheduleId = quest.QuestScheduleId,
                 RandomRewardNum = quest.RandomRewardNum(),
                 ChargeRewardNum = quest.RewardParams.ChargeRewardNum,
                 ProgressBonusNum = quest.RewardParams.ProgressBonusNum,
@@ -74,7 +73,7 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
                 }
             }
 
-            responses.Add(ChatResponse.ServerMessage(client, $"Finishing {questId.ToString()} ({questId})."));
+            responses.Add(ChatResponse.ServerMessage(client, $"Finishing {quest.QuestId.ToString()} ({quest.QuestId})."));
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Chat/Command/Commands/WarpCommand.cs
+++ b/Arrowgene.Ddon.GameServer/Chat/Command/Commands/WarpCommand.cs
@@ -65,8 +65,8 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
             //An actual questId is needed for the client to actually accept the progress update.
             //I assume we could slip something in whenever it asks for the quest list, but this works for now.
             //Or, refactor after the BBI PR to use S2C_BATTLE_71_12_16_NTC;
-            QuestId baseId = (QuestId)70000001;
-            var baseQuest = QuestManager.GetQuest(baseId);
+            uint scheduleId = 70000001;
+            var baseQuest = QuestManager.GetQuestByScheduleId(scheduleId);
             if (baseQuest is null)
             {
                 responses.Add(ChatResponse.CommandError(client, $"Missing base quest."));
@@ -81,7 +81,7 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
             S2CQuestQuestProgressNtc progressNtc = new S2CQuestQuestProgressNtc()
             {
                 ProgressCharacterId = client.Character.CharacterId,
-                QuestScheduleId = (uint)baseId,
+                QuestScheduleId = scheduleId,
                 QuestProcessStateList = new List<CDataQuestProcessState>()
                 {
                     new CDataQuestProcessState()
@@ -99,7 +99,7 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
             S2CQuestQuestProgressNtc resetNtc = new S2CQuestQuestProgressNtc()
             {
                 ProgressCharacterId = client.Character.CharacterId,
-                QuestScheduleId = (uint)baseId,
+                QuestScheduleId = scheduleId,
                 QuestProcessStateList = new List<CDataQuestProcessState>()
                 {
                     new CDataQuestProcessState()

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -46,9 +46,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Quest quest = null;
             bool IsQuestControlled = false;
-            foreach (var questId in client.Party.QuestState.StageQuests(stageId))
+            foreach (var questScheduleId in client.Party.QuestState.StageQuests(stageId))
             {
-                quest = client.Party.QuestState.GetQuest(questId);
+                quest = client.Party.QuestState.GetQuest(questScheduleId);
                 if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId))
                 {
                     IsQuestControlled = true;

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -29,9 +29,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Quest quest = null;
             bool IsQuestControlled = false;
-            foreach (var questId in client.Party.QuestState.StageQuests(stageId))
+            foreach (var questScheduleId in client.Party.QuestState.StageQuests(stageId))
             {
-                quest = QuestManager.GetQuest(questId);
+                quest = QuestManager.GetQuestByScheduleId(questScheduleId);
                 // if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
                 if (quest.HasEnemiesInInCurrentStage(stageId))
                 {

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceSetOmInstantKeyValueHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceSetOmInstantKeyValueHandler.cs
@@ -33,9 +33,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             client.Send(res);
 
             // Check for OM callbacks in the quest
-            foreach (var questId in client.Party.QuestState.GetActiveQuestIds())
+            foreach (var questScheduleId in client.Party.QuestState.GetActiveQuestScheduleIds())
             {
-                var quest = QuestManager.GetQuest(questId);
+                var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
                 if (quest != null)
                 {
                     quest.HandleOmInstantValue(client, req.Structure.Key, req.Structure.Value);

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -54,18 +54,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
             foreach (var questProgress in progress)
             {
-                if (questProgress.VariantId != 0)
-                {
-                    Logger.Debug($"Getting quest progress. Adding {questProgress.QuestId} with variant {questProgress.VariantId}");
-                    party.QuestState.AddNewQuest(questProgress.QuestId, questProgress.Step, true, (uint)questProgress.VariantId);
-                    continue;
-                }
-
-                party.QuestState.AddNewQuest(questProgress.QuestId, questProgress.Step, true);
+                party.QuestState.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
             }
 
             // Add quest for debug command
-            party.QuestState.AddNewQuest(QuestManager.GetQuest(70000001));
+            party.QuestState.AddNewQuest(QuestManager.GetQuestByScheduleId(70000001));
 
             S2CPartyPartyJoinNtc ntc = new S2CPartyPartyJoinNtc();
             ntc.HostCharacterId = client.Character.CharacterId;

--- a/Arrowgene.Ddon.GameServer/Handler/QuestCancelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestCancelHandler.cs
@@ -16,21 +16,19 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CQuestQuestCancelRes Handle(GameClient client, C2SQuestQuestCancelReq packet)
         {                
-            QuestId questId = (QuestId)packet.QuestScheduleId;
-
-            var quest = client.Party.QuestState.GetQuest(questId);
-            Server.Database.RemoveQuestProgress(client.Character.CommonId, quest.QuestId, quest.QuestType);
+            var quest = client.Party.QuestState.GetQuest(packet.QuestScheduleId);
+            Server.Database.RemoveQuestProgress(client.Character.CommonId, quest.QuestScheduleId, quest.QuestType);
             
-            bool isPriority = Server.Database.DeletePriorityQuest(client.Character.CommonId, questId);
+            bool isPriority = Server.Database.DeletePriorityQuest(client.Character.CommonId, quest.QuestScheduleId);
 
             if (client.Party.Leader.Client == client) //Only the leader should be able to inform the party quest state.
             {
-                client.Party.QuestState.CancelQuest(quest.QuestId);
+                client.Party.QuestState.CancelQuest(quest.QuestScheduleId);
 
                 S2CQuestQuestCancelNtc cancelNtc = new S2CQuestQuestCancelNtc()
                 {
                     QuestId = (uint)quest.QuestId,
-                    QuestScheduleId = (uint)quest.QuestScheduleId
+                    QuestScheduleId = quest.QuestScheduleId
                 };
                 client.Party.SendToAll(cancelNtc);
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestCancelPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestCancelPriorityQuestHandler.cs
@@ -26,9 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CQuestCancelPriorityQuestRes Handle(GameClient client, C2SQuestCancelPriorityQuestReq packet)
         {
-            QuestId questId = (QuestId) packet.QuestScheduleId;
-
-            Server.Database.DeletePriorityQuest(client.Character.CommonId, questId);
+            Server.Database.DeletePriorityQuest(client.Character.CommonId, packet.QuestScheduleId);
 
             client.Party.QuestState.UpdatePriorityQuestList(Server, client, client.Party);
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestDecideDeliveryItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestDecideDeliveryItemHandler.cs
@@ -28,9 +28,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ProcessNo = packet.Structure.ProcessNo,
             };
 
-            QuestId questId = (QuestId)packet.Structure.QuestScheduleId;
-            var questState = client.Party.QuestState.GetQuestState(questId);
-
+            var questState = client.Party.QuestState.GetQuestState(packet.Structure.QuestScheduleId);
             if (questState.DeliveryRequestComplete())
             {
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
@@ -30,8 +30,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ProcessNo = packet.Structure.ProcessNo,
             };
 
-            QuestId questId = (QuestId)packet.Structure.QuestScheduleId;
-            var questState = client.Party.QuestState.GetQuestState(questId);
+            var questState = client.Party.QuestState.GetQuestState(packet.Structure.QuestScheduleId);
 
             Dictionary<uint, CDataDeliveredItem> deliveredItems = new Dictionary<uint, CDataDeliveredItem>();
             List<CDataItemUpdateResult> itemUpdateResults = new List<CDataItemUpdateResult>();

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
@@ -64,19 +64,19 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var tutorialQuestInProgress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.Tutorial);
             foreach (var questProgress in tutorialQuestInProgress)
             {
-                if (!QuestManager.IsQuestEnabled(questProgress.QuestId))
+                if (!QuestManager.IsQuestEnabled(questProgress.QuestScheduleId))
                 {
                     continue;
                 }
 
-                var quest = QuestManager.GetQuest(questProgress.QuestId);
+                var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
                 var tutorialQuest = quest.ToCDataTutorialQuestOrderList(questProgress.Step);
                 ntc.TutorialQuestOrderList.Add(tutorialQuest);
             }
 
             if (client.Party != null)
             {
-                var priorityQuests = Server.Database.GetPriorityQuests(client.Party.Leader.Client.Character.CommonId);
+                var priorityQuests = Server.Database.GetPriorityQuestScheduleIds(client.Party.Leader.Client.Character.CommonId);
                 foreach (var questId in priorityQuests)
                 {
                     if (!QuestManager.IsQuestEnabled(questId))
@@ -84,7 +84,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    var quest = QuestManager.GetQuest(questId);
+                    var quest = QuestManager.GetQuestByScheduleId(questId);
                     ntc.PriorityQuestList.Add(new CDataPriorityQuest()
                     {
                         QuestId = (uint)quest.QuestId,

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsGroupHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsGroupHandler.cs
@@ -45,9 +45,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 GroupId = request.GroupId
             };
 
-            var quests = QuestManager.GetQuestsByType(QuestType.ExtremeMission).Where(x => x.Value.MissionParams.Group == request.GroupId).Select(x => x.Value).OrderBy(x => x.QuestId);
+            var quests = QuestManager.GetQuestsByType(QuestType.ExtremeMission)
+                .Select(x => QuestManager.GetQuestByScheduleId(x))
+                .Where(x => x.MissionParams.Group == request.GroupId)
+                .OrderBy(x => x.QuestScheduleId);
             foreach (var quest in quests)
             {
+                if (quest.MissionParams.Group != request.GroupId)
+                {
+                    continue;
+                }
+
                 var entry = quest.ToCDataTimeGainQuestList(0);
                 results.TimeGainQuestList.Add(entry);
             }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsRecruitListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsRecruitListHandler.cs
@@ -20,13 +20,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             var results = new S2CQuestGetEndContentsRecruitListRes();
 
-            foreach (var (questId, quest) in QuestManager.GetQuestsByType(QuestType.ExtremeMission))
+            foreach (var questScheduleId in QuestManager.GetQuestsByType(QuestType.ExtremeMission))
             {
+                var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
                 results.Unk1List.Add(new CDataQuestRecruitListItem()
                 {
-                    QuestScheduleId = (uint) quest.QuestScheduleId,
+                    QuestScheduleId = quest.QuestScheduleId,
                     QuestId = (uint) quest.QuestId,
-                    GroupsRecruiting = (uint) Server.BoardManager.GetGroupsForBoardId(BoardManager.QuestIdToExmBoardId(quest.QuestId)).Where(x => !x.ContentInProgress).ToList().Count
+                    GroupsRecruiting = (uint) Server.BoardManager.GetGroupsForBoardId(BoardManager.QuestScheduleIdToExmBoardId(quest.QuestScheduleId)).Where(x => !x.ContentInProgress).ToList().Count
                 });
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetLightQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetLightQuestListHandler.cs
@@ -27,19 +27,19 @@ namespace Arrowgene.Ddon.GameServer.Handler
             res.GpCompletePriceGp = 10;
             res.LightQuestList = new List<CDataLightQuestList>();
 
-            var activeQuests = client.Party.QuestState.GetActiveQuestIds();
-            var quests = QuestManager.GetQuestsByType(QuestType.Light);
-            foreach (var quest in quests)
+            var activeQuests = client.Party.QuestState.GetActiveQuestScheduleIds();
+            foreach (var questScheduleId in QuestManager.GetQuestsByType(QuestType.Light))
             {
-                if (activeQuests.Contains(quest.Key))
+                var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
+                if (activeQuests.Contains(quest.QuestScheduleId))
                 {
                     continue;
                 }
-                if (!QuestManager.IsBoardQuest(quest.Key))
+                if (!QuestManager.IsBoardQuest(quest.QuestId))
                 {
                     continue;
                 }
-                res.LightQuestList.Add(quest.Value.ToCDataLightQuestList(0));
+                res.LightQuestList.Add(quest.ToCDataLightQuestList(0));
             }
 
             client.Send(res);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetMainQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetMainQuestListHandler.cs
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             S2CQuestGetMainQuestListRes res = new S2CQuestGetMainQuestListRes();
             S2CQuestGetMainQuestNtc ntc = new S2CQuestGetMainQuestNtc();
-            foreach (var questId in client.Party.QuestState.GetActiveQuestIds())
+            foreach (var questId in client.Party.QuestState.GetActiveQuestScheduleIds())
             {
                 var quest = client.Party.QuestState.GetQuest(questId);
                 if (quest.QuestType == QuestType.Main)

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetPartyQuestProgressInfoHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetPartyQuestProgressInfoHandler.cs
@@ -34,7 +34,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             EntitySerializer<S2CQuestGetPartyQuestProgressInfoRes> serializer = EntitySerializer.Get<S2CQuestGetPartyQuestProgressInfoRes>();
             S2CQuestGetPartyQuestProgressInfoRes pcap = serializer.Read(GameFull.data_Dump_142);
 
-            foreach (var questId in client.Party.QuestState.GetActiveQuestIds())
+            foreach (var questId in client.Party.QuestState.GetActiveQuestScheduleIds())
             {
                 var quest = client.Party.QuestState.GetQuest(questId);
                 var questState = client.Party.QuestState.GetQuestState(questId);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetPriorityQuestHandler.cs
@@ -32,10 +32,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
             CDataPriorityQuestSetting setting = new CDataPriorityQuestSetting();
             setting.CharacterId = partyLeader.Client.Character.CharacterId;
 
-            var priorityQuests = Server.Database.GetPriorityQuests(partyLeader.Client.Character.CommonId);
-            foreach (var questId in priorityQuests)
+            var priorityQuestScheduleIds = Server.Database.GetPriorityQuestScheduleIds(partyLeader.Client.Character.CommonId);
+            foreach (var questScheduleId in priorityQuestScheduleIds)
             {
-                var quest = client.Party.QuestState.GetQuest(questId);
+                var quest = client.Party.QuestState.GetQuest(questScheduleId);
                 if (quest == null)
                 {
                     continue;
@@ -46,7 +46,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     // Quest State should not be null, but don't crash
                     // Just delete the quest from priority list
-                    Server.Database.DeletePriorityQuest(partyLeader.Client.Character.CommonId, questId);
+                    Server.Database.DeletePriorityQuest(partyLeader.Client.Character.CommonId, questScheduleId);
                     Logger.Error($"Client {partyLeader.Client.Character.CommonId} has priority quest for quest state which doesn't exist");
                     continue;
                 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxListHandler.cs
@@ -33,10 +33,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             uint listNo = 1;
             foreach (var boxReward in Server.RewardManager.GetQuestBoxRewards(client))
             {
+                var quest = QuestManager.GetQuestByScheduleId(boxReward.QuestScheduleId);
                 res.RewardBoxRecordList.Add(new CDataRewardBoxRecord()
                 {
                     ListNo = listNo,
-                    QuestId = (uint)boxReward.QuestId,
+                    QuestId = (uint)quest.QuestId,
                     RewardItemList = Quest.AsCDataRewardBoxItems(boxReward)
                 });
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetTutorialQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetTutorialQuestListHandler.cs
@@ -29,8 +29,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             // This handler should return personal quests which have not been started
             // yet when the player enters the StageNo
-            foreach (var quest in QuestManager.GetTutorialQuestsByStageNo(request.StageNo).Where(x => x.Enabled).ToList())
+            foreach (var questScheduleId in QuestManager.GetTutorialQuestsByStageNo(request.StageNo).Where(x => QuestManager.IsQuestEnabled(x)).ToList())
             {
+                var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
+
                 uint stageNo = (uint) StageManager.ConvertIdToStageNo(quest.StageId);
                 if (stageNo != request.StageNo)
                 {

--- a/Arrowgene.Ddon.GameServer/Handler/QuestPlayStartHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestPlayStartHandler.cs
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CQuestPlayerStartRes Handle(GameClient client, C2SQuestPlayerStartReq request)
         {
-            var quest = QuestManager.GetQuest(request.QuestScheduleId);
+            var quest = QuestManager.GetQuestByScheduleId(request.QuestScheduleId);
             if (quest != null)
             {
                 client.Party.QuestState.AddNewQuest(quest);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestOrderHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestOrderHandler.cs
@@ -26,16 +26,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             var res = new S2CQuestQuestOrderRes();
 
-            QuestId questId = (QuestId)packet.Structure.QuestScheduleId;
-            var quest = client.Party.QuestState.GetQuest(questId);
-            if (client.Party.QuestState.GetActiveQuestIds().Contains(questId))
+            var quest = client.Party.QuestState.GetQuest(packet.Structure.QuestScheduleId);
+            if (client.Party.QuestState.GetActiveQuestScheduleIds().Contains(packet.Structure.QuestScheduleId))
             {
-                var questState = client.Party.QuestState.GetQuestState(questId);
+                var questState = client.Party.QuestState.GetQuestState(quest.QuestScheduleId);
                 res.QuestProcessStateList = quest.ToCDataQuestList(questState.Step).QuestProcessStateList;
             }
             else
             {
-                Logger.Debug($"Quest q{questId} inactive.");
+                Logger.Debug($"Quest '{packet.Structure.QuestScheduleId}' inactive.");
             }
 
             client.Send(res);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -31,13 +31,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             res.QuestProgressResult = 0;
 
             var partyQuestState = client.Party.QuestState;
-
             ushort processNo = packet.Structure.ProcessNo;
-            QuestId questId = (QuestId) packet.Structure.QuestScheduleId;
+            uint questScheduleId = packet.Structure.QuestScheduleId;
 
-            Logger.Debug($"QuestId={questId}, KeyId={packet.Structure.KeyId} ProgressCharacterId={packet.Structure.ProgressCharacterId}, QuestScheduleId={packet.Structure.QuestScheduleId}, ProcessNo={packet.Structure.ProcessNo}\n");
+            Logger.Debug($"QuestScheduleId={questScheduleId}, KeyId={packet.Structure.KeyId} ProgressCharacterId={packet.Structure.ProgressCharacterId}, ProcessNo={packet.Structure.ProcessNo}\n");
 
-            if (QuestManager.GetQuest(questId) == null)
+            if (QuestManager.GetQuestByScheduleId(questScheduleId) == null)
             {
                 // Tell the quest state machine that for these static quest packets
                 // these processes are terminated
@@ -50,41 +49,26 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                var processState = partyQuestState.GetProcessState(questId, processNo);
+                var processState = partyQuestState.GetProcessState(questScheduleId, processNo);
 
-                var quest = client.Party.QuestState.GetQuest(questId);
+                var quest = client.Party.QuestState.GetQuest(questScheduleId);
                 res.QuestProcessState = quest.StateMachineExecute(Server, client, processState, out questProgressState);
 
-                partyQuestState.UpdateProcessState(questId, res.QuestProcessState);
+                partyQuestState.UpdateProcessState(questScheduleId, res.QuestProcessState);
 
                 if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.World)
                 {
-                    // A Quest has started, setting the HasStarted on the quest in QuestState
-                    partyQuestState.SetHasStarted(quest.QuestId, true);
-
                     foreach (var memberClient in client.Party.Clients)
                     {
-                        var questProgress = Server.Database.GetQuestProgressById(memberClient.Character.CommonId, quest.QuestId);
+                        var questProgress = Server.Database.GetQuestProgressById(memberClient.Character.CommonId, questScheduleId);
 
                         if (questProgress != null)
                         {
                             continue;
                         }
 
-                        // Handle new variant quests and the specific quest being added to this list with the variant id.
-
-                        if (quest.IsVariantQuest)
-                        {
-                            if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, 0, quest.VariantId))
-                            {
-                                Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
-                            }
-
-                            continue;
-                        }
-
                         // Add a new world quest record for the player
-                        if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, quest.QuestId, quest.QuestType, 0))
+                        if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, questScheduleId, quest.QuestType, 0))
                         {
                             Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
                         }
@@ -93,7 +77,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 else if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.Tutorial)
                 {
                     // Add a new personal quest record for the player
-                    if (!Server.Database.InsertQuestProgress(client.Character.CommonId, quest.QuestId, quest.QuestType, 0))
+                    if (!Server.Database.InsertQuestProgress(client.Character.CommonId, questScheduleId, quest.QuestType, 0))
                     {
                         Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
                     }
@@ -101,7 +85,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 if (questProgressState == QuestProgressState.Checkpoint || questProgressState == QuestProgressState.Accepted)
                 {
-                    partyQuestState.UpdatePartyQuestProgress(Server, client.Party, questId);
+                    partyQuestState.UpdatePartyQuestProgress(Server, client.Party, questScheduleId);
                 }
                 else if (questProgressState == QuestProgressState.Complete)
                 {
@@ -112,7 +96,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 if (res.QuestProcessState.Count > 0)
                 {
                     Logger.Info("==========================================================================================");
-                    Logger.Info($"{questId}: ProcessNo={res.QuestProcessState[0].ProcessNo}, SequenceNo={res.QuestProcessState[0].SequenceNo}, BlockNo={res.QuestProcessState[0].BlockNo},");
+                    Logger.Info($"{quest.QuestId} ({quest.QuestScheduleId}): ProcessNo={res.QuestProcessState[0].ProcessNo}, SequenceNo={res.QuestProcessState[0].SequenceNo}, BlockNo={res.QuestProcessState[0].BlockNo},");
                     Logger.Info("==========================================================================================");
                 }
             }
@@ -140,14 +124,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
         private void CompleteQuest(Quest quest, GameClient client, PartyGroup party, PartyQuestState partyQuestState)
         {
             // Distribute rewards to the party
-            partyQuestState.DistributePartyQuestRewards(Server, party, quest.QuestId);
+            partyQuestState.DistributePartyQuestRewards(Server, party, quest.QuestScheduleId);
 
             // Resolve quest state for all members participating in the quest
-            partyQuestState.CompletePartyQuestProgress(Server, party, quest.QuestId);
+            partyQuestState.CompletePartyQuestProgress(Server, party, quest.QuestScheduleId);
 
             S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
             {
-                QuestScheduleId = (uint)quest.QuestId,
+                QuestScheduleId = quest.QuestScheduleId,
                 RandomRewardNum = quest.RandomRewardNum(),
                 ChargeRewardNum = quest.RewardParams.ChargeRewardNum,
                 ProgressBonusNum = quest.RewardParams.ProgressBonusNum,

--- a/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
@@ -16,20 +16,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SQuestSetPriorityQuestReq> packet)
         {
-            QuestId questId = (QuestId)packet.Structure.QuestScheduleId;
-
             S2CQuestSetPriorityQuestNtc ntc = new S2CQuestSetPriorityQuestNtc()
             {
                 CharacterId = client.Character.CharacterId
             };
 
-            Server.Database.InsertPriorityQuest(client.Character.CommonId, questId);
+            Server.Database.InsertPriorityQuest(client.Character.CommonId, packet.Structure.QuestScheduleId);
 
-            var priorityQuests = Server.Database.GetPriorityQuests(client.Character.CommonId);
-            foreach (var priorityQuestId in priorityQuests)
+            var prioirtyQuests = Server.Database.GetPriorityQuestScheduleIds(client.Character.CommonId);
+            foreach (var questScheduleId in prioirtyQuests)
             {
-                var quest = client.Party.QuestState.GetQuest(priorityQuestId);
-                var questState = client.Party.QuestState.GetQuestState(questId);
+                var quest = client.Party.QuestState.GetQuest(questScheduleId);
+                var questState = client.Party.QuestState.GetQuestState(questScheduleId);
                 ntc.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState.Step));
             }
 

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -27,7 +27,7 @@ namespace Arrowgene.Ddon.GameServer.Party
         private PlayerPartyMember _leader;
         private PlayerPartyMember _host;
         private bool _isBreakup;
-        
+
         public readonly ulong ContentId;
         public bool ContentInProgress;
 
@@ -618,6 +618,7 @@ namespace Arrowgene.Ddon.GameServer.Party
         {
             InstanceEnemyManager.Clear();
             Contexts.Clear();
+            QuestState.ResetInstance();
             foreach (GameClient client in Clients)
             {
                 client.InstanceGatheringItemManager.Clear();
@@ -628,7 +629,6 @@ namespace Arrowgene.Ddon.GameServer.Party
                 client.Character.ContextOwnership.Clear();
             }
             OmManager.ResetAllOmData(InstanceOmData);
-            QuestState.ResetInstance();
         }
 
         public PartyMember GetPartyMemberByCharacter(CharacterCommon characterCommon)
@@ -782,7 +782,7 @@ namespace Arrowgene.Ddon.GameServer.Party
         public int ClientIndex(GameClient client)
         {
             if (!Members.Any() || !Clients.Any()) return 0;
-            
+
             var ind = Members.FindIndex(member =>
                 member is PlayerPartyMember playerMember
                 && playerMember.Client == client

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -110,7 +110,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             return quest;
         }
 
-        public GenericQuest(QuestId questId, QuestId questScheduleId, QuestType questType, bool discoverable) : base(questId, questScheduleId, questType, discoverable)
+        public GenericQuest(QuestId questId, uint questScheduleId, QuestType questType, bool discoverable) : base(questId, questScheduleId, questType, discoverable)
         {
             QuestLayoutFlagSetInfo = new List<QuestLayoutFlagSetInfo>();
         }
@@ -133,7 +133,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
             else
             {
-                var proccessState = client.Party.QuestState.GetProcessState(QuestId, 0);
+                var proccessState = client.Party.QuestState.GetProcessState(QuestScheduleId, 0);
                 // We need to signal the current block
                 client.Party.SendToAll(new S2CQuestQuestProgressWorkSaveNtc()
                 {

--- a/Arrowgene.Ddon.GameServer/Quests/MainQuests/Mq030260_HopesBitterEnd.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/MainQuests/Mq030260_HopesBitterEnd.cs
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.GameServer.Quests.MainQuests
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(Mq030260_HopesBitterEnd));
 
-        public Mq030260_HopesBitterEnd() : base(QuestId.HopesBitterEnd, QuestId.HopesBitterEnd, QuestType.Main)
+        public Mq030260_HopesBitterEnd() : base(QuestId.HopesBitterEnd, (uint) QuestId.HopesBitterEnd, QuestType.Main)
         {
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -2,14 +2,12 @@ using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Context;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Shared.Asset;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,7 +51,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public readonly QuestId QuestId;
         public readonly bool IsDiscoverable;
         public readonly QuestType QuestType;
-        public readonly QuestId QuestScheduleId;
+        public readonly uint QuestScheduleId;
         public QuestAreaId QuestAreaId { get; set; }
         public StageId StageId {  get; set; }
         public uint NewsImageId { get; set; }
@@ -76,11 +74,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public Dictionary<uint, QuestEnemyGroup> EnemyGroups { get; set; }
         public HashSet<StageId> UniqueEnemyGroups { get; protected set; }
         public List<QuestServerAction> ServerActions { get; protected set; }
-        public bool IsVariantQuest { get; set; }
-        public uint VariantId { get; set; }
         public bool Enabled { get; protected set; }
 
-        public Quest(QuestId questId, QuestId questScheduleId, QuestType questType, bool isDiscoverable = false)
+        public Quest(QuestId questId, uint questScheduleId, QuestType questType, bool isDiscoverable = false)
         {
             QuestId = questId;
             QuestType = questType;
@@ -100,8 +96,6 @@ namespace Arrowgene.Ddon.GameServer.Quests
             QuestLayoutFlags = new List<QuestLayoutFlag>();
             EnemyGroups = new Dictionary<uint, QuestEnemyGroup>();
             UniqueEnemyGroups = new HashSet<StageId>();
-            IsVariantQuest = false;
-            VariantId = 0;
             MissionParams = new QuestMissionParams();
             ServerActions = new List<QuestServerAction>();
             Processes = new List<QuestProcess>();
@@ -219,7 +213,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             var quest = new CDataQuestList()
             {
                 QuestId = (uint)QuestId,
-                QuestScheduleId = (uint)QuestScheduleId,
+                QuestScheduleId = QuestScheduleId,
                 BaseLevel = BaseLevel,
                 ContentJoinItemRank = MinimumItemRank,
                 IsClientOrder = step > 0,
@@ -313,8 +307,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             var result = new CDataPriorityQuest()
             {
                 QuestId = (uint) QuestId,
-                QuestScheduleId = (uint) QuestScheduleId,
-
+                QuestScheduleId = QuestScheduleId,
             };
 
             for (uint i = 0; i < announceNoCount; i++)
@@ -584,7 +577,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         public virtual void PopulateStartingEnemyData(PartyQuestState partyQuestState)
         {
-            var questState = partyQuestState.GetQuestState(this.QuestId);
+            var questState = partyQuestState.GetQuestState(this.QuestScheduleId);
             foreach (var processState in questState.ProcessState.Values)
             {
                 if (processState.ProcessNo >= Processes.Count)
@@ -684,7 +677,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             List<CDataRewardBoxItem> results = new List<CDataRewardBoxItem>();
 
-            Quest quest = QuestManager.GetRewardQuest(rewards.QuestId, rewards.VariantId);
+            Quest quest = QuestManager.GetQuestByScheduleId(rewards.QuestScheduleId);
             if (quest == null)
             {
                 return new List<CDataRewardBoxItem>();
@@ -720,8 +713,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             QuestBoxRewards obj = new QuestBoxRewards()
             {
-                QuestId = QuestId,
-                VariantId = VariantId
+                QuestScheduleId = QuestScheduleId
             };
 
             foreach (var reward in ItemRewards)

--- a/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/CreateCharacterHandler.cs
@@ -580,7 +580,8 @@ namespace Arrowgene.Ddon.LoginServer.Handler
             }
 
             // Insert the first main quest to start the chain
-            if (!Database.InsertQuestProgress(character.CommonId, QuestId.ResolutionsAndOmens, QuestType.Main, 0))
+            // note: We cast the QuestId to a ScheduleId because main quests have the same QuestId and QuestScheduleId
+            if (!Database.InsertQuestProgress(character.CommonId, (uint) QuestId.ResolutionsAndOmens, QuestType.Main, 0))
             {
                 Logger.Error("Failed to seed first MSQ for player");
             }

--- a/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.Shared.Asset
         public QuestType Type { get; set; }
         public QuestId QuestId { get; set; }
         public QuestId NextQuestId { get; set; }
-        public QuestId QuestScheduleId { get; set; }
+        public uint QuestScheduleId { get; set; }
         public QuestAreaId QuestAreaId { get; set; }
         public StageId StageId {  get; set; }
         public uint NewsImageId { get; set; }
@@ -44,7 +44,6 @@ namespace Arrowgene.Ddon.Shared.Asset
         public List<QuestLayoutFlag> QuestLayoutFlags { get; set; }
         public List<QuestLayoutFlagSetInfo> QuestLayoutSetInfoFlags { get; set; }
         public Dictionary<uint, QuestEnemyGroup> EnemyGroups {  get; set; }
-        public uint VariantId { get; set; }
         public QuestMissionParams MissionParams {  get; set; }
         public List<QuestServerAction> ServerActions { get; set; }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -102,26 +102,16 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 assetData.NewsImageId = jNewsImage.GetUInt32();
             }
 
-            // For the purpose of setting up alternate quests.
-
-            if (jQuest.TryGetProperty("variant_id", out JsonElement AltQuestId))
-            {
-                assetData.VariantId = AltQuestId.GetUInt32();
-            } else
-            {
-                assetData.VariantId = 0;
-            }
-
             assetData.NextQuestId = 0;
             if (jQuest.TryGetProperty("next_quest", out JsonElement jNextQuest))
             {
                 assetData.NextQuestId = (QuestId)jNextQuest.GetUInt32();
             }
 
-            assetData.QuestScheduleId = assetData.QuestId;
+            assetData.QuestScheduleId = (uint) assetData.QuestId;
             if (jQuest.TryGetProperty("quest_schedule_id", out JsonElement jQuestScheduleId))
             {
-                assetData.QuestScheduleId = (QuestId)jQuestScheduleId.GetUInt32();
+                assetData.QuestScheduleId = jQuestScheduleId.GetUInt32();
             }
 
             if (jQuest.TryGetProperty("quest_layout_set_info_flags", out JsonElement jLayoutSetInfoFlags))

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001 Ape One.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001 Ape One.json
@@ -1,75 +1,75 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "A Strange Creature Dances In the Forest",
-  "quest_id": 20055001,
-  "variant_id": 587654,
-  "base_level": 15,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "MysreeForest",
-  "news_image": 101,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 490
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 70
-    },
-    {
-      "type": "exp",
-      "amount": 690
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Strange Creature Dances In the Forest",
+    "quest_id": 20055001,
+    "quest_schedule_id": 587654,
+    "base_level": 15,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "MysreeForest",
+    "news_image": 101,
+    "rewards": [
         {
-          "item_id": 448,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 490
         },
         {
-          "item_id": 61,
-          "num": 2
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 70
         },
         {
-          "item_id": 9409,
-          "num": 1
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 57
-      },
-      "enemies": [
+            "type": "exp",
+            "amount": 690
+        },
         {
-          "comment": "Young Dread Ape",
-          "enemy_id": "0x015502",
-          "named_enemy_params_id": 459,
-          "level": 15,
-          "exp": 2780,
-          "is_boss": true
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 448,
+                    "num": 1
+                },
+                {
+                    "item_id": 61,
+                    "num": 2
+                },
+                {
+                    "item_id": 9409,
+                    "num": 1
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 57
+            },
+            "enemies": [
+                {
+                    "comment": "Young Dread Ape",
+                    "enemy_id": "0x015502",
+                    "named_enemy_params_id": 459,
+                    "level": 15,
+                    "exp": 2780,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001 Sphinx one.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001 Sphinx one.json
@@ -1,75 +1,75 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "A Strange Bird Dances In the Forest",
-  "quest_id": 20055001,
-  "variant_id": 102030,
-  "base_level": 18,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "MysreeForest",
-  "news_image": 101,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 590
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 90
-    },
-    {
-      "type": "exp",
-      "amount": 830
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Strange Bird Dances In the Forest",
+    "quest_id": 20055001,
+    "quest_schedule_id": 102030,
+    "base_level": 18,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "MysreeForest",
+    "news_image": 101,
+    "rewards": [
         {
-          "item_id": 448,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 590
         },
         {
-          "item_id": 61,
-          "num": 2
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 90
         },
         {
-          "item_id": 9409,
-          "num": 1
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 57
-      },
-      "enemies": [
+            "type": "exp",
+            "amount": 830
+        },
         {
-          "comment": "Sphinx",
-          "enemy_id": "0x015302",
-          "named_enemy_params_id": 459,
-          "level": 18,
-          "exp": 2950,
-          "is_boss": true
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 448,
+                    "num": 1
+                },
+                {
+                    "item_id": 61,
+                    "num": 2
+                },
+                {
+                    "item_id": 9409,
+                    "num": 1
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 57
+            },
+            "enemies": [
+                {
+                    "comment": "Sphinx",
+                    "enemy_id": "0x015302",
+                    "named_enemy_params_id": 459,
+                    "level": 18,
+                    "exp": 2950,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_102030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_102030.json
@@ -1,7 +1,7 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "A Strange Bird Dances In the Forest",
+    "comment": "A Strange Bird Dances In the Forest (Sphinx)",
     "quest_id": 20055001,
     "quest_schedule_id": 102030,
     "base_level": 18,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_587654.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_587654.json
@@ -1,7 +1,7 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "A Strange Creature Dances In the Forest",
+    "comment": "A Strange Creature Dances In the Forest (Ape)",
     "quest_id": 20055001,
     "quest_schedule_id": 587654,
     "base_level": 15,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004 Redcaps.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004 Redcaps.json
@@ -1,91 +1,91 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "The Abductors’ True Nature",
-  "quest_id": 20055004,
-  "variant_id": 121231,
-  "base_level": 19,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "MysreeForest",
-  "news_image": 111,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 520
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 100
-    },
-    {
-      "type": "exp",
-      "amount": 750
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Abductors’ True Nature",
+    "quest_id": 20055004,
+    "quest_schedule_id": 121231,
+    "base_level": 19,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "MysreeForest",
+    "news_image": 111,
+    "rewards": [
         {
-          "item_id": 8173,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 520
         },
         {
-          "item_id": 9376,
-          "num": 2
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 100
         },
         {
-          "item_id": 9368,
-          "num": 3
+            "type": "exp",
+            "amount": 750
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 8173,
+                    "num": 1
+                },
+                {
+                    "item_id": 9376,
+                    "num": 2
+                },
+                {
+                    "item_id": 9368,
+                    "num": 3
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 67,
-        "group_id": 4
-      },
-      "enemies": [
+    ],
+    "enemy_groups": [
         {
-          "enemy_id": "0x011110",
-          "level": 19,
-          "exp": 200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "level": 19,
-          "exp": 200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "level": 19,
-          "exp": 200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "level": 19,
-          "exp": 200,
-          "is_boss": false
+            "stage_id": {
+                "id": 67,
+                "group_id": 4
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004 Troll.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004 Troll.json
@@ -1,73 +1,73 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "The Abductors’ True Nature",
-  "quest_id": 20055004,
-  "variant_id": 364258,
-  "base_level": 31,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "MysreeForest",
-  "news_image": 111,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 1020
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 160
-    },
-    {
-      "type": "exp",
-      "amount": 1430
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Abductors’ True Nature",
+    "quest_id": 20055004,
+    "quest_schedule_id": 364258,
+    "base_level": 31,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "MysreeForest",
+    "news_image": 111,
+    "rewards": [
         {
-          "item_id": 605,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1020
         },
         {
-          "item_id": 9411,
-          "num": 2
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 160
         },
         {
-          "item_id": 52,
-          "num": 3
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 67,
-        "group_id": 4
-      },
-      "enemies": [
+            "type": "exp",
+            "amount": 1430
+        },
         {
-          "enemy_id": "0x015040",
-          "level": 31,
-          "exp": 5000,
-          "is_boss": true
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 605,
+                    "num": 1
+                },
+                {
+                    "item_id": 9411,
+                    "num": 2
+                },
+                {
+                    "item_id": 52,
+                    "num": 3
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 67,
+                "group_id": 4
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015040",
+                    "level": 31,
+                    "exp": 5000,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_121231.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_121231.json
@@ -1,10 +1,10 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Abductors’ True Nature",
+    "comment": "The Abductors' True Nature (Redcaps)",
     "quest_id": 20055004,
-    "quest_schedule_id": 364258,
-    "base_level": 31,
+    "quest_schedule_id": 121231,
+    "base_level": 19,
     "minimum_item_rank": 0,
     "discoverable": false,
     "area_id": "MysreeForest",
@@ -13,30 +13,30 @@
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1020
+            "amount": 520
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 160
+            "amount": 100
         },
         {
             "type": "exp",
-            "amount": 1430
+            "amount": 750
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 605,
+                    "item_id": 8173,
                     "num": 1
                 },
                 {
-                    "item_id": 9411,
+                    "item_id": 9376,
                     "num": 2
                 },
                 {
-                    "item_id": 52,
+                    "item_id": 9368,
                     "num": 3
                 }
             ]
@@ -50,10 +50,28 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x015040",
-                    "level": 31,
-                    "exp": 5000,
-                    "is_boss": true
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x011110",
+                    "level": 19,
+                    "exp": 200,
+                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_364258.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_364258.json
@@ -1,10 +1,10 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Abductors’ True Nature",
+    "comment": "The Abductors' True Nature (Troll)",
     "quest_id": 20055004,
-    "quest_schedule_id": 121231,
-    "base_level": 19,
+    "quest_schedule_id": 364258,
+    "base_level": 31,
     "minimum_item_rank": 0,
     "discoverable": false,
     "area_id": "MysreeForest",
@@ -13,30 +13,30 @@
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 520
+            "amount": 1020
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 100
+            "amount": 160
         },
         {
             "type": "exp",
-            "amount": 750
+            "amount": 1430
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 8173,
+                    "item_id": 605,
                     "num": 1
                 },
                 {
-                    "item_id": 9376,
+                    "item_id": 9411,
                     "num": 2
                 },
                 {
-                    "item_id": 9368,
+                    "item_id": 52,
                     "num": 3
                 }
             ]
@@ -50,28 +50,10 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x011110",
-                    "level": 19,
-                    "exp": 200,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x011110",
-                    "level": 19,
-                    "exp": 200,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x011110",
-                    "level": 19,
-                    "exp": 200,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x011110",
-                    "level": 19,
-                    "exp": 200,
-                    "is_boss": false
+                    "enemy_id": "0x015040",
+                    "level": 31,
+                    "exp": 5000,
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070000.json
@@ -1,103 +1,103 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "Seeking Vengeance",
-  "quest_id": 20070000,
-  "base_level": 43,
-  "minimum_item_rank": 0,
-  "discoverable": true,
-  "area_id": "NorthernBetlandPlains",
-  "news_image": 141,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 1410
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 220
-    },
-    {
-      "type": "exp",
-      "amount": 1980
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Seeking Vengeance",
+    "quest_id": 20070000,
+    "base_level": 43,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "NorthernBetlandPlains",
+    "news_image": 141,
+    "rewards": [
         {
-          "item_id": 9297,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1410
         },
         {
-          "item_id": 9420,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 220
         },
         {
-          "item_id": 9402,
-          "num": 3
-        }
-      ]
-    },
-    {
-      "type": "random",
-      "loot_pool": [
+            "type": "exp",
+            "amount": 1980
+        },
         {
-          "item_id": 34,
-          "num": 9,
-          "chance": 1.0
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 299
-      },
-      "enemies": [
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 9297,
+                    "num": 1
+                },
+                {
+                    "item_id": 9420,
+                    "num": 1
+                },
+                {
+                    "item_id": 9402,
+                    "num": 3
+                }
+            ]
+        },
         {
-          "enemy_id": "0x015020",
-          "level": 43,
-          "exp": 12000,
-          "is_boss": true
+            "type": "random",
+            "loot_pool": [
+                {
+                    "item_id": 34,
+                    "num": 9,
+                    "chance": 1.0
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 53,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "npc_id": "Johann",
-      "message_id": 11830
-    },
-    {
-      "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Accept",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 53,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "announce_type": "Update",
-      "npc_id": "Johann",
-      "message_id": 11835
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 299
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015020",
+                    "level": 43,
+                    "exp": 12000,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 53,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Johann",
+            "message_id": 11830
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 53,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Johann",
+            "message_id": 11835
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
@@ -1,72 +1,72 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "The Greenery Falls, Dancing",
-  "quest_id": 20055004,
-  "base_level": 41,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "DeenanWoods",
-  "news_image": 203,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 1120
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 180
-    },
-    {
-      "type": "exp",
-      "amount": 900
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Greenery Falls, Dancing",
+    "quest_id": 20105005,
+    "base_level": 41,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "DeenanWoods",
+    "news_image": 203,
+    "rewards": [
         {
-          "item_id": 7726,
-          "num": 3
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1120
         },
         {
-          "item_id": 9419,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 180
         },
         {
-          "item_id": 9401,
-          "num": 3
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 340
-      },
-      "enemies": [
+            "type": "exp",
+            "amount": 900
+        },
         {
-          "enemy_id": "0x015031",
-          "level": 41,
-          "exp": 10000,
-          "is_boss": true
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 7726,
+                    "num": 3
+                },
+                {
+                    "item_id": 9419,
+                    "num": 1
+                },
+                {
+                    "item_id": 9401,
+                    "num": 3
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 340
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015031",
+                    "level": 41,
+                    "exp": 10000,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestProgress.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestProgress.cs
@@ -10,10 +10,9 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
     public class QuestProgress
     {
         public uint CharacterCommonId { get; set; }
-        public QuestId QuestId { get; set; }
+        public uint QuestScheduleId { get; set; }
         public QuestType QuestType { get; set; }
         public uint Step { get; set; }
-        public uint ? VariantId { get; set; }
     }
 
     public enum QuestProgressStatus : uint

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
@@ -176,8 +176,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
     {
         public uint UniqRewardId { get; set; }
         public uint CharacterCommonId { get; set; }
-        public QuestId QuestId { get; set; }
-        public uint VariantId { get; set; }
+        public uint QuestScheduleId { get; set; }
         public int NumRandomRewards { get; set; }
         public List<int> RandomRewardIndices { get; set; }
 

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -206,7 +206,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool DeleteEquippedCustomSkill(uint commonId, JobId job, byte slotNo) { return true; }
         public bool DeleteNormalSkillParam(uint commonId, JobId job, uint skillNo) { return true; }
         public bool DeletePawn(uint pawnId) { return true; }
-        public bool DeletePriorityQuest(uint characterCommonId, QuestId questId) { return true; }
+        public bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId) { return true; }
         public bool DeleteReleasedWarpPoint(uint characterId, uint warpPointId) { return true; }
         public bool DeleteShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
         public bool DeleteSpSkill(uint pawnId, JobId job, byte spSkillId) { return true; }
@@ -224,8 +224,8 @@ namespace Arrowgene.Ddon.Test.Database
         public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType) { return new List<CompletedQuest>(); }
         public bool CreateMeta(DatabaseMeta meta) { return true; }
         public DatabaseMeta GetMeta() { return new DatabaseMeta(); }
-        public List<QuestId> GetPriorityQuests(uint characterCommonId) { return new List<QuestId>(); }
-        public QuestProgress GetQuestProgressById(uint characterCommonId, QuestId questId) { return new QuestProgress(); }
+        public List<uint> GetPriorityQuestScheduleIds(uint characterCommonId) { return new List<uint>(); }
+        public QuestProgress GetQuestProgressById(uint characterCommonId, uint questScheduleId) { return new QuestProgress(); }
         public List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType) { return new List<QuestProgress>(); }
         public ulong InsertBazaarExhibition(BazaarExhibition exhibition) { return 1; }
         public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards) { return true; }
@@ -247,8 +247,8 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertLearnedCustomSkill(uint commonId, CustomSkill skill) { return true; }
         public bool InsertNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
         public bool InsertPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
-        public bool InsertPriorityQuest(uint characterCommonId, QuestId questId) { return true; }
-        public bool InsertQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step, uint variantId=0) { return true; }
+        public bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId) { return true; }
+        public bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step) { return true; }
         public bool InsertReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
         public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility) { return true; }
         public bool InsertShortcut(uint characterId, CDataShortCut shortcut) { return true; }
@@ -257,7 +257,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertStorage(uint characterId, StorageType storageType, Storage storage) { return true; }
         public bool InsertStorageItem(uint characterId, StorageType storageType, ushort slotNo, uint itemNum, Item item, DbConnection? connectionIn = null) { return true; }
         public bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
-        public bool RemoveQuestProgress(uint characterCommonId, QuestId questId, QuestType questType) { return true; }
+        public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType) { return true; }
         public bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId, DbConnection? connectionIn = null) { return true; }
@@ -327,7 +327,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertIfNotExistsPawnCraftProgress(CraftProgress craftProgress) { return true; }
         public bool UpdatePawnCraftProgress(CraftProgress craftProgress) { return true; }
         public bool DeletePawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId) { return true; }
-        public bool UpdateQuestProgress(uint characterCommonId, QuestId questId, QuestType questType, uint step) { return true; }
+        public bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step) { return true; }
         public bool UpdateReleasedWarpPoint(uint characterId, ReleasedWarpPoint updatedReleasedWarpPoint) { return true; }
         public bool UpdateShortcut(uint characterId, uint oldPageNo, uint oldButtonNo, CDataShortCut updatedShortcut) { return true; }
         public bool UpdateStatusInfo(CharacterCommon character) { return true; }


### PR DESCRIPTION
- Reenables variants of world quests
- Replaces the `VariantQuestId` field with the `QuestScheduleId` field that already exists in most packets.
- Quests which don't specify a quest schedule, have the quest schedule id assigned as the quest id.
- Quests which have a schedule id now have the schedule id append to the name `q<quest_id>_<quest_schedule_id>.json`.

Attempts to address concerns in #438

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
