### PR TITLE
fix: Fix small bugs

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -171,27 +171,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return gWorldQuests[areaId].Select(x => x.QuestId).ToList();
         }
 
-        /**
-         * @brief Magic number derived by taking a known BoardId associated with a QuestId and subtracting the two.
-         * A pattern was noticed that the BoardId values had the same distribution as the QuestId and via some
-         * experimentation this pattern was found and confirmed to work.
-         */
-        private static readonly ulong BOARD_ID_MAGIC_VALUE_CONSTANT = 17179869184UL;
-
         public static Quest GetQuestByBoardId(ulong boardId)
         {
-            uint questId = (uint)(boardId - QuestManager.BOARD_ID_MAGIC_VALUE_CONSTANT);
+            uint questId = BoardManager.GetQuestIdFromBoardId(boardId);
             return GetQuest(questId);
-        }
-
-        public static ulong QuestIdToBoardId(uint questId)
-        {
-            return questId + QuestManager.BOARD_ID_MAGIC_VALUE_CONSTANT;
-        }
-
-        public static ulong QuestIdToBoardId(QuestId questId)
-        {
-            return QuestIdToBoardId((uint)questId);
         }
 
         public static List<Quest> GetTutorialQuestsByStageNo(uint stageNo)

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -539,6 +539,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new EntryBoardEntryRecreateHandler(this));
             AddHandler(new EntryBoardItemKickHandler(this));
             AddHandler(new EntryBoardEntryBoardItemExtendTimeoutHandler(this));
+            AddHandler(new EntryBoardPartyRecruitCategoryListHandler(this));
 
             AddHandler(new ServerGameTimeGetBaseinfoHandler(this));
             AddHandler(new ServerGetGameSettingHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterCharacterDownHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterCharacterDownHandler.cs
@@ -11,7 +11,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SCharacterCharacterDownNtc> packet)
         {
-            //Unsure what CAPCOM wanted with this packet.
+            // Unsure what CAPCOM wanted with this packet.
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemCreateHandler.cs
@@ -26,12 +26,20 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // var pcap = new S2CEntryBoardEntryBoardItemCreateRes.Serializer().Read(GameFull.Dump_710.AsBuffer())
 
             var data = Server.BoardManager.CreateNewGroup(request.BoardId, request.CreateParam, request.Password, client.Character);
-            // Override some defaults using JSON config
-            var quest = QuestManager.GetQuestByBoardId(request.BoardId);
-            if (quest != null)
+
+            if (BoardManager.BoardIdIsExm(request.BoardId))
             {
+                // Override some defaults using JSON config
+                var quest = QuestManager.GetQuestByBoardId(request.BoardId);
                 data.EntryItem.Param.MinEntryNum = (ushort)quest.MissionParams.MinimumMembers;
                 data.EntryItem.Param.MaxEntryNum = (ushort)quest.MissionParams.MaximumMembers;
+            }
+            else if (BoardManager.BoardIdIsRecruitmentCategory(request.BoardId))
+            {
+                uint recruitmentCategory = BoardManager.RecruitmentCategoryFromBoardId(request.BoardId);
+                var recruitmentData = Server.AssetRepository.RecruitmentBoardCategoryAsset.RecruitmentBoardCategories[recruitmentCategory];
+                data.EntryItem.Param.MinEntryNum = recruitmentData.PartyMin;
+                data.EntryItem.Param.MaxEntryNum = recruitmentData.PartyMax;
             }
 
             data.EntryItem.PartyLeaderCharacterId = data.PartyLeaderCharacterId;

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemReadyHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemReadyHandler.cs
@@ -1,14 +1,9 @@
-using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
-using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -65,7 +60,19 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     var characterId = members[i];
                     var memberClient = Server.ClientLookup.GetClientByCharacterId(characterId);
 
-                    party.Invite(memberClient, hostClient);
+                    var invitedMember = party.Invite(memberClient, hostClient);
+                    if (invitedMember.HasError)
+                    {
+                        Logger.Error($"(EntryBoard) Failed to invite CharacterId={memberClient.Character.CharacterId} to PartyId={party.Id}");
+                        continue;
+                    }
+
+                    var partyMember = party.Accept(memberClient);
+                    if (partyMember.HasError)
+                    {
+                        Logger.Error($"(EntryBoard) CharacterId={memberClient.Character.CharacterId} failed to accept invite for PartyId={party.Id}");
+                        continue;
+                    }
 
                     inviteAcceptNtc.MemberIndex = i;
                     memberClient.Send(inviteAcceptNtc);

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardPartyRecruitCategoryListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardPartyRecruitCategoryListHandler.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Logging;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class EntryBoardPartyRecruitCategoryListHandler : GameRequestPacketHandler<C2SEntryBoardPartyRecruitCategoryListReq, S2CEntryBoardPartyRecruitCategoryListRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(EntryBoardPartyRecruitCategoryListHandler));
+
+        public EntryBoardPartyRecruitCategoryListHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CEntryBoardPartyRecruitCategoryListRes Handle(GameClient client, C2SEntryBoardPartyRecruitCategoryListReq request)
+        {
+            var res = new S2CEntryBoardPartyRecruitCategoryListRes();
+            foreach (var (categoryId, data) in Server.AssetRepository.RecruitmentBoardCategoryAsset.RecruitmentBoardCategories)
+            {
+                res.Unk1List.Add(new CDataEntryRecruitCategoryData()
+                {
+                    CategoryId = data.CategoryId,
+                    CategoryName = data.CategoryName,
+                    NumGroups = (uint)Server.BoardManager.GetGroupsForBoardId(BoardManager.BoardIdFromRecruitmentCategory(data.CategoryId)).Where(x => !x.ContentInProgress).ToList().Count
+                });
+            }
+            return res;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Dump;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.GameServer.Quests;
@@ -40,13 +41,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 return;
             }
 
