### PR TITLE
fix: Fix issue with null quest

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxListHandler.cs
@@ -34,6 +34,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             foreach (var boxReward in Server.RewardManager.GetQuestBoxRewards(client))
             {
                 var quest = QuestManager.GetQuestByScheduleId(boxReward.QuestScheduleId);
+                if (quest == null)
+                {
+                    Logger.Error($"Quest reward for QuestScheduleId={boxReward.QuestScheduleId}, but no definition of quest exists.");
+                    continue;
+                }
+
                 res.RewardBoxRecordList.Add(new CDataRewardBoxRecord()
                 {
                     ListNo = listNo,


### PR DESCRIPTION
Fixed an issue where the quest reward handler will crash if a quest reward is available for a quest with no definition.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
