### PR TITLE
fix: Various fixes related to quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -228,6 +228,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return GetQuest((QuestId)questId);
         }
 
+        public static bool IsQuestEnabled(uint questId)
+        {
+            var quest = GetQuest(questId);
+            return (quest == null) ? false : quest.Enabled;
+        }
+
+        public static bool IsQuestEnabled(QuestId questId)
+        {
+            return IsQuestEnabled((uint)questId);
+        }
+
         public class LayoutFlag
         {
             public static CDataQuestLayoutFlagSetInfo Create(uint layoutFlag, StageNo stageNo, uint groupId)

--- a/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
@@ -75,6 +75,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             557, // Heroic Spirit Sleeping Path: Feryana Wilderness
             558, // Old Heroic Spirit Shrine
             576, // Fort Thines: Great Dining Hall
+            578, // Bonus Dungeon Lobby
             580, // Fortress City Megado: Craft Room
             584, // Eli Guard Tower
             594, // Northern Bandit Hideout

--- a/Arrowgene.Ddon.GameServer/Context/ContextManager.cs
+++ b/Arrowgene.Ddon.GameServer/Context/ContextManager.cs
@@ -41,6 +41,14 @@ namespace Arrowgene.Ddon.GameServer.Context
             }
         }
 
+        public static void RemoveContext(PartyGroup partyGroup, ulong uniqueId)
+        {
+            lock (partyGroup.Contexts)
+            {
+                partyGroup.Contexts.Remove(uniqueId);
+            }
+        }
+
         public static Tuple<CDataContextSetBase, CDataContextSetAdditional> SetAndGetContext(PartyGroup partyGroup, ulong uniqueId, Tuple<CDataContextSetBase, CDataContextSetAdditional> context)
         {
             lock (partyGroup.Contexts)

--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceEventDropItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceEventDropItemManager.cs
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
 
         private bool DropEnabled(Character character, EventItem item, Enemy enemy, StageId stageId)
         {
-            if (item.QuestIds.Count > 0 && !item.QuestIds.Any(x => QuestManager.GetQuest(x).Enabled))
+            if (item.QuestIds.Count > 0 && !item.QuestIds.Any(x => QuestManager.IsQuestEnabled(x)))
             {
                 return false;
             }

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -32,7 +32,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             foreach (var questId in client.Party.QuestState.StageQuests(stageId))
             {
                 quest = QuestManager.GetQuest(questId);
-                if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
+                // if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
+                if (quest.HasEnemiesInInCurrentStage(stageId))
                 {
                     IsQuestControlled = true;
                     break;

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -51,17 +51,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 return;
             }
 
-            var quests = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
-            foreach (var quest in quests)
+            var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+            foreach (var questProgress in progress)
             {
-                if (quest.VariantId != 0)
+                if (questProgress.VariantId != 0)
                 {
-                    Logger.Debug($"Getting quest progress. Adding {quest.QuestId} with variant {quest.VariantId}");
-                    party.QuestState.AddNewQuest(quest.QuestId, quest.Step, true, (uint)quest.VariantId);
+                    Logger.Debug($"Getting quest progress. Adding {questProgress.QuestId} with variant {questProgress.VariantId}");
+                    party.QuestState.AddNewQuest(questProgress.QuestId, questProgress.Step, true, (uint)questProgress.VariantId);
                     continue;
                 }
 
-                party.QuestState.AddNewQuest(quest.QuestId, quest.Step, true);
+                party.QuestState.AddNewQuest(questProgress.QuestId, questProgress.Step, true);
             }
 
             // Add quest for debug command

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
@@ -64,6 +64,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var tutorialQuestInProgress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.Tutorial);
             foreach (var questProgress in tutorialQuestInProgress)
             {
+                if (!QuestManager.IsQuestEnabled(questProgress.QuestId))
+                {
+                    continue;
+                }
+
                 var quest = QuestManager.GetQuest(questProgress.QuestId);
                 var tutorialQuest = quest.ToCDataTutorialQuestOrderList(questProgress.Step);
                 ntc.TutorialQuestOrderList.Add(tutorialQuest);
@@ -74,7 +79,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var priorityQuests = Server.Database.GetPriorityQuests(client.Party.Leader.Client.Character.CommonId);
                 foreach (var questId in priorityQuests)
                 {
-                    var quest = client.Party.QuestState.GetQuest(questId);
+                    if (!QuestManager.IsQuestEnabled(questId))
+                    {
+                        continue;
+                    }
+
+                    var quest = QuestManager.GetQuest(questId);
                     ntc.PriorityQuestList.Add(new CDataPriorityQuest()
                     {
                         QuestId = (uint)quest.QuestId,

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetTutorialQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetTutorialQuestListHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using System.IO;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -28,7 +29,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             // This handler should return personal quests which have not been started
             // yet when the player enters the StageNo
-            foreach (var quest in QuestManager.GetTutorialQuestsByStageNo(request.StageNo))
+            foreach (var quest in QuestManager.GetTutorialQuestsByStageNo(request.StageNo).Where(x => x.Enabled).ToList())
             {
                 uint stageNo = (uint) StageManager.ConvertIdToStageNo(quest.StageId);
                 if (stageNo != request.StageNo)

--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -307,10 +307,9 @@ namespace Arrowgene.Ddon.GameServer.Party
                 quest = GetQuest(questId);
             }
 
-            if (quest == null)
+            if (!QuestManager.IsQuestEnabled(questId))
             {
-                // Might be progress from removed quest (or one in development).
-                Logger.Error($"Unable to locate quest data for {questId}");
+                // Quest either not enabled or removed (skip it)
                 return;
             }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -511,7 +511,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 foreach (var enemy in enemyGroup.Enemies)
                 {
                     var uid = ContextManager.CreateEnemyUID(enemy.Index, enemyGroup.StageId.ToStageLayoutId());
-                    client.Party.Contexts.Remove(uid);
+                    ContextManager.RemoveContext(client.Party, uid);
                 }
 
                 S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()
@@ -534,7 +534,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     foreach (var enemy in group.Enemies)
                     {
                         var uid = ContextManager.CreateEnemyUID(enemy.Index, group.StageId.ToStageLayoutId());
-                        client.Party.Contexts.Remove(uid);
+                        ContextManager.RemoveContext(client.Party, uid);
                     }
 
                     S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020010.json
@@ -216,6 +216,7 @@
                     "stage_id": {
                         "id": 335
                     },
+                    "bgm_stop": true,
                     "event_id": 15,
                     "jump_stage_id": {
                         "id": 3

--- a/docs/quests/holiday_personal_quests.md
+++ b/docs/quests/holiday_personal_quests.md
@@ -4,6 +4,8 @@ There appears to be a set of holiday/seasonal personal quests. Some which don't 
 
 ## Halloween
 
+https://moreali523425.com/2018/10/02/post-5695/
+
 - quest\q60301001\quest\60301001\q60301001_st0200.qst.json (mentions pumpkins)
 - quest\q60301054\quest\60301054\q60301054_st0200.qst.json (also mentions pumpkins)
 


### PR DESCRIPTION
- Don't populate quest information for quests which are not enabled.
- Add a new function to check if a quest is enabled which can handle null without causing an exception.
-  Mark Bonus Lobby as a safe area
- Add potential fix for BGM which don't end
- Reverted the "improved" quest groups as it doesn't work 100% of the time

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
