### PR TITLE
feat: Implement the EXM "Onset of Darkness: Restricted Stage"

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsGroupHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetEndContentsGroupHandler.cs
@@ -45,8 +45,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 GroupId = request.GroupId
             };
 
-            var quests = QuestManager.GetQuestsByType(QuestType.ExtremeMission).Where(x => x.Value.MissionParams.Group == request.GroupId);
-            foreach (var (questId, quest) in quests)
+            var quests = QuestManager.GetQuestsByType(QuestType.ExtremeMission).Where(x => x.Value.MissionParams.Group == request.GroupId).Select(x => x.Value).OrderBy(x => x.QuestId);
+            foreach (var quest in quests)
             {
                 var entry = quest.ToCDataTimeGainQuestList(0);
                 results.TimeGainQuestList.Add(entry);

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -384,12 +384,13 @@ namespace Arrowgene.Ddon.GameServer.Quests
 #endif
 
             HashSet<uint> items = new HashSet<uint>();
+            List<QuestRewardItem> rewards = this.ItemRewards.Concat(this.SelectableRewards).ToList();
             // Rewards for EXM seem to show up independently
-            foreach (var rewardData in this.ItemRewards)
+            foreach (var rewardData in rewards)
             {
                 foreach (var reward in rewardData.LootPool)
                 {
-                    if (rewardData.RewardType == QuestRewardType.Fixed)
+                    if (rewardData.RewardType == QuestRewardType.Fixed || rewardData.RewardType == QuestRewardType.Select)
                     {
                         result.RewardItemDetailList.Add(new CDataRewardItemDetail()
                         {
@@ -457,6 +458,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 QuestId = (uint) QuestId,
                 QuestScheudleId = (uint) QuestScheduleId,
                 BaseLevel = BaseLevel,
+                StartPos = MissionParams.StartPos,
                 QuestEnemyInfoList = EnemyGroups.Values.SelectMany(group => group.Enemies.Select(enemy => new CDataQuestEnemyInfo()
                 {
                     GroupId = enemy.UINameId,

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -870,6 +870,12 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 assetData.MissionParams.QuestPhaseGroupIdList.Add(new CDataCommonU32() { Value = element.GetUInt32() });
             }
 
+            assetData.MissionParams.StartPos = 0;
+            if (jMissionParams.TryGetProperty("start_pos", out JsonElement jStartPos))
+            {
+                assetData.MissionParams.StartPos = jStartPos.GetByte();
+            }
+
             assetData.MissionParams.MinimumMembers = 4;
             if (jMissionParams.TryGetProperty("minimum_members", out JsonElement jMinimumMembers))
             {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204001.json
@@ -1,0 +1,196 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "ExtremeMission",
+    "comment": "Onset of Darkness: Restricted Stage",
+    "quest_id": 50204001,
+    "base_level": 80,
+    "minimum_item_rank": 72,
+    "discoverable": false,
+    "mission_params": {
+        "group": 2,
+        "minimum_members": 1,
+        "playtime": 600,
+        "solo_only": false,
+        "max_pawns": 3,
+        "phase_groups": []
+    },
+    "order_conditions": [
+        {"type": "ClearExtremeMission", "Param1": 50204002}
+    ],
+    "rewards": [
+        {
+            "type": "fixed",
+            "loot_pool": [
+                {
+                    "item_id": 41,
+                    "num": 1
+                }
+            ]
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 14877,
+                    "num": 1
+                },
+                {
+                    "item_id": 14993,
+                    "num": 1
+                },
+                {
+                    "item_id": 15203,
+                    "num": 1
+                },
+                {
+                    "item_id": 15364,
+                    "num": 1
+                },
+                {
+                    "item_id": 15589,
+                    "num": 1
+                }
+            ]
+        },
+        {
+            "type": "jp",
+            "amount": 4000
+        },
+        {
+            "type": "exp",
+            "amount": 250000
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "comment": "Boss",
+            "stage_id": {
+                "id": 458,
+                "group_id": 1
+            },
+            "enemies": [
+                {
+                    "comment": "Black Knight (Fan of Swords)",
+                    "enemy_id": "0x080502",
+                    "level": 80,
+                    "exp": 0,
+                    "blood_orbs": 2000,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "comment": "Boss",
+            "stage_id": {
+                "id": 458,
+                "group_id": 2
+            },
+            "enemies": [
+                {
+                    "comment": "Black Knight Phantom",
+                    "enemy_id": "0x080500",
+                    "level": 80,
+                    "exp": 0,
+                    "start_think_tbl_no": 1,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Black Knight Phantom",
+                    "enemy_id": "0x080500",
+                    "level": 80,
+                    "exp": 0,
+                    "start_think_tbl_no": 1,
+                    "enemy_target_types_id": 1
+                }
+            ]
+        },
+        {
+            "comment": "Boss",
+            "stage_id": {
+                "id": 458,
+                "group_id": 2
+            },
+            "enemies": [
+                {
+                    "comment": "Black Knight Phantom",
+                    "enemy_id": "0x080500",
+                    "level": 80,
+                    "exp": 0,
+                    "start_think_tbl_no": 1,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Black Knight Phantom",
+                    "enemy_id": "0x080500",
+                    "level": 80,
+                    "exp": 0,
+                    "start_think_tbl_no": 1,
+                    "enemy_target_types_id": 1
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "IsGatherPartyInStage",
+                    "stage_id": {
+                        "id": 458
+                    }
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Start",
+                    "groups": [0]
+                },
+                {
+                    "type": "PlayEvent",
+                    "flags": [],
+                    "stage_id": {
+                        "id": 458
+                    },
+                    "event_id": 5
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "IsGatherPartyInStage",
+                    "stage_id": {
+                        "id": 458
+                    }
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "EmHpLess", "Param1": 889, "Param2": 1, "Param3": 0, "Param4": 41}
+                    ]
+                },
+                {
+                    "type": "KillGroup",
+                    "groups": [1]
+                },
+                {
+                    "type": "ExtendTime",
+                    "amount": 120
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "EmHpLess", "Param1": 889, "Param2": 1, "Param3": 0, "Param4": 36}
+                    ]
+                },
+                {
+                    "type": "KillGroup",
+                    "groups": [2]
+                },
+                {
+                    "type": "ExtendTime",
+                    "amount": 120
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50206000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50206000.json
@@ -254,6 +254,7 @@
                     "level": 80,
                     "exp": 0,
                     "enemy_target_types_id": 1,
+                    "start_think_tbl_no": 2,
                     "named_enemy_params_id": 1700
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestMissionParams.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestMissionParams.cs
@@ -9,6 +9,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         {
             QuestPhaseGroupIdList = new List<CDataCommonU32>();
         }
+        public byte StartPos { get; set; }
         public uint MinimumMembers { get; set; }
         public uint MaximumMembers { get; set; }
         public uint PlaytimeInSeconds { get; set; }


### PR DESCRIPTION
- Implemented the EXM "Onset of Darkness: Restricted Stage" 
- Add support for selectable rewards in EXM
- Added think table type to ghost in q50206000.json
- Added option to provide a start position in the mission params
- Sort EXM quests by quest ID instead of dictionary order

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
