### PR TITLE
fixes: WQ and MSQ Fixes

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000002.json
@@ -53,7 +53,8 @@
                 {"type": "QstLayout", "action": "Set", "value": 273},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1215, "quest_id": 70000001, "Comment": "Mysial"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "check_commands": [
                 {"type": "EventEnd", "Param1": 200, "Param2": 0}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000003.json
@@ -107,7 +107,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "stage_id": {
                 "id": 3,
@@ -118,7 +119,6 @@
         },
         {
             "type": "Raw",
-            "announce_type": "Accept",
             "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 972, "comment": "Spawns Heinz and Gerd in Tel"}
             ],
@@ -131,7 +131,7 @@
         },
         {
             "type": "PartyGather",
-            "checkpoint": true,
+            "announce_type": "Accept",
             "stage_id": {
                 "id": 1
             },
@@ -143,7 +143,6 @@
         },
         {
             "type": "Raw",
-            "announce_type": "Update",
             "check_commands": [
                 {"type": "EventEnd", "Param1": 100, "Param2": 10}
             ],
@@ -153,6 +152,7 @@
         },
         {
             "type": "IsStageNo",
+            "announce_type": "Update",
             "checkpoint": true,
             "stage_id": {
                 "id": 25
@@ -217,7 +217,6 @@
         },
         {
             "type": "Raw",
-            "announce_type": "Update",
             "check_commands": [
                 {"type": "EventEnd", "Param1": 100, "Param2": 15}
             ],
@@ -227,6 +226,7 @@
         },
         {
             "type": "TalkToNpc",
+            "announce_type": "Update",
             "checkpoint": true,
             "stage_id": {
                 "id": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000004.json
@@ -56,7 +56,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "stage_id": {
                 "id": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000005.json
@@ -91,7 +91,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Leo0",
             "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000006.json
@@ -107,7 +107,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Joseph",
             "message_id": 7603

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000007.json
@@ -54,7 +54,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Leo0",
             "message_id": 7660

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000009.json
@@ -85,45 +85,45 @@
                 "id": 83,
                 "group_id": 0
             },
-			"placement_type": "Manual",
+            "placement_type": "Manual",
             "enemies": [
                 {
                     "enemy_id": "0x010205",
                     "level": 28,
                     "exp": 996,
-					"index": 6,
+                    "index": 6,
                     "named_enemy_params_id": 147
                 },
                 {
                     "enemy_id": "0x010205",
                     "level": 28,
                     "exp": 996,
-					"index": 7,
+                    "index": 7,
                     "named_enemy_params_id": 147
                 },
-				{
+                {
                     "enemy_id": "0x010205",
                     "level": 28,
                     "exp": 996,
-					"index": 8,
+                    "index": 8,
                     "named_enemy_params_id": 147
                 },
                 {
                     "enemy_id": "0x015800",
                     "level": 28,
                     "exp": 996,
-					"index": 9,
+                    "index": 9,
                     "named_enemy_params_id": 125
                 },
                 {
                     "enemy_id": "0x015002",
                     "level": 30,
                     "exp": 1126,
-					"index": 4,
-					"is_boss": true,
+                    "index": 4,
+                    "is_boss": true,
                     "named_enemy_params_id": 146
                 }
-           ]
+            ]
         }
     ],
     "blocks": [
@@ -138,7 +138,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Leo0",
             "message_id": 0
@@ -187,18 +188,18 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
-			"flags": [
+            "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 981, "comment": "Spawns Vanessa and other NPC"},
-				{"type": "MyQst", "action": "Set", "value": 80, "comment": "Starts Vanessa FSM"}
-			],
+                {"type": "MyQst", "action": "Set", "value": 80, "comment": "Starts Vanessa FSM"}
+            ],
             "groups": [0]
         },
         {
             "type": "PlayEvent",
-			"flags": [
+            "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 981, "comment": "Spawns Vanessa and other NPC"},
-				{"type": "MyQst", "action": "Clear", "value": 80, "comment": "Starts Vanessa FSM"}
-			],
+                {"type": "MyQst", "action": "Clear", "value": 80, "comment": "Starts Vanessa FSM"}
+            ],
             "stage_id": {
                 "id": 83
             },
