### PR TITLE
fix: Fix small bugs found in various quests and rewards

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/SpecialShops.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/SpecialShops.json
@@ -29807,7 +29807,7 @@
                             ],
                             "pool": [
                                 {
-                                    "item_id": 21427,
+                                    "item_id": 21437,
                                     "name": "Crimson Firangi",
                                     "amount": 1
                                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
@@ -45,7 +45,7 @@
     {
       "stage_id": {
         "id": 99,
-        "group_id": 20
+        "group_id": 2
       },
       "enemies": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
@@ -49,25 +49,25 @@
       },
       "enemies": [
         {
-          "enemy_id": "01015800",
+          "enemy_id": "0x015800",
           "level": 44,
           "exp": 1100,
           "is_boss": false
         },
         {
-          "enemy_id": "01015800",
+          "enemy_id": "0x015800",
           "level": 44,
           "exp": 1100,
           "is_boss": false
         },
         {
-          "enemy_id": "01015800",
+          "enemy_id": "0x015800",
           "level": 44,
           "exp": 1100,
           "is_boss": false
         },
         {
-          "enemy_id": "01015800",
+          "enemy_id": "0x015800",
           "level": 44,
           "exp": 1100,
           "is_boss": false

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
@@ -6,7 +6,7 @@
     "base_level": 46,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "EasternZandora",
+    "area_id": "EasternZandora",
     "rewards": [
         {
             "type": "wallet",
@@ -53,8 +53,8 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 1,
-                "group_id": 461
+                "id": 169,
+                "group_id": 1
             },
             "enemies": [
                 {
@@ -62,21 +62,21 @@
                     "level": 46,
                     "exp": 1200,
                     "is_boss": false,
-					"hm_present_no": 52
-        },
-        {
+                    "hm_present_no": 52
+                },
+                {
                     "enemy_id": "0x011010",
                     "level": 46,
                     "exp": 1200,
                     "is_boss": false,
-					"hm_present_no": 52
-        },
-        {
+                    "hm_present_no": 52
+                },
+                {
                     "enemy_id": "0x011012",
                     "level": 46,
                     "exp": 1200,
                     "is_boss": false,
-					"hm_present_no": 54
+                    "hm_present_no": 54
                 }
             ]
         }


### PR DESCRIPTION
- Fix q20035006 by adjusting the group ID from 20 -> 2
- Fix q20075007 by correcting enemy IDs to be valid hex numbers
- Fix q20080006 by adjusting the spawn location to Water Channel Ruins, group 1.
- Fix crimson exchange where the wrong Crimson Firangi was being rewarded for HS.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
