### PR TITLE
refactor: rework quest enemy spawn

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -32,7 +32,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             foreach (var questId in client.Party.QuestState.StageQuests(stageId))
             {
                 quest = QuestManager.GetQuest(questId);
-                if (quest.HasEnemiesInInCurrentStage(stageId))
+                if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
                 {
                     IsQuestControlled = true;
                     break;

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -193,6 +193,20 @@ namespace Arrowgene.Ddon.GameServer.Party
             }
         }
 
+        public bool HasEnemiesInCurrentStageGroup(Quest quest, StageId stageId, uint subGroupId)
+        {
+            lock (ActiveQuests)
+            {
+                var questState = ActiveQuests[quest.QuestId];
+                if (!questState.QuestEnemies.ContainsKey(stageId))
+                {
+                    return false;
+                }
+
+                return questState.QuestEnemies[stageId].ContainsKey(subGroupId);
+            }
+        }
+
         public void SetInstanceEnemies(Quest quest, StageId stageId, ushort subGroupId, List<InstancedEnemy> enemies)
         {
             lock (ActiveQuests)

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Context;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Asset;
@@ -506,6 +507,16 @@ namespace Arrowgene.Ddon.GameServer.Quests
             {
                 var enemyGroup = EnemyGroups[groupId];
 
+                // Cleanup old contexts if we are replacing monsters with new ones
+                foreach (var enemy in enemyGroup.Enemies)
+                {
+                    var uid = ContextManager.CreateEnemyUID(enemy.Index, enemyGroup.StageId.ToStageLayoutId());
+                    if (client.Party.Contexts.ContainsKey(uid))
+                    {
+                        client.Party.Contexts.Remove(uid);
+                    }
+                }
+
                 S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()
                 {
                     LayoutId = enemyGroup.StageId.ToStageLayoutId()
@@ -522,6 +533,16 @@ namespace Arrowgene.Ddon.GameServer.Quests
             {
                 if (group.StageId.Id == stageId.Id)
                 {
+                    // Cleanup old contexts if we are replacing monsters with new ones
+                    foreach (var enemy in group.Enemies)
+                    {
+                        var uid = ContextManager.CreateEnemyUID(enemy.Index, group.StageId.ToStageLayoutId());
+                        if (client.Party.Contexts.ContainsKey(uid))
+                        {
+                            client.Party.Contexts.Remove(uid);
+                        }
+                    }
+
                     S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()
                     {
                         LayoutId = group.StageId.ToStageLayoutId()

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -511,10 +511,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 foreach (var enemy in enemyGroup.Enemies)
                 {
                     var uid = ContextManager.CreateEnemyUID(enemy.Index, enemyGroup.StageId.ToStageLayoutId());
-                    if (client.Party.Contexts.ContainsKey(uid))
-                    {
-                        client.Party.Contexts.Remove(uid);
-                    }
+                    client.Party.Contexts.Remove(uid);
                 }
 
                 S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()
@@ -537,10 +534,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     foreach (var enemy in group.Enemies)
                     {
                         var uid = ContextManager.CreateEnemyUID(enemy.Index, group.StageId.ToStageLayoutId());
-                        if (client.Party.Contexts.ContainsKey(uid))
-                        {
-                            client.Party.Contexts.Remove(uid);
-                        }
+                        client.Party.Contexts.Remove(uid);
                     }
 
                     S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
@@ -111,22 +111,6 @@
                     "index": 11
                 }
             ]
-        },
-        {
-            "stage_id": {
-                "id": 1,
-                "group_id": 83
-            },
-            "placement_type": "Manual",
-            "enemies": [
-                {
-                    "enemy_id": "0x010411",
-                    "level": 4,
-                    "exp": 136,
-                    "is_boss": false,
-                    "index": 8
-                }
-            ]
         }
     ],
     "blocks": [
@@ -140,8 +124,14 @@
             "message_id": 10800
         },
         {
-            "type": "KillGroup",
+            "type": "DiscoverEnemy",
             "announce_type": "Accept",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
             "groups": [ 0 ]
         },
         {
@@ -152,8 +142,7 @@
         {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 1,
-                "group_id": 0
+                "id": 1
             },
             "announce_type": "Update",
             "npc_id": "Walter",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
@@ -1,86 +1,86 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "Dispatch A Clamor of Harpies",
-  "quest_id": 20015005,
-  "base_level": 8,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "BreyaCoast",
-  "news_image": 25,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 220
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 30
-    },
-    {
-      "type": "exp",
-      "amount": 290
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Dispatch A Clamor of Harpies",
+    "quest_id": 20015005,
+    "base_level": 8,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "BreyaCoast",
+    "news_image": 25,
+    "rewards": [
         {
-          "item_id": 506,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 220
         },
         {
-          "item_id": 8543,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 30
+        },
+        {
+            "type": "exp",
+            "amount": 290
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 506,
+                    "num": 1
+                },
+                {
+                    "item_id": 8543,
+                    "num": 1
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 94
-      },
-      "enemies": [
+    ],
+    "enemy_groups": [
         {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 4,
-          "exp": 94,
-          "is_boss": false
+            "stage_id": {
+                "id": 1,
+                "group_id": 94
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x010600",
+                    "level": 4,
+                    "exp": 94,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 4,
+                    "exp": 94,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 4,
+                    "exp": 94,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010600",
+                    "level": 4,
+                    "exp": 94,
+                    "is_boss": false
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }


### PR DESCRIPTION
Allow world monsters to consume a group until the quest reaches a step which requires the group.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