+            var partyLeader = party.Leader.Client.Character;
+
             res.ContentNumber = party.ContentId;
-            if (res.ContentNumber != 0)
+            if (BoardManager.BoardIdIsExm(party.ContentId))
             {
                 Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Contents);
             }
-
-            var partyLeader = party.Leader.Client.Character;
+            else
+            {
+                Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, partyLeader, OnlineStatus.PtLeader);
+                if (partyLeader.CharacterId != client.Character.CharacterId)
+                {
+                    Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.PtMember);
+                }
+            }
 
             S2CPartyPartyJoinNtc ntc = new S2CPartyPartyJoinNtc();
             ntc.HostCharacterId = party.Host.Client.Character.CharacterId;

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
@@ -28,6 +28,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 return;
             }
 
+            party.Leave(client);
+            Logger.Info(client, $"Left PartyId:{party.Id}");
 
             if (party.ContentId != 0)
             {
@@ -35,8 +37,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 if (!data.IsInRecreate)
                 {
                     Server.BoardManager.RemoveCharacterFromGroup(client.Character);
-                    Server.PartyQuestContentManager.RemovePartyMember(party.Id, client.Character);
                     Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
+
+                    if (BoardManager.BoardIdIsExm(party.ContentId))
+                    {
+                        Server.PartyQuestContentManager.RemovePartyMember(party.Id, client.Character);
+                    }
+
+                    if (party.MemberCount() == 1 && party.Leader != null && !BoardManager.BoardIdIsExm(party.ContentId))
+                    {
+                        Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, party.Leader.Client.Character, OnlineStatus.Online);
+                    }
                 }
                 else
                 {
@@ -47,10 +58,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
             }
-            
-
-            party.Leave(client);
-            Logger.Info(client, $"Left PartyId:{party.Id}");
 
             S2CPartyPartyLeaveNtc partyLeaveNtc = new S2CPartyPartyLeaveNtc();
             partyLeaveNtc.CharacterId = client.Character.CharacterId;

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsRecruitListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsRecruitListHandler.cs
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     QuestScheduleId = (uint) quest.QuestScheduleId,
                     QuestId = (uint) quest.QuestId,
