### PR TITLE
fix: Fix issue with 2.x migration

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.0.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.0.sql
@@ -1,2 +1,4 @@
 INSERT INTO ddon_quest_progress(character_common_id, quest_type, quest_id, step, variant_quest_id)
-VALUES ((SELECT character_common_id FROM ddon_completed_quests WHERE quest_id = 30), 3, 20010, 0, 0);
+SELECT ddon_completed_quests.character_common_id, 3, 20010, 0, 0
+FROM ddon_completed_quests
+WHERE ddon_completed_quests.quest_id = 30;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.1.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.1.sql
@@ -1,2 +1,4 @@
 INSERT INTO ddon_quest_progress(character_common_id, quest_type, quest_id, step, variant_quest_id)
-VALUES ((SELECT character_common_id FROM ddon_completed_quests WHERE quest_id = 20070), 3, 20080, 0, 0);
+SELECT ddon_completed_quests.character_common_id, 3, 20080, 0, 0
+FROM ddon_completed_quests
+WHERE ddon_completed_quests.quest_id = 20070;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.2.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.2.sql
@@ -1,2 +1,4 @@
 INSERT INTO ddon_quest_progress(character_common_id, quest_type, quest_id, step, variant_quest_id)
-VALUES ((SELECT character_common_id FROM ddon_completed_quests WHERE quest_id = 20140), 3, 20150, 0, 0);
+SELECT ddon_completed_quests.character_common_id, 3, 20150, 0, 0
+FROM ddon_completed_quests
+WHERE ddon_completed_quests.quest_id = 20140;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.3.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_2.3.sql
@@ -1,2 +1,4 @@
 INSERT INTO ddon_quest_progress(character_common_id, quest_type, quest_id, step, variant_quest_id)
-VALUES ((SELECT character_common_id FROM ddon_completed_quests WHERE quest_id = 20200), 3, 20210, 0, 0);
+SELECT ddon_completed_quests.character_common_id, 3, 20210, 0, 0
+FROM ddon_completed_quests
+WHERE ddon_completed_quests.quest_id = 20200;


### PR DESCRIPTION
Fixed an issue where the MSQ migrations through a constraint failure exception when no characters in the database match the query.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
