### PR TITLE
adjustments: Enhance rewards for EXM

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
@@ -26,6 +26,10 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 800
         }
     ],
     "enemy_groups" : [
@@ -286,6 +290,7 @@
                     "named_enemy_params_id": 631,
                     "level": 58,
                     "exp": 0,
+                    "blood_orbs": 200,
                     "is_boss": true
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50102020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50102020.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1500
+        },
+        {
+            "type": "exp",
+            "amount": 25000
         }
     ],
     "enemy_groups" : [
@@ -196,6 +204,7 @@
                     "index": 0,
                     "level": 60,
                     "exp": 0,
+                    "blood_orbs": 200,
                     "named_enemy_params_id": 682,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50103020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50103020.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1500
+        },
+        {
+            "type": "exp",
+            "amount": 25000
         }
     ],
     "enemy_groups" : [
@@ -177,6 +185,7 @@
                     "enemy_id": "0x015711",
                     "level": 60,
                     "exp": 0,
+                    "blood_orbs": 100,
                     "is_boss": true
                 },
                 {
@@ -184,6 +193,7 @@
                     "enemy_id": "0x015840",
                     "level": 60,
                     "exp": 0,
+                    "blood_orbs": 100,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1500
+        },
+        {
+            "type": "exp",
+            "amount": 25000
         }
     ],
     "enemy_groups" : [
@@ -41,6 +49,7 @@
                     "enemy_id": "0x021002",
                     "level": 60,
                     "exp": 0,
+                    "blood_orbs": 1000,
                     "named_enemy_params_id": 440,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1550
+        },
+        {
+            "type": "exp",
+            "amount": 35000
         }
     ],
     "enemy_groups" : [
@@ -33,19 +41,98 @@
             "comment": "Boss",
             "stage_id": {
                 "id": 433,
-                "group_id": 1
+                "group_id": 0
             },
             "enemies": [
                 {
                     "comment": "Scourge",
-                    "enemy_id": "0x071310",
+                    "enemy_id": "0x020606",
                     "level": 65,
                     "exp": 0,
                     "is_boss": true,
-                    "infection_type": 1,
+                    "blood_orbs": 500,
                     "named_enemy_params_id": 1674
                 }
             ]
+        },
+        {
+            "comment": "Foundation Adds",
+            "stage_id": {
+                "id": 433,
+                "group_id": 1
+            },
+            "enemies": [
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 65,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 65,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 65,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 65,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                },
+                {
+                    "comment": "Grimwarg",
+                    "enemy_id": "0x010205",
+                    "level": 65,
+                    "exp": 0,
+                    "infection_type": 1,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                },
+                {
+                    "comment": "Grimwarg",
+                    "enemy_id": "0x010205",
+                    "level": 65,
+                    "exp": 0,
+                    "infection_type": 1,
+                    "repop_count": 50,
+                    "repop_wait_second": 45,
+                    "enemy_target_types_id": 1,
+                    "named_enemy_params_id": 1430
+                }
+            ]
+        },
+        {
+            "comment": "Blocks Monsters from Spawning",
+            "stage_id": {
+                "id": 433,
+                "group_id": 4
+            },
+            "enemies": []
         }
     ],
     "processes": [
@@ -55,7 +142,10 @@
                     "type": "IsGatherPartyInStage",
                     "stage_id": {
                         "id": 433
-                    }
+                    },
+                    "result_commands": [
+                        {"type": "DecideDivideArea", "Param1": 113, "Param2": 2}
+                    ]
                 },
                 {
                     "type": "KillGroup",
@@ -69,19 +159,13 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "NoticeInterruptContents"}
-                    ],
-                    "result_commands": [
-                        {"type": "SetCheckPoint"}
+                        {"type": "EmHpLess", "Param1": 113, "Param2": 0, "Param3": 0, "Param4": 50}
                     ]
                 },
                 {
-                    "type": "Raw",
-                    "result_commands": [
-                        {"type": "ReturnCheckPointEx", "Param": 0},
-                        {"type": "ReturnCheckPointEx", "Param": 1},
-                        {"type": "EndEndQuest"}
-                    ]
+                    "comment": "Spawn",
+                    "type": "SpawnGroup",
+                    "groups": [1]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1600
+        },
+        {
+            "type": "exp",
+            "amount": 50000
         }
     ],
     "enemy_groups" : [
@@ -41,6 +49,7 @@
                     "enemy_id": "0x021003",
                     "level": 70,
                     "exp": 0,
+                    "blood_orbs": 650,
                     "named_enemy_params_id": 942,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202003.json
@@ -27,6 +27,14 @@
                     "num": 1
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1000
+        },
+        {
+            "type": "exp",
+            "amount": 50000
         }
     ],
     "enemy_groups" : [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50203000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50203000.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1650
+        },
+        {
+            "type": "exp",
+            "amount": 65000
         }
     ],
     "enemy_groups" : [
@@ -41,6 +49,7 @@
                     "enemy_id": "0x080600",
                     "level": 75,
                     "exp": 0,
+                    "blood_orbs": 750,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204002.json
@@ -26,6 +26,14 @@
                     "num": 3
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 2000
+        },
+        {
+            "type": "exp",
+            "amount": 80000
         }
     ],
     "enemy_groups" : [
@@ -41,6 +49,7 @@
                     "enemy_id": "0x080501",
                     "level": 80,
                     "exp": 0,
+                    "blood_orbs": 1000,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50206000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50206000.json
@@ -60,6 +60,14 @@
                     "chance": 0.05
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1600
+        },
+        {
+            "type": "exp",
+            "amount": 100000
         }
     ],
     "enemy_groups" : [
@@ -452,8 +460,15 @@
                     "repop_wait_second": 45
                 }
             ]
