### PR TITLE
fix: Fix issues with EXM recruitment board

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
@@ -434,26 +434,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     lock (_Boards)
                     {
-                        foreach (var characterId in data.Members)
-                        {
-                            var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
-                            if (memberClient != null)
-                            {
-                                memberClient.Send(new S2CEntryBoardItemUnreadyNtc());
-                            }
-                        }
-
-                        // Restart the recruitment timer
-                        data.EntryItem.TimeOut = BoardManager.PARTY_BOARD_TIMEOUT;
-                        StartRecruitmentTimer(data.EntryItem.Id, BoardManager.PARTY_BOARD_TIMEOUT);
-                        foreach (var characterId in data.Members)
-                        {
-                            var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
-                            if (memberClient != null)
-                            {
-                                memberClient.Send(new S2CEntryBoardItemTimeoutTimerNtc() { TimeOut = BoardManager.PARTY_BOARD_TIMEOUT });
-                            }
-                        }
+                        RestartRecruitment(entryItemId);
                     }
                 });
 
@@ -461,6 +442,41 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     _Server.TimerManager.CancelTimer(data.ReadyUpTimerId);
                     return false;
+                }
+
+                return true;
+            }
+        }
+
+        public bool RestartRecruitment(uint entryItemId)
+        {
+            lock (_Boards)
+            {
+                var data = GetGroupData(entryItemId);
+                if (data == null)
+                {
+                    return false;
+                }
+
+                foreach (var characterId in data.Members)
+                {
+                    var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
+                    if (memberClient != null)
+                    {
+                        memberClient.Send(new S2CEntryBoardItemUnreadyNtc());
+                    }
+                }
+
+                // Restart the recruitment timer
+                data.EntryItem.TimeOut = BoardManager.PARTY_BOARD_TIMEOUT;
+                StartRecruitmentTimer(data.EntryItem.Id, BoardManager.PARTY_BOARD_TIMEOUT);
+                foreach (var characterId in data.Members)
+                {
+                    var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
+                    if (memberClient != null)
+                    {
+                        memberClient.Send(new S2CEntryBoardItemTimeoutTimerNtc() { TimeOut = BoardManager.PARTY_BOARD_TIMEOUT });
+                    }
                 }
 
                 return true;

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemEntryHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemEntryHandler.cs
@@ -1,46 +1,54 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
-    public class EntryBoardEntryBoardItemEntryHandler : GameRequestPacketHandler<C2SEntryBoardEntryBoardItemEntryReq, S2CEntryBoardEntryBoardItemEntryRes>
+    public class EntryBoardEntryBoardItemEntryHandler : StructurePacketHandler<GameClient, C2SEntryBoardEntryBoardItemEntryReq>
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(EntryBoardEntryBoardItemEntryHandler));
 
+        private DdonGameServer _Server;
+
         public EntryBoardEntryBoardItemEntryHandler(DdonGameServer server) : base(server)
         {
+            _Server = server;
         }
 
-        public override S2CEntryBoardEntryBoardItemEntryRes Handle(GameClient client, C2SEntryBoardEntryBoardItemEntryReq request)
+        public override void Handle(GameClient client, StructurePacket<C2SEntryBoardEntryBoardItemEntryReq> request)
         {
-            var data = Server.BoardManager.GetGroupData(request.EntryId);
+            var data = _Server.BoardManager.GetGroupData(request.Structure.EntryId);
             if (data == null)
             {
-                return new S2CEntryBoardEntryBoardItemEntryRes()
+                client.Send(new S2CEntryBoardEntryBoardItemEntryRes()
                 {
                     Error = (uint)ErrorCode.ERROR_CODE_ENTRY_BOARD_NO_ITEM
-                };
+                });
+                return;
             }
 
             if (data.ContentInProgress)
             {
-                return new S2CEntryBoardEntryBoardItemEntryRes()
+                client.Send(new S2CEntryBoardEntryBoardItemEntryRes()
                 {
                     Error = (uint)ErrorCode.ERROR_CODE_ENTRY_BOARD_ITEM_CREATE_OVER
-                };
+                });
+                return;
             }
 
-            if (!Server.BoardManager.AddCharacterToGroup(data.EntryItem.Id, client.Character))
+            if (!_Server.BoardManager.AddCharacterToGroup(data.EntryItem.Id, client.Character))
             {
-                return new S2CEntryBoardEntryBoardItemEntryRes()
+                client.Send(new S2CEntryBoardEntryBoardItemEntryRes()
                 {
                     Error = (uint)ErrorCode.ERROR_CODE_ENTRY_BOARD_NO_SPACE
-                };
+                });
             }
 
             CDataEntryMemberData memberData;
@@ -59,18 +67,37 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             foreach (var characterId in data.Members)
             {
-                var memberClient = Server.ClientLookup.GetClientByCharacterId(characterId);
+                var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
                 memberClient.Send(ntc);
             }
 
-            Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.EntryBoard);
+            _Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.EntryBoard);
 
-            data.EntryItem.TimeOut = (ushort)Server.BoardManager.GetRecruitmentTimeLeft(data.EntryItem.Id);
+            data.EntryItem.TimeOut = (ushort)_Server.BoardManager.GetRecruitmentTimeLeft(data.EntryItem.Id);
 
-            return new S2CEntryBoardEntryBoardItemEntryRes()
+            client.Send(new S2CEntryBoardEntryBoardItemEntryRes()
             {
                 EntryItem = data.EntryItem
-            };
+            });
+
+            // Work after the response to the request was handeled
+            if (data.Members.Count == data.EntryItem.Param.MaxEntryNum)
+            {
+                _Server.BoardManager.CancelRecruitmentTimer(data.EntryItem.Id);
+                foreach (var characterId in data.Members)
+                {
+                    var memberClient = _Server.ClientLookup.GetClientByCharacterId(characterId);
+                    // Allows the menu to transition
+                    memberClient.Send(new S2CEntryBoardEntryBoardItemReadyNtc()
+                    {
+                        MaxMember = data.EntryItem.Param.MaxEntryNum,
+                        TimeOut = BoardManager.ENTRY_BOARD_READY_TIMEOUT,
+                    });
+                    memberClient.Send(new S2CEntryBoardItemTimeoutTimerNtc() { TimeOut = BoardManager.ENTRY_BOARD_READY_TIMEOUT });
+                }
+
+                _Server.BoardManager.StartReadyUpTimer(data.EntryItem.Id, BoardManager.ENTRY_BOARD_READY_TIMEOUT);
+            }
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
@@ -64,7 +64,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 client.Send(new S2CEntryBoardEntryBoardItemLeaveNtc());
 
+                Server.BoardManager.CancelReadyUpTimer(data.EntryItem.Id);
                 Server.BoardManager.RemoveCharacterFromGroup(client.Character);
+                Server.BoardManager.RestartRecruitment(data.EntryItem.Id);
+
                 Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
             }
 


### PR DESCRIPTION
- Fixed an issue where the party wasn't able to ready up when all slots were filled.
- Fixed an issue where if a member quit after some players pressed ready, that they would be stuck until the timer expired.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