@@ -211,18 +212,18 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
-			"flags": [
+            "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 981, "comment": "Spawns Vanessa and other NPC"},
-				{"type": "MyQst", "action": "Set", "value": 80, "comment": "Starts Vanessa FSM"}
-			],
+                {"type": "MyQst", "action": "Set", "value": 80, "comment": "Starts Vanessa FSM"}
+            ],
             "groups": [1]
         },
         {
             "type": "PlayEvent",
-			"flags": [
+            "flags": [
                 {"type": "QstLayout", "action": "Clear", "value": 981, "comment": "Spawns Vanessa and other NPC"},
-				{"type": "MyQst", "action": "Clear", "value": 80, "comment": "Starts Vanessa FSM"}
-			],
+                {"type": "MyQst", "action": "Clear", "value": 80, "comment": "Starts Vanessa FSM"}
+            ],
             "stage_id": {
                 "id": 83
             },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000010.json
@@ -83,7 +83,8 @@
                         {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Leo0",
                     "message_id": 7840

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000011.json
@@ -21,7 +21,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Mysial0",
             "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000012.json
@@ -90,7 +90,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Joseph",
             "message_id": 7898

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000013.json
@@ -118,7 +118,8 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1672, "quest_id": 70000001, "comment": "Open Lever Door  (Stone Door, middle)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1111, "quest_id": 70000001, "comment": "Closed Water Flow Control Door"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1671, "quest_id": 70000001, "comment": "Closed Lever Door (Stone Door, middle)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 1317, "quest_id": 70000001, "comment": "Waterfalls"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1317, "quest_id": 70000001, "comment": "Waterfalls"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Klaus0",
                     "message_id": 7931

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000014.json
@@ -219,7 +219,8 @@
                         {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
                         {"type": "QstLayout", "action": "Set", "value": 1009, "comment": "Spawns Gerd in the Audience Chamber"},
                         {"type": "QstLayout", "action": "Set", "value": 1239, "comment": "Spawns Heinz in the Audience Chamber"},
-                        {"type": "QstLayout", "action": "Set", "value": 1240, "comment": "Spawns Vanessa in the Audience Chamber"}
+                        {"type": "QstLayout", "action": "Set", "value": 1240, "comment": "Spawns Vanessa in the Audience Chamber"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Gerd1",
                     "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000015.json
@@ -157,7 +157,8 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1113, "quest_id": 70002001, "comment": "Large Door Closed"},
-                        {"type": "WorldManageLayout", "action": "Clear", "value": 1114, "quest_id": 70002001, "comment": "Large Door Open"}
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 1114, "quest_id": 70002001, "comment": "Large Door Open"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Leo0",
                     "message_id": 11520

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000016.json
@@ -151,7 +151,8 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 3859, "quest_id": 70002001, "comment": "Floor Mounted Levers in for gardnox, Large Door"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 3859, "quest_id": 70002001, "comment": "Floor Mounted Levers in for gardnox, Large Door"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Leo0",
                     "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000017.json
@@ -21,7 +21,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Mysial0",
             "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000018.json
@@ -98,7 +98,8 @@
                         {"type": "WorldManageLayout", "action": "Set", "value": 1215, "quest_id": 70000001, "comment": "Mysial"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Leo0",
                     "message_id": 8149

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
@@ -57,7 +57,8 @@
                         {"type": "WorldManageLayout", "action": "Set", "value": 1215, "quest_id": 70000001, "comment": "Mysial"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Joseph",
                     "message_id": 8202

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
@@ -101,6 +101,7 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
 
                         {"type": "WorldManageLayout", "action": "Set", "value": 1106, "quest_id": 70003001, "comment": "Front Door Levers"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1104, "quest_id": 70003001, "comment": "Large Front Door Closed"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000021.json
@@ -85,6 +85,7 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
 
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1103, "quest_id": 70003001, "comment": "Third Ark Spawn Point"},
                         {"type": "QstLayout", "action": "Set", "value": 1025, "comment": "Spawns Heinz in the audience chamber"}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000022.json
@@ -99,6 +99,7 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
 
                         {"type": "WorldManageLayout", "action": "Set", "value": 1202, "quest_id": 70003001, "comment": "Mergoda Warp Off"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1203, "quest_id": 70003001, "comment": "Mergoda Warp on"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000023.json
@@ -75,6 +75,7 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
                         {"type": "QstLayout", "action": "Set", "value": 1031, "comment": "Spawn Klaus"},
 
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1098, "quest_id": 70003001, "comment": "Close Diametes Door"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000024.json
@@ -129,6 +129,7 @@
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
 
                         {"type": "WorldManageLayout", "action": "Set", "value": 1098, "quest_id": 70003001, "comment": "Close Diametes Door"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1713, "quest_id": 70003001, "comment": "Open Diametes Door"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000025.json
@@ -84,7 +84,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Leo0",
             "message_id": 10853

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000026.json
@@ -65,6 +65,7 @@
         "group_id": 1
       },
       "flags": [
+        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
         {
           "type": "QstLayout",
           "action": "Set",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000027.json
@@ -60,7 +60,7 @@
                 {
                     "enemy_id": "0x015200",
                     "level": 18,
-					"named_enemy_params_id": 457,
+                    "named_enemy_params_id": 457,
                     "exp": 1771,
                     "is_boss": true
                 }
@@ -79,7 +79,8 @@
                 {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 1219, "quest_id": 70000001, "comment": "Iris"},
                 {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"}
+                {"type": "WorldManageLayout", "action": "Set", "value": 1293, "quest_id": 70000001, "comment": "The White Dragon (Dead)"},
+                {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
             ],
             "npc_id": "Leo0",
             "message_id": 10938

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000028.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000028.json
@@ -62,7 +62,8 @@
                         {"type": "WorldManageLayout", "action": "Clear", "value": 1215, "quest_id": 70000001, "comment": "Mysial"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Joseph",
                     "message_id": 11553

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000029.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000029.json
@@ -147,7 +147,8 @@
                         {"type": "WorldManageLayout", "action": "Set", "value": 1215, "quest_id": 70000001, "comment": "Mysial"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Leo0",
                     "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000030.json
@@ -22,7 +22,8 @@
                     },
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Clear", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"}
                     ],
                     "npc_id": "Joseph",
                     "message_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
@@ -1,151 +1,163 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "Boats Buddy",
-  "quest_id": 20010001,
-  "base_level": 8,
-  "minimum_item_rank": 0,
-  "discoverable": true,
-  "area_id": "BreyaCoast",
-  "news_image": 22,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 240
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 30
-    },
-    {
-      "type": "exp",
-      "amount": 390
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Boats Buddy",
+    "quest_id": 20010001,
+    "base_level": 9,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "BreyaCoast",
+    "news_image": 22,
+    "rewards": [
         {
-          "item_id": 502,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 240
         },
         {
-          "item_id": 9370,
-          "num": 2
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 30
+        },
+        {
+            "type": "exp",
+            "amount": 390
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 502,
+                    "num": 1
+                },
+                {
+                    "item_id": 9370,
+                    "num": 2
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 83
-      },
-      "enemies": [
+    ],
+    "enemy_groups": [
         {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "placement_type": "Manual",
+            "enemies": [
+                {
+                    "enemy_id": "0x010600",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 4
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 5
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 6
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 7
+                }
+            ]
         },
         {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "placement_type": "Manual",
+            "enemies": [
+                {
+                    "enemy_id": "0x010400",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 8
+                },
+                {
+                    "enemy_id": "0x010400",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 9
+                },
+                {
+                    "enemy_id": "0x010400",
+                    "level": 9,
+                    "exp": 94,
+                    "is_boss": false,
+                    "index": 10
+                },
+                {
+                    "enemy_id": "0x010401",
+                    "level": 9,
+                    "exp": 190,
+                    "is_boss": false,
+                    "index": 11
+                }
+            ]
         },
         {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "placement_type": "Manual",
+            "enemies": [
+                {
+                    "enemy_id": "0x010411",
+                    "level": 4,
+                    "exp": 136,
+                    "is_boss": false,
+                    "index": 8
+                }
+            ]
         }
-      ]
-    },
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 84
-      },
-      "enemies": [
+    ],
+    "blocks": [
         {
-          "enemy_id": "0x010410",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1,
+                "group_id": 0
+            },
+            "npc_id": "Walter",
+            "message_id": 10800
         },
         {
-          "enemy_id": "0x010410",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "groups": [ 0 ]
         },
         {
-          "enemy_id": "0x010410",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [ 1 ]
         },
         {
-          "enemy_id": "0x010410",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1,
+                "group_id": 0
+            },
+            "announce_type": "Update",
+            "npc_id": "Walter",
+            "message_id": 10805
         }
-      ]
-    },
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 81
-      },
-      "enemies": [
-        {
-          "enemy_id": "0x010411",
-          "level": 4,
-          "exp": 136,
-          "is_boss": false
-        }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 1,
-        "group_id": 0
-      },
-      "npc_id": "Walter",
-      "message_id": 10800
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [ 1 ]
-    },
-    {
-      "type": "KillGroup",
-
-      "announce_type": "Update",
-      "groups": [ 2 ]
-    },
-    {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 1,
-        "group_id": 0
-      },
-      "announce_type": "Update",
-      "npc_id": "Walter",
-      "message_id": 10805
-    }
-  ]
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000.json
@@ -3,24 +3,24 @@
     "type": "World",
     "comment": "The Dead City's Chronicles",
     "quest_id": 20090000,
