### PR TITLE
feat: Enable "Unlimited revive refills" course effect

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.Shared.Model.Quest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 
@@ -33,6 +34,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             public double PawnCraftBonus = 0.0;
             public bool DisablePartyExpAdjustment = false;
             public double EnemyBloodOrbMultiplier = 0.0;
+            public bool InfiniteRevive = false;
         };
 
         private void ApplyCourseEffects(uint courseId)
@@ -67,6 +69,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             break;
                         case GPCourseId.BloodOrbUp:
                             _CourseBonus.EnemyBloodOrbMultiplier += (effect.Param0 / 100.0);
+                            break;
+                        case GPCourseId.InfiniteRevive:
+                            _CourseBonus.InfiniteRevive = true;
                             break;
                     }
                 }
@@ -105,6 +110,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             break;
                         case GPCourseId.BloodOrbUp:
                             _CourseBonus.EnemyBloodOrbMultiplier -= (effect.Param0 / 100.0);
+                            break;
+                        case GPCourseId.InfiniteRevive:
+                            _CourseBonus.InfiniteRevive = false;
                             break;
                     }
                 }
@@ -232,6 +240,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
             lock (_CourseBonus)
             {
                 return _CourseBonus.EnemyBloodOrbMultiplier;
+            }
+        }
+
+        public bool InfiniteReviveRefresh()
+        {
+            lock (_CourseBonus)
+            {
+                return _CourseBonus.InfiniteRevive;
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterGetReviveChargeableTimeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterGetReviveChargeableTimeHandler.cs
@@ -22,7 +22,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
            //  Refresh revival at 5:00AM JST.
 
-            if(Server.LastRevivalPowerRechargeTime.ContainsKey(client.Character.CharacterId))
+            if (Server.GpCourseManager.InfiniteReviveRefresh())
+            {
+                res.RemainTime = 0;
+            }
+            else if(Server.LastRevivalPowerRechargeTime.ContainsKey(client.Character.CharacterId))
             {
                 DateTime utcNow = DateTime.UtcNow;
                 TimeZoneInfo jstZone = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");

--- a/Arrowgene.Ddon.LoginServer/Handler/GetCharacterListHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/GetCharacterListHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Arrowgene.Buffers;
@@ -46,18 +47,33 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                 cResponse.CharacterListElement.CurrentJobBaseInfo.Job = c.Job;
                 cResponse.CharacterListElement.CurrentJobBaseInfo.Level = (byte) c.ActiveCharacterJobData.Lv;
 
+                ulong now = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
                 List<CDataGPCourseValid> ValidCourses = new List<CDataGPCourseValid>();
                 foreach (var ValidCourse in _AssetRepo.GPCourseInfoAsset.ValidCourses)
                 {
+                    if (now > ValidCourse.Value.EndTime)
+                    {
+                        continue;
+                    }
+
                     CDataGPCourseValid cDataGPCourseValid = new CDataGPCourseValid()
                     {
                         Id = c.CharacterId,
                         CourseId = ValidCourse.Value.Id,
                         NameA = _AssetRepo.GPCourseInfoAsset.Courses[ValidCourse.Value.Id].Name, // Course Name
                         NameB = _AssetRepo.GPCourseInfoAsset.Courses[ValidCourse.Value.Id].IconPath, // Link to a icon
-                        StartTime = ValidCourse.Value.StartTime,
-                        EndTime = ValidCourse.Value.EndTime,
                     };
+
+                    if ((now >= ValidCourse.Value.StartTime) && (now <= ValidCourse.Value.EndTime))
+                    {
+                        cDataGPCourseValid.StartTime = ValidCourse.Value.StartTime;
+                        cDataGPCourseValid.EndTime = ValidCourse.Value.EndTime;
+                    }
+                    else
+                    {
+                        cDataGPCourseValid.StartTime = ValidCourse.Value.StartTime;
+                    }
 
                     ValidCourses.Add(cDataGPCourseValid);
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/GpCourseInfo.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/GpCourseInfo.json
@@ -226,16 +226,16 @@
         },
         {
             "id": 17,
-            "name": "Arrowgene QOL Course",
+            "name": "Arrowgene Blessing",
             "comment": "Example of custom made course effect.",
             "icon_path": "",
-            "description": "Allows item boxes to be used outside the main city, enable expanded storage tabs and allows craft items to be consumed from the storage box.",
+            "description": "Allows players to use infinite revive refresh, item boxes to be used outside the main city, enable expanded storage tabs and allows craft items to be consumed from the storage box.",
             "url": "",
             "target": 0,
             "priority_grp": 100,
             "priority_same_time": 70,
             "announce_type": 2,
-            "effects": [ 2, 3, 69, 216, 217, 128 ]
+            "effects": [ 1, 2, 3, 69, 216, 217, 128 ]
         },
         {
             "id": 18,


### PR DESCRIPTION
- Added support for unlimited revives in the course manager.
- Renamed "Arrowgene QOL Course" to "Arrowgene Blessing".
- Added unlimited revive effect to "Arrowgene Blessing".
- Fixed issue where ended course still shows up.
- Added support for upcoming course effect to report "activating".

![image](https://github.com/user-attachments/assets/cc82c4a6-3a18-4437-8c2f-e7ef0cf3b9f8)

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
