### PR TITLE
fix: World Quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestJoinLobbyQuestInfoNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestJoinLobbyQuestInfoNtc.cs
@@ -33,7 +33,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
         public List<CDataSetQuestOrderList> SetQuestOrderList { get; set; }
         public List<CDataMainQuestOrderList> MainQuestOrderList { get; set; }
         public List<CDataTutorialQuestOrderList> TutorialQuestOrderList { get; set; }
-        public List<CDataLotQuestOrderList> LotQuestOrderList { get; set; }
+        public List<CDataLotQuestOrderList> LotQuestOrderList { get; set; } // TYPE_PAWN=1?
         public List<CDataS2CQuestJoinLobbyQuestInfoNtcUnk0> Unk0 { get; set; } // Probably those purple quests from season 3
         public List<CDataWildHuntQuestOrderList> WildHuntQuestOrderList { get; set; } // or maybe this
         public List<CDataTimeLimitedQuestOrderList> TimeLimitedQuestOrderList { get; set; }
@@ -87,6 +87,5 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 return obj;
             }
         }
-
     }
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
@@ -41,22 +41,6 @@
       ]
     }
   ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 196
-      },
-      "enemies": [
-        {
-          "enemy_id": "0x015002",
-          "level": 30,
-          "exp": 6500,
-          "is_boss": true
-        }
-      ]
-    }
-  ],
   "blocks": [
     {
       "type": "NewNpcTalkAndOrder",


### PR DESCRIPTION
- Fix issue with q20100001 by removing unused enemy node.

Authored-by: Dogs

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
