### PR TITLE
feat: Add new exp penalty knob

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -794,9 +794,50 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return maxLevel;
         }
 
+        private bool AllMembersOwnedBySameCharacter(PartyGroup party)
+        {
+            uint characterId = 0;
+            foreach (var member in party.Members)
+            {
+                uint id = 0;
+                if (member is PlayerPartyMember)
+                {
+                    var client = ((PlayerPartyMember)member).Client;
+                    id = client.Character.CharacterId;
+                }
+                else if (member is PawnPartyMember)
+                {
+                    var pawn = ((PawnPartyMember)member).Pawn;
+                    if (pawn.IsRented)
+                    {
+                        return false;
+                    }
+
+                    id = pawn.CharacterId;
+                }
+
+                if (characterId == 0)
+                {
+                    characterId = id;
+                }
+
+                if (characterId != id)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         private double CalculatePartyRangeMultipler(GameMode gameMode, PartyGroup party)
         {
             if (!_GameSettings.AdjustPartyEnemyExp || gameMode == GameMode.BitterblackMaze)
+            {
+                return 1.0;
+            }
+
+            if (_GameSettings.DisableExpCorrectionForMyPawn && AllMembersOwnedBySameCharacter(party))
             {
                 return 1.0;
             }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Shared.Model;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Runtime.Serialization;
 
 namespace Arrowgene.Ddon.Server
@@ -161,6 +162,11 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 25)] public uint DefaultWarpFavorites { get; set; }
 
         /// <summary>
+        /// Disables the exp correction if all party members are owned by the same character.
+        /// </summary>
+        [DataMember(Order = 26)] public bool DisableExpCorrectionForMyPawn { get; set; }
+
+        /// <summary>
         /// Various URLs used by the client.
         /// Shared with the login server.
         /// </summary>
@@ -204,7 +210,7 @@ namespace Arrowgene.Ddon.Server
                 (9, 10, 0.5),
             };
 
-            AdjustTargetLvEnemyExp = true;
+            AdjustTargetLvEnemyExp = false;
             AdjustTargetLvEnemyExpTiers = new List<(uint MinLv, uint MaxLv, double ExpMultiplier)>()
             {
                 (0, 2, 1.0),
@@ -217,6 +223,8 @@ namespace Arrowgene.Ddon.Server
             EnablePawnCatchup = true;
             PawnCatchupMultiplier = 1.5;
             PawnCatchupLvDiff = 5;
+
+            DisableExpCorrectionForMyPawn = true;
 
             GameClockTimescale = 90;
 
@@ -282,6 +290,7 @@ namespace Arrowgene.Ddon.Server
             EnablePawnCatchup = setting.EnablePawnCatchup;
             PawnCatchupMultiplier = setting.PawnCatchupMultiplier;
             PawnCatchupLvDiff = setting.PawnCatchupLvDiff;
+            DisableExpCorrectionForMyPawn = setting.DisableExpCorrectionForMyPawn;
             PlayPointMax = setting.PlayPointMax;
             JobLevelMax = setting.JobLevelMax;
             ClanMemberMax = setting.ClanMemberMax;


### PR DESCRIPTION
Added a new GameSetting DisableExpCorrectionForMyPawn which disables party level difference checks if all members of the party are owned by the same character.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