-                    GroupsRecruiting = (uint) Server.BoardManager.GetGroupsForBoardId(QuestManager.QuestIdToBoardId(quest.QuestId)).Where(x => !x.ContentInProgress).ToList().Count
+                    GroupsRecruiting = (uint) Server.BoardManager.GetGroupsForBoardId(BoardManager.QuestIdToExmBoardId(quest.QuestId)).Where(x => !x.ContentInProgress).ToList().Count
                 });
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestPlayStartTimerHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestPlayStartTimerHandler.cs
@@ -25,7 +25,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CQuestPlayStartTimerRes Handle(GameClient client, C2SQuestPlayStartTimerReq request)
         {
-            if (client.Party.ContentId == 0)
+            if (!BoardManager.BoardIdIsExm(client.Party.ContentId))
             {
                 // See on the MSQ for the Spirit Dragon, this handler gets called
                 // even though there is no timer present in the quest

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -70,10 +70,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     client.Party.ResetInstance();
                     client.Party.SendToAll(new S2CInstanceAreaResetNtc());
+                    // Next two packets seem to be send when transitioning to a safe area in all pcaps
+                    // not sure what they do though
+                    client.Party.SendToAll(new S2C_SEASON_62_38_16_NTC());
+                    // client.Party.SendToAll(new S2C_SEASON_62_39_16_NTC) ??? Does this go to all, it has a character ID
                 }
             }
 