-    "base_level": 49,
+    "base_level": 50,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "ZandoraWastelands",
+    "area_id": "ZandoraWastelands",
     "rewards": [
         {
             "type": "exp",
-            "amount": 1880
+            "amount": 2500
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1340
+            "amount": 1650
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 210
+            "amount": 280
         },
         {
             "type": "select",
@@ -43,8 +43,8 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 164,
-                "group_id": 4
+                "id": 77,
+                "group_id": 23
             },
             "enemies": [
                 {
@@ -52,17 +52,29 @@
                     "level": 50,
                     "exp": 20000,
                     "is_boss": true
-        },
-        {
+                },
+                {
                     "enemy_id": "0x010607",
-                    "level": 48,
+                    "level": 50,
                     "exp": 1200,
                     "is_boss": false
-        },
-        {
-                    "enemy_id": "0x011160",
-                    "level": 49,
-                    "exp": 1300,
+                },
+                {
+                    "enemy_id": "0x010607",
+                    "level": 50,
+                    "exp": 1200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010607",
+                    "level": 50,
+                    "exp": 1200,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010607",
+                    "level": 50,
+                    "exp": 1200,
                     "is_boss": false
                 }
             ]
@@ -72,7 +84,12 @@
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1075, "comment": "Spawns Lise0 NPC"}
+                {
+                    "type": "QstLayout",
+                    "action": "Set",
+                    "value": 1075,
+                    "comment": "Spawns Lise0 NPC"
+                }
             ],
             "stage_id": {
                 "id": 1,
@@ -83,6 +100,17 @@
             "message_id": 11372
         },
         {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
             "type": "CollectItem",
             "announce_type": "Update",
             "stage_id": {
@@ -91,18 +119,13 @@
                 "layer_no": 1
             },
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1754, "comment": "Spawns Glowing Item"}
+                {
+                    "type": "QstLayout",
+                    "action": "Set",
+                    "value": 1754,
+                    "comment": "Spawns Glowing Item"
+                }
             ]