+        },
+        {
+            "comment": "Phase 1 (3) (prevent monsters from spawning during Zuhl fight)",
+            "stage_id": {
+                "id": 433,
+                "group_id": 5
+            },
+            "enemies": []
         }
-
     ],
     "processes": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300001.json
@@ -95,7 +95,6 @@
                 }
             ]
         },
-
         {
             "type": "random",
             "comment": "Unappraised Moon Trinket (Soldier)",
@@ -137,6 +136,14 @@
                     "chance": 0.10
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 200
+        },
+        {
+            "type": "exp",
+            "amount": 50000
         }
     ],
     "enemy_groups" : [
@@ -152,6 +159,7 @@
                     "enemy_id": "0x080200",
                     "level": 45,
                     "exp": 0,
+                    "blood_orbs": 200,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300003.json
@@ -136,6 +136,14 @@
                     "chance": 0.10
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 300
+        },
+        {
+            "type": "exp",
+            "amount": 85000
         }
     ],
     "enemy_groups" : [
@@ -151,7 +159,8 @@
                     "enemy_id": "0x080300",
                     "level": 55,
                     "exp": 0,
-                    "is_boss": true
+                    "is_boss": true,
+                    "blood_orbs": 500
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300006.json
@@ -136,6 +136,14 @@
                     "chance": 0.10
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 1500
+        },
+        {
+            "type": "exp",
+            "amount": 100000
         }
     ],
     "enemy_groups" : [
@@ -151,6 +159,7 @@
                     "enemy_id": "0x080100",
                     "level": 60,
                     "exp": 0,
+                    "blood_orbs": 1000,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300010.json
@@ -112,6 +112,14 @@
                     "chance": 0.05
                 }
             ]
+        },
+        {
+            "type": "jp",
+            "amount": 2500
+        },
+        {
+            "type": "exp",
+            "amount": 200000
         }
     ],
     "enemy_groups" : [
@@ -128,6 +136,7 @@
                     "level": 80,
                     "exp": 0,
                     "is_boss": true,
+                    "blood_orbs": 1500,
                     "named_enemy_params_id": 1564
                 }
             ]


### PR DESCRIPTION
- Adjusted EXM such that they drop EXP, BO and JP.
- Adjusted EM5 to make it closer to original EXM implementation and make rewards worthwhile.
- Block monsters in "Phindym War Chronicles" that should not be spawning.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
