### PR TITLE
fix: Fix issue with spontaneous world quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -65,9 +65,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // Populate rest of quests for the area
             foreach (var questId in QuestManager.GetWorldQuestIdsByAreaId(packet.Structure.DistributeId))
             {
-                if (activeQuestIds.Contains(questId))
+                if (activeQuestIds.Contains(questId) || client.Party.QuestState.IsCompletedWorldQuest(questId))
                 {
-                    // Skip quests already populated
+                    // Skip quests already populated or completed
                     continue;
                 }
 

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -631,7 +631,7 @@ namespace Arrowgene.Ddon.GameServer.Party
                 client.Character.ContextOwnership.Clear();
             }
             OmManager.ResetAllOmData(InstanceOmData);
-            QuestState.ResetInstanceQuestState();
+            QuestState.ResetInstance();
         }
 
         public PartyMember GetPartyMemberByCharacter(CharacterCommon characterCommon)


### PR DESCRIPTION
- Fixed an issue where world quests completion was not being tracked properly.
- Fixed an issue where the area quest fetch was not cleaning up state properly.
- Added some defensive checks to prevent exceptions from being thrown.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
