### PR TITLE
fix: Fix bug with next quest progress

### DIFF
--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -547,7 +547,7 @@ namespace Arrowgene.Ddon.GameServer.Party
                 if (quest.NextQuestId != QuestId.None)
                 {
                     var nextQuest = GetQuest((uint) quest.NextQuestId);
-                    server.Database.InsertQuestProgress(memberClient.Character.CommonId, nextQuest.QuestScheduleId, nextQuest.QuestType, nextQuest.QuestScheduleId);
+                    server.Database.InsertQuestProgress(memberClient.Character.CommonId, nextQuest.QuestScheduleId, nextQuest.QuestType, 0);
                 }
 
                 if (!memberClient.Character.CompletedQuests.ContainsKey(quest.QuestId))


### PR DESCRIPTION
Fixed an issue introduced with the quest schedule ID where the quest progress for the next quest was set to the schedule id.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