-        },
-        {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Accept",
-            "groups": [0]
-        },
-        {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "groups": [0]
         },
         {
             "type": "NewTalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
@@ -1,7 +1,7 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "A Wish For Inheritance",
+    "comment": "Inherited Experience",
     "quest_id": 20990003,
     "base_level": 50,
     "minimum_item_rank": 0,
@@ -83,8 +83,19 @@
             "message_id": 11372
         },
         {
-            "type": "CollectItem",
+            "type": "DiscoverEnemy",
             "announce_type": "Accept",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "reset_group": false,
+            "announce_type": "Update",
+            "groups": [0]
+        },
+        {
+            "type": "CollectItem",
+            "announce_type": "Update",
             "stage_id": {
                 "id": 58,
                 "group_id": 1,
@@ -93,11 +104,6 @@
             "flags": [
                 {"type": "QstLayout", "action": "Set", "value": 1302, "comment": "Spawns Glowing Item"}
             ]
-        },
-        {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "groups": [0]
         },
         {
             "type": "TalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
@@ -54,10 +54,28 @@
                     "is_boss": true
                 },
                 {
-                    "enemy_id": "0x015102",
+                    "enemy_id": "0x010606",
                     "level": 55,
-                    "exp": 21000,
-                    "is_boss": true
+                    "exp": 2100,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010606",
+                    "level": 55,
+                    "exp": 2100,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010606",
+                    "level": 55,
+                    "exp": 2100,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010606",
+                    "level": 55,
+                    "exp": 2100,
+                    "is_boss": false
                 }
             ]
         }
@@ -81,6 +99,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {


### PR DESCRIPTION
- Fixes small issues found in world quests due to enemy placement, invalid enemies or order of quest rules.
- Fixes issue found in the main story quest "Envoy of Reconciliation" related to improper quest checkpoints.
- Removed season 3 Elliot, Lise and Gurdolin from the audience chamber in season 1 and season 2.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
