### PR TITLE
fix: Fix issue with next quest

### DIFF
--- a/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyQuestState.cs
@@ -330,7 +330,8 @@ namespace Arrowgene.Ddon.GameServer.Party
 
             if (quest.NextQuestId != 0)
             {
-                AddNewQuest(quest.QuestScheduleId, 0);
+                var nextQuest = QuestManager.RollQuestForQuestId(quest.NextQuestId);
+                AddNewQuest(nextQuest.QuestScheduleId, 0);
             }
         }
 


### PR DESCRIPTION
Fixed an issue where the next quest was not set to the next quest but instead the current quest.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
