### PR TITLE
fix: Fix issue with tutorial quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -155,6 +155,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return quest.IsPersonal ? client.QuestState : client.Party.QuestState;
         }
 
+        public static HashSet<uint> CollectQuestScheduleIds(GameClient client, StageId stageId)
+        {
+            var questScheduleIds = new HashSet<uint>();
+            questScheduleIds.UnionWith(client.QuestState.StageQuests(stageId));
+            questScheduleIds.UnionWith(client.Party.QuestState.StageQuests(stageId));
+            return questScheduleIds;
+        }
+
         public class LayoutFlag
         {
             public static CDataQuestLayoutFlagSetInfo Create(uint layoutFlag, StageNo stageNo, uint groupId)

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -158,8 +158,13 @@ namespace Arrowgene.Ddon.GameServer.Characters
         public static HashSet<uint> CollectQuestScheduleIds(GameClient client, StageId stageId)
         {
             var questScheduleIds = new HashSet<uint>();
-            questScheduleIds.UnionWith(client.QuestState.StageQuests(stageId));
+
             questScheduleIds.UnionWith(client.Party.QuestState.StageQuests(stageId));
+            if (client.Party.Clients.Count == 1)
+            {
+                questScheduleIds.UnionWith(client.QuestState.StageQuests(stageId));
+            }
+            
             return questScheduleIds;
         }
 

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -48,10 +48,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
             foreach (var questScheduleId in client.Party.QuestState.StageQuests(stageId))
             {
                 quest = client.Party.QuestState.GetQuest(questScheduleId);
-                if (quest != null && client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId))
+                if (quest != null)
                 {
-                    IsQuestControlled = true;
-                    break;
+                    var questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                    if (questStateManager.HasEnemiesInCurrentStageGroup(quest, stageId))
+                    {
+                        IsQuestControlled = true;
+                        break;
+                    }
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -45,7 +45,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Quest quest = null;
             bool IsQuestControlled = false;
-            foreach (var questScheduleId in client.Party.QuestState.StageQuests(stageId))
+            foreach (var questScheduleId in QuestManager.CollectQuestScheduleIds(client, stageId))
             {
                 quest = client.Party.QuestState.GetQuest(questScheduleId);
                 if (quest != null)

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -7,6 +7,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -29,7 +30,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Quest quest = null;
             bool IsQuestControlled = false;
-            foreach (var questScheduleId in client.Party.QuestState.StageQuests(stageId))
+            foreach (var questScheduleId in QuestManager.CollectQuestScheduleIds(client, stageId))
             {
                 quest = QuestManager.GetQuestByScheduleId(questScheduleId);
                 // if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
@@ -52,7 +53,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 response.QuestId = (uint) quest.QuestId;
 
-                foreach (var enemy in client.Party.QuestState.GetInstancedEnemies(quest, stageId, subGroupId))
+                var questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                foreach (var enemy in questStateManager.GetInstancedEnemies(quest, stageId, subGroupId))
                 {
                     response.EnemyList.Add(new CDataLayoutEnemyData()
                     {

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -61,7 +61,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     continue;
                 }
 
-                QuestStateManager questStateManager = quest.IsPersonal ? join.Value.QuestState : party.QuestState;
+                QuestStateManager questStateManager = QuestManager.GetQuestStateManager(client, quest);
                 questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
             }
 

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -6,7 +6,6 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Quests
@@ -154,7 +153,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
             else
             {
-                var proccessState = client.Party.QuestState.GetProcessState(QuestScheduleId, 0);
+                var questStateManager = QuestManager.GetQuestStateManager(client, this);
+
+                var proccessState = questStateManager.GetProcessState(QuestScheduleId, 0);
                 // We need to signal the current block
                 client.Party.SendToAll(new S2CQuestQuestProgressWorkSaveNtc()
                 {
@@ -174,6 +175,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         public override List<CDataQuestProcessState> StateMachineExecute(DdonGameServer server, GameClient client, QuestProcessState processState, out QuestProgressState questProgressState)
         {
+            var questStateManager = QuestManager.GetQuestStateManager(client, this);
+
             if (processState.ProcessNo >= Processes.Count)
             {
                 questProgressState = QuestProgressState.Unknown;
@@ -210,7 +213,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 foreach (var enemyGroupId in questBlock.EnemyGroupIds)
                 {
                     var enemyGroup = EnemyGroups[enemyGroupId];
-                    client.Party.QuestState.SetInstanceEnemies(this, enemyGroup.StageId, (ushort)enemyGroup.SubGroupId, enemyGroup.CreateNewInstance());
+                    questStateManager.SetInstanceEnemies(this, enemyGroup.StageId, (ushort)enemyGroup.SubGroupId, enemyGroup.CreateNewInstance());
                 }
             }
             else
@@ -218,7 +221,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 foreach (var enemyGroupId in questBlock.EnemyGroupIds)
                 {
                     var enemies = EnemyGroups[enemyGroupId];
-                    client.Party.QuestState.SetInstanceEnemies(this, enemies.StageId, (ushort)enemies.SubGroupId, new List<InstancedEnemy>());
+                    questStateManager.SetInstanceEnemies(this, enemies.StageId, (ushort)enemies.SubGroupId, new List<InstancedEnemy>());
                 }
             }
 


### PR DESCRIPTION
Fixed an issue where tutorial quests with enemies caused an exception because the wrong quest state mananager was queried.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