-            if (client.Party.ContentInProgress)
+            if (client.Party.ContentInProgress && BoardManager.BoardIdIsExm(client.Party.ContentId))
             {
                 var quest = QuestManager.GetQuestByBoardId(client.Party.ContentId);
                 if (quest != null)

--- a/Arrowgene.Ddon.GameServer/Handler/WarpGetReturnLocationHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/WarpGetReturnLocationHandler.cs
@@ -1,6 +1,8 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using System.Collections.Generic;
 
@@ -84,7 +86,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                if (SafeStageRedirect.ContainsKey(client.Character.LastSafeStageId))
+                if (BoardManager.BoardIdIsExm(client.Party.ContentId))
+                {
+                    response.JumpLocation.stageId = client.Character.Stage.Id;
+                }
+                else if (SafeStageRedirect.ContainsKey(client.Character.LastSafeStageId))
                 {
                     response.JumpLocation.stageId = SafeStageRedirect[client.Character.LastSafeStageId];
                 }

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -617,6 +617,7 @@ namespace Arrowgene.Ddon.GameServer.Party
         public void ResetInstance()
         {
             InstanceEnemyManager.Clear();
+            Contexts.Clear();
             foreach (GameClient client in Clients)
             {
                 client.InstanceGatheringItemManager.Clear();

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -199,7 +199,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 }
             }
 
-            if (questBlock.BlockType == QuestBlockType.ExtendTime && client.Party.ContentId != 0)
+            if (questBlock.BlockType == QuestBlockType.ExtendTime && BoardManager.BoardIdIsExm(client.Party.ContentId))
             {
                 var newEndTime = server.PartyQuestContentManager.ExtendTimer(client.Party.Id, questBlock.TimeAmount);
                 client.Party.SendToAll(new S2CQuestPlayAddTimerNtc() { PlayEndDateTime = newEndTime });
@@ -316,7 +316,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
             if (questBlock.Announcements.EndContentsPurpose != 0)
             {
-                resultCommands.Add(QuestManager.ResultCommand.AddEndContentsPurpose(questBlock.Announcements.EndContentsPurpose, 0));
+                resultCommands.Add(QuestManager.ResultCommand.AddEndContentsPurpose(questBlock.Announcements.EndContentsPurpose, 1));
             }
 
             foreach (var item in questBlock.HandPlayerItems)

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -533,12 +533,13 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             ResetEnemiesForStage(client, stageId);
 
-            // client.Party.SendToAll(new S2C_63_11_16_NTC() { StageNo = res.StageNo });
             // TODO: Figure out what these do
-            // client.Party.SendToAll(new S2CSituationDataStartNtc() { Unk0 = 1 });
+            client.Party.SendToAll(new S2C_63_0_16_NTC() { Unk0 = 2 });
+            client.Party.SendToAll(new S2C_63_11_16_NTC() { StageNo = (uint) StageManager.ConvertIdToStageNo(stageId) });
 #if false
-                var pcap2 = new S2CSituationDataUpdateObjectivesNtc.Serializer().Read(pcap2_data);
-                client.Party.SendToAll(pcap2);
+            // S2C_63_2_16_NTC appears to have objective data inside of it
+            var pcap2 = new S2CSituationDataUpdateObjectivesNtc.Serializer().Read(pcap2_data);
+            client.Party.SendToAll(pcap2);
 #endif
         }
 

--- a/Arrowgene.Ddon.Rpc/Command/InfoCommand.cs
+++ b/Arrowgene.Ddon.Rpc/Command/InfoCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.Shared.Model;
@@ -40,8 +40,13 @@ namespace Arrowgene.Ddon.Rpc.Command
         public RpcCommandResult Execute(DdonGameServer gameServer)
         {
             Infos.Clear();
-            foreach (GameClient client in gameServer.Clients)
+            foreach (GameClient client in gameServer.ClientLookup.GetAll())
             {
+                if (client == null || client.Character == null)
+                {
+                    continue;
+                }
+
                 Info info = new Info();
                 info.X = client.Character.X;
                 info.Y = client.Character.Y;
@@ -50,6 +55,7 @@ namespace Arrowgene.Ddon.Rpc.Command
                 info.StageId = client.Character.Stage.Id;
                 info.GroupId = client.Character.Stage.GroupId;
                 info.LayerNo = client.Character.Stage.LayerNo;
+
                 Account account = client.Account;
                 if (account != null)
                 {

--- a/Arrowgene.Ddon.Shared/Asset/RecruitmentBoardCategoryAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/RecruitmentBoardCategoryAsset.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Asset
+{
+    public class BoardCategory
+    {
+        public BoardCategory()
+        {
+            CategoryName = string.Empty;
+        }
+
+        public string CategoryName {  get; set; }
+        public uint CategoryId { get; set; }
+        public ushort PartyMin { get; set; }
+        public ushort PartyMax { get; set; }
+    }
+
+    public class RecruitmentBoardCategoryAsset
+    {
+        public RecruitmentBoardCategoryAsset()
+        {
+            RecruitmentBoardCategories = new Dictionary<uint, BoardCategory>();
+        }
+
+        public Dictionary<uint, BoardCategory> RecruitmentBoardCategories { get; set; }
+    }
+}

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -815,7 +815,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
             }
 
             announcements.EndContentsPurpose = 0;
-            if (jBlock.TryGetProperty("end_contents_announce", out JsonElement jEndContentsPurpose))
+            if (jBlock.TryGetProperty("end_contents_purpose", out JsonElement jEndContentsPurpose))
             {
                 announcements.EndContentsPurpose = jEndContentsPurpose.GetInt32();
             }

--- a/Arrowgene.Ddon.Shared/AssetReader/RecruitmentBoardCategoryDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/RecruitmentBoardCategoryDeserializer.cs
@@ -1,0 +1,49 @@
+using Arrowgene.Ddon.Shared.Asset;
+using Arrowgene.Logging;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Arrowgene.Ddon.Shared.AssetReader
+{
+    public class RecruitmentBoardCategoryDeserializer : IAssetDeserializer<RecruitmentBoardCategoryAsset>
+    {
+        private static readonly ILogger Logger = LogProvider.Logger(typeof(SecretAbilityDeserializer));
+
+        public RecruitmentBoardCategoryAsset ReadPath(string path)
+        {
+            Logger.Info($"Reading {path}");
+
+            RecruitmentBoardCategoryAsset asset = new RecruitmentBoardCategoryAsset();
+
+            string json = File.ReadAllText(path);
+            JsonDocument document = JsonDocument.Parse(json);
+
+            foreach (var category in document.RootElement.EnumerateArray().ToList())
+            {
+                var data = new BoardCategory()
+                {
+                    CategoryId = category.GetProperty("id").GetUInt32(),
+                    CategoryName = category.GetProperty("name").GetString()
+                };
+
+                data.PartyMin = 2;
+                if (category.TryGetProperty("party_min", out JsonElement jPartyMin))
+                {
+                    data.PartyMin = jPartyMin.GetUInt16();
+                }
+
+                data.PartyMax = 4;
+                if (category.TryGetProperty("party_min", out JsonElement jPartyMax))
+                {
+                    data.PartyMax = jPartyMax.GetUInt16();
+                }
+
+                asset.RecruitmentBoardCategories[data.CategoryId] = data;
+            }
+
+            return asset;
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/AssetRepository.cs
+++ b/Arrowgene.Ddon.Shared/AssetRepository.cs
@@ -46,6 +46,7 @@ namespace Arrowgene.Ddon.Shared
         public const string PawnCostReductionKey = "PawnCostReduction.json"; 
         public const string BitterblackMazeKey = "BitterblackMaze.json";
         public const string QuestDropItemsKey = "QuestEnemyDrops.json";
+        public const string RecruitmentBoardCategoryKey = "RecruitmentGroups.json";
 
         private static readonly ILogger Logger = LogProvider.Logger(typeof(AssetRepository));
 
@@ -91,6 +92,7 @@ namespace Arrowgene.Ddon.Shared
             PawnCostReductionAsset = new PawnCostReductionAsset();
             BitterblackMazeAsset = new BitterblackMazeAsset();
             QuestDropItemAsset = new QuestDropItemAsset();
+            RecruitmentBoardCategoryAsset = new RecruitmentBoardCategoryAsset();
         }
 
         public List<CDataErrorMessage> ClientErrorCodes { get; private set; }
@@ -120,6 +122,7 @@ namespace Arrowgene.Ddon.Shared
         public PawnCostReductionAsset PawnCostReductionAsset { get; private set; }
         public BitterblackMazeAsset BitterblackMazeAsset { get; private set; }
         public QuestDropItemAsset QuestDropItemAsset { get; private set; }
+        public RecruitmentBoardCategoryAsset RecruitmentBoardCategoryAsset { get; private set; }
 
         public void Initialize()
         {
@@ -149,6 +152,8 @@ namespace Arrowgene.Ddon.Shared
             RegisterAsset(value => PawnCostReductionAsset = value, PawnCostReductionKey, new PawnCostReductionAssetDeserializer());
             RegisterAsset(value => BitterblackMazeAsset = value, BitterblackMazeKey, new BitterblackMazeAssetDeserializer());
             RegisterAsset(value => QuestDropItemAsset = value, QuestDropItemsKey, new QuestDropAssetDeserializer());
+            RegisterAsset(value => RecruitmentBoardCategoryAsset = value, RecruitmentBoardCategoryKey, new RecruitmentBoardCategoryDeserializer());
+
             var questAssetDeserializer = new QuestAssetDeserializer(this.NamedParamAsset, QuestDropItemAsset);
             questAssetDeserializer.LoadQuestsFromDirectory(Path.Combine(_directory.FullName, QuestAssestKey), QuestAssets);
         }

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -147,6 +147,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataEntryItemParam.Serializer());
             Create(new CDataEntryMemberData.Serializer());
             Create(new CDataEntryBoardItemSearchParameter.Serializer());
+            Create(new CDataEntryRecruitCategoryData.Serializer());
             Create(new CDataRaidBossPlayStartData.Serializer());
             Create(new CDataRaidBossEnemyParam.Serializer());
 
@@ -487,6 +488,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SEntryBoardEntryBoardItemRecreateReq.Serializer());
             Create(new C2SEntryBoardItemKickReq.Serializer());
             Create(new C2SEntryBoardEntryBoardItemExtendTimeoutReq.Serializer());
+            Create(new C2SEntryBoardPartyRecruitCategoryListReq.Serializer());
 
             Create(new C2SAchievementReceivableRewardNtc.Serializer());
             Create(new C2SAchievementCompleteNtc.Serializer());
@@ -900,6 +902,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CEntryBoardItemPartyNtc.Serializer());
             Create(new S2CEntryBoardItemKickRes.Serializer());
             Create(new S2CEntryBoardEntryBoardItemExtendTimeoutRes.Serializer());
+            Create(new S2CEntryBoardPartyRecruitCategoryListRes.Serializer());
 
             Create(new S2CEquipChangeCharacterEquipJobItemNtc.Serializer());
             Create(new S2CEquipChangeCharacterEquipJobItemRes.Serializer());
@@ -1176,7 +1179,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CServerWeatherForecastGetRes.Serializer());
             Create(new S2CServerTimeUpdateNtc.Serializer());
 
-            Create(new S2CSituationDataStartNtc.Serializer());
+            Create(new S2C_63_0_16_NTC.Serializer());
             Create(new S2CSituationDataUpdateObjectivesNtc.Serializer());
             Create(new S2CSituationDataEndNtc.Serializer());
             Create(new S2C_63_7_16_NTC.Serializer());
@@ -1226,6 +1229,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CSkillRegisterPresetAbilityRes.Serializer());
             Create(new S2CSkillSetPresetAbilityNameRes.Serializer());
             Create(new S2CSkillSetPresetAbilityListRes.Serializer());
+
+            Create(new S2C_SEASON_62_38_16_NTC.Serializer());
 
             Create(new S2CSetCommunicationShortcutRes.Serializer());
             Create(new S2CSetShortcutRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SEntryBoardPartyRecruitCategoryListReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SEntryBoardPartyRecruitCategoryListReq.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SEntryBoardPartyRecruitCategoryListReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_ENTRY_BOARD_PARTY_RECRUIT_CATEGORY_LIST_REQ;
+
+        public C2SEntryBoardPartyRecruitCategoryListReq()
+        {
+        }
+
+        public class Serializer : PacketEntitySerializer<C2SEntryBoardPartyRecruitCategoryListReq>
+        {
+            public override void Write(IBuffer buffer, C2SEntryBoardPartyRecruitCategoryListReq obj)
+            {
+            }
+
+            public override C2SEntryBoardPartyRecruitCategoryListReq Read(IBuffer buffer)
+            {
+                C2SEntryBoardPartyRecruitCategoryListReq obj = new C2SEntryBoardPartyRecruitCategoryListReq();
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CEntryBoardPartyRecruitCategoryListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CEntryBoardPartyRecruitCategoryListRes.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CEntryBoardPartyRecruitCategoryListRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_ENTRY_BOARD_PARTY_RECRUIT_CATEGORY_LIST_RES;
+
+        public S2CEntryBoardPartyRecruitCategoryListRes()
+        {
+            Unk1List = new List<CDataEntryRecruitCategoryData>();
+        }
+
+        public uint Unk0 { get; set; }
+        public List<CDataEntryRecruitCategoryData> Unk1List { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CEntryBoardPartyRecruitCategoryListRes>
+        {
+            public override void Write(IBuffer buffer, S2CEntryBoardPartyRecruitCategoryListRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteUInt32(buffer, obj.Unk0);
+                WriteEntityList(buffer, obj.Unk1List);
+            }
+
+            public override S2CEntryBoardPartyRecruitCategoryListRes Read(IBuffer buffer)
+            {
+                S2CEntryBoardPartyRecruitCategoryListRes obj = new S2CEntryBoardPartyRecruitCategoryListRes();
+                ReadServerResponse(buffer, obj);
+                obj.Unk0 = ReadUInt32(buffer);
+                obj.Unk1List = ReadEntityList<CDataEntryRecruitCategoryData>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_63_0_16_NTC.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_63_0_16_NTC.cs
@@ -4,22 +4,22 @@ using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 {
-    public class S2CSituationDataStartNtc : IPacketStructure
+    public class S2C_63_0_16_NTC : IPacketStructure
     {
         public PacketId Id => PacketId.S2C_63_0_16_NTC;
 
         public uint Unk0 { get; set; }
 
-        public class Serializer : PacketEntitySerializer<S2CSituationDataStartNtc>
+        public class Serializer : PacketEntitySerializer<S2C_63_0_16_NTC>
         {
-            public override void Write(IBuffer buffer, S2CSituationDataStartNtc obj)
+            public override void Write(IBuffer buffer, S2C_63_0_16_NTC obj)
             {
                 WriteUInt32(buffer, obj.Unk0);
             }
 
-            public override S2CSituationDataStartNtc Read(IBuffer buffer)
+            public override S2C_63_0_16_NTC Read(IBuffer buffer)
             {
-                S2CSituationDataStartNtc obj = new S2CSituationDataStartNtc();
+                S2C_63_0_16_NTC obj = new S2C_63_0_16_NTC();
                 obj.Unk0 = ReadUInt32(buffer);
                 return obj;
             }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_SEASON_62_38_16_NTC.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_SEASON_62_38_16_NTC.cs
@@ -1,0 +1,29 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2C_SEASON_62_38_16_NTC : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_SEASON_62_38_16_NTC;
+
+        public S2C_SEASON_62_38_16_NTC()
+        {
+        }
+
+        public uint StageNo { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2C_SEASON_62_38_16_NTC>
+        {
+            public override void Write(IBuffer buffer, S2C_SEASON_62_38_16_NTC obj)
+            {
+            }
+
+            public override S2C_SEASON_62_38_16_NTC Read(IBuffer buffer)
+            {
+                S2C_SEASON_62_38_16_NTC obj = new S2C_SEASON_62_38_16_NTC();
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataEntryRecruitCategoryData.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataEntryRecruitCategoryData.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataEntryRecruitCategoryData
+    {
+        public CDataEntryRecruitCategoryData()
+        {
+            CategoryName = string.Empty;
+        }
+
+        public uint CategoryId { get; set; }
+        public string CategoryName { get; set; }
+        public uint NumGroups { get; set; }
+
+        public class Serializer : EntitySerializer<CDataEntryRecruitCategoryData>
+        {
+            public override void Write(IBuffer buffer, CDataEntryRecruitCategoryData obj)
+            {
+                WriteUInt32(buffer, obj.CategoryId);
+                WriteMtString(buffer, obj.CategoryName);
+                WriteUInt32(buffer, obj.NumGroups);
+            }
+
+            public override CDataEntryRecruitCategoryData Read(IBuffer buffer)
+            {
+                CDataEntryRecruitCategoryData obj = new CDataEntryRecruitCategoryData();
+                obj.CategoryId = ReadUInt32(buffer);
+                obj.CategoryName = ReadMtString(buffer);
+                obj.NumGroups = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/RecruitmentGroups.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/RecruitmentGroups.json
@@ -1,0 +1,30 @@
+[
+    {
+        "id": 1,
+        "name": "Main Story Progress"
+    },
+    {
+        "id": 2,
+        "name": "Open World Exploration"
+    },
+    {
+        "id": 3,
+        "name": "Earn EXP/PP"
+    },
+    {
+        "id": 4,
+        "name": "Earn Gold"
+    },
+    {
+        "id": 5,
+        "name": "Earn BO/HO"
+    },
+    {
+        "id": 6,
+        "name": "Collect Materials"
+    },
+    {
+        "id": 7,
+        "name": "Seasonal Events"
+    }
+]

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -297,9 +297,9 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_CHARACTER_2_11_16_NTC = new PacketId(2, 11, 16, "S2C_CHARACTER_2_11_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId C2S_CHARACTER_COMMUNITY_CHARACTER_STATUS_GET_REQ = new PacketId(2, 12, 1, "C2S_CHARACTER_COMMUNITY_CHARACTER_STATUS_GET_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_CHARACTER_COMMUNITY_CHARACTER_STATUS_GET_RES = new PacketId(2, 12, 2, "S2C_CHARACTER_COMMUNITY_CHARACTER_STATUS_GET_RES", ServerType.Game, PacketSource.Server); // コミュニティキャラクターステータス取得要求に
-        public static readonly PacketId C2S_CHARACTER_CHARACTER_DOWN_NTC = new PacketId(2, 13, 16, "S2C_CHARACTER_CHARACTER_DOWN_NTC", ServerType.Game, PacketSource.Client, "S2C_CHARACTER_2_13_16_NTC");
-        public static readonly PacketId C2S_CHARACTER_CHARACTER_DOWN_CANCEL_NTC = new PacketId(2, 14, 16, "S2C_CHARACTER_CHARACTER_DOWN_CANCEL_NTC", ServerType.Game, PacketSource.Client, "S2C_CHARACTER_2_14_16_NTC");
-        public static readonly PacketId C2S_CHARACTER_CHARACTER_DEAD_NTC = new PacketId(2, 15, 16, "S2C_CHARACTER_CHARACTER_DEAD_NTC", ServerType.Game, PacketSource.Client, "S2C_CHARACTER_2_15_16_NTC");
+        public static readonly PacketId C2S_CHARACTER_CHARACTER_DOWN_NTC = new PacketId(2, 13, 16, "C2S_CHARACTER_CHARACTER_DOWN_NTC", ServerType.Game, PacketSource.Client, "C2S_CHARACTER_2_13_16_NTC");
+        public static readonly PacketId C2S_CHARACTER_CHARACTER_DOWN_CANCEL_NTC = new PacketId(2, 14, 16, "C2S_CHARACTER_CHARACTER_DOWN_CANCEL_NTC", ServerType.Game, PacketSource.Client, "C2S_CHARACTER_2_14_16_NTC");
+        public static readonly PacketId C2S_CHARACTER_CHARACTER_DEAD_NTC = new PacketId(2, 15, 16, "C2S_CHARACTER_CHARACTER_DEAD_NTC", ServerType.Game, PacketSource.Client, "C2S_CHARACTER_2_15_16_NTC");
         public static readonly PacketId C2S_CHARACTER_CHARACTER_POINT_REVIVE_REQ = new PacketId(2, 16, 1, "C2S_CHARACTER_CHARACTER_POINT_REVIVE_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_CHARACTER_CHARACTER_POINT_REVIVE_RES = new PacketId(2, 16, 2, "S2C_CHARACTER_CHARACTER_POINT_REVIVE_RES", ServerType.Game, PacketSource.Server); // キャラクタ復活(復活力消費)に
         public static readonly PacketId C2S_CHARACTER_CHARACTER_GOLDEN_REVIVE_REQ = new PacketId(2, 17, 1, "C2S_CHARACTER_CHARACTER_GOLDEN_REVIVE_REQ", ServerType.Game, PacketSource.Client);


### PR DESCRIPTION
- Fixed an issue where contexts were not properly cleared after resetting the instance.
- Fixed an issue where a NPE is hit in the RPC info command when players are logging in.
- Attempt to address an issue about what happens to a player when they die during an EXM.
- Enabled non-exm recruitment from the recruitment board.
- Send some unknown packets found during EXM exploration but unsure what they do.
- Fixed some packets which were named as S2C but were actually C2S.
- Fixed parsing for adding end contents purpose.
- Fixed unexpected party invite expiration.

![image](https://github.com/user-attachments/assets/2075bd19-c609-43d1-b025-414c7263ceef)

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
