### PR TITLE
research: Quest Failures

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -143,7 +143,7 @@ namespace Arrowgene.Ddon.Database
 
         // CharacterJobData
         bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null);
-        bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData);
+        bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData, DbConnection? connectionIn = null);
 
         // Wallet Points
         bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint);
@@ -414,37 +414,39 @@ namespace Arrowgene.Ddon.Database
         );
 
         // Rewards
-        bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards);
-        bool DeleteBoxRewardItem(uint commonId, uint uniqId);
-        List<QuestBoxRewards> SelectBoxRewardItems(uint commonId);
+        bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards, DbConnection? connectionIn = null);
+        bool DeleteBoxRewardItem(uint commonId, uint uniqId, DbConnection? connectionIn = null);
+        List<QuestBoxRewards> SelectBoxRewardItems(uint commonId, DbConnection? connectionIn = null);
 
         // Completed Quests
-        List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType);
-        CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId);
+        List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
+        CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId, DbConnection? connectionIn = null);
         bool InsertIfNotExistCompletedQuest(
             uint characterCommonId,
             QuestId questId,
-            QuestType questType
+            QuestType questType,
+            DbConnection? connectionIn = null
         );
 
         bool ReplaceCompletedQuest(
             uint characterCommonId,
             QuestId questId,
             QuestType questType,
-            uint count = 1
+            uint count = 1,
+            DbConnection? connectionIn = null
         );
 
         // Quest Progress
-        bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step);
-        bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step);
-        bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType);
-        List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType);
-        QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId);
+        bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
+        bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
+        bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null);
+        List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
+        QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
 
         // Quest Priority
-        bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId);
-        List<uint> GetPriorityQuestScheduleIds(uint characterCommonId);
-        bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId);
+        bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
+        List<uint> GetPriorityQuestScheduleIds(uint characterCommonId, DbConnection? connectionIn = null);
+        bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
 
         // System mail
         long InsertSystemMailAttachment(SystemMailAttachment attachment);
@@ -495,9 +497,10 @@ namespace Arrowgene.Ddon.Database
         // Play points
         bool ReplaceCharacterPlayPointData(
             uint id,
-            CDataJobPlayPoint updatedCharacterPlayPointData
+            CDataJobPlayPoint updatedCharacterPlayPointData,
+            DbConnection? connectionIn = null
         );
-        bool UpdateCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData);
+        bool UpdateCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData, DbConnection? connectionIn = null);
 
         // Stamps
         public bool InsertCharacterStampData(uint id, CharacterStampBonus stampData);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlCompletedQuests.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlCompletedQuests.cs
@@ -23,19 +23,12 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private readonly string SqlSelectCompletedQuestById = $"SELECT {BuildQueryField(CompletedQuestsFields)} FROM \"ddon_completed_quests\" WHERE \"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id;";
         private readonly string SqlUpdateCompletedQuestId = $"UPDATE \"ddon_completed_quests\" SET \"clear_count\" = @clear_count WHERE \"character_common_id\" = @character_common_id AND \"quest_id\" = @quest_id;";
 
-        public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType)
+        public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null)
         {
-            using TCon connection = OpenNewConnection();
-            return GetCompletedQuestsByType(connection, characterCommonId, questType);
-        }
-
-        public List<CompletedQuest> GetCompletedQuestsByType(TCon connection, uint characterCommonId, QuestType questType)
-        {
-            List<CompletedQuest> results = new List<CompletedQuest>();
-
-            ExecuteInTransaction(conn =>
+            return ExecuteQuerySafe<List<CompletedQuest>>(connectionIn, (connection) =>
             {
-                ExecuteReader(conn, SqlSelectCompletedQuestByType,
+                List<CompletedQuest> results = new List<CompletedQuest>();
+                ExecuteReader(connection, SqlSelectCompletedQuestByType,
                     command => {
                         AddParameter(command, "@character_common_id", characterCommonId);
                         AddParameter(command, "@quest_type", (uint)questType);
@@ -45,90 +38,76 @@ namespace Arrowgene.Ddon.Database.Sql.Core
 
                             results.Add(new CompletedQuest()
                             {
-                                QuestId = (QuestId) GetUInt32(reader, "quest_id"),
+                                QuestId = (QuestId)GetUInt32(reader, "quest_id"),
                                 QuestType = questType,
                                 ClearCount = GetUInt32(reader, "clear_count")
                             });
                         }
                     });
+                return results;
             });
-
-            return results;
         }
 
-        public CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId)
+        public CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId, DbConnection? connectionIn = null)
         {
-            using TCon connection = OpenNewConnection();
-            return GetCompletedQuestsById(connection, characterCommonId, questId);
-        }
-
-        public CompletedQuest GetCompletedQuestsById(TCon connection, uint characterCommonId, QuestId questId)
-        {
-            CompletedQuest result = null;
-
-            ExecuteInTransaction(conn =>
+            return ExecuteQuerySafe<CompletedQuest>(connectionIn, (connection) =>
             {
-                ExecuteReader(conn, SqlSelectCompletedQuestById,
+                CompletedQuest result = null;
+                ExecuteReader(connection, SqlSelectCompletedQuestById,
                     command => {
                         AddParameter(command, "@character_common_id", characterCommonId);
-                        AddParameter(command, "@quest_id", (uint) questId);
+                        AddParameter(command, "@quest_id", (uint)questId);
                     }, reader => {
                         if (reader.Read())
                         {
                             result = new CompletedQuest()
                             {
                                 QuestId = questId,
-                                QuestType = (QuestType) GetUInt32(reader, "quest_type"),
+                                QuestType = (QuestType)GetUInt32(reader, "quest_type"),
                                 ClearCount = GetUInt32(reader, "clear_count")
                             };
                         }
                     });
+                return result;
             });
-
-            return result;
         }
 
-        public bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType)
+        public bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, DbConnection? connectionIn = null)
         {
-            using TCon connection = OpenNewConnection();
-            return InsertIfNotExistCompletedQuest(connection, characterCommonId, questId, questType);
-        }
-
-        public bool InsertIfNotExistCompletedQuest(TCon connection, uint characterCommonId, QuestId questId, QuestType questType)
-        {
-            return ExecuteNonQuery(connection, SqlInsertIfNotExistCompletedQuestId, command =>
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
             {
-                AddParameter(command, "character_common_id", characterCommonId);
-                AddParameter(command, "quest_id", (uint) questId);
-                AddParameter(command, "quest_type", (uint) questType);
-                AddParameter(command, "clear_count", 1);
-            }) == 1;
+                return ExecuteNonQuery(connection, SqlInsertIfNotExistCompletedQuestId, command =>
+                {
+                    AddParameter(command, "character_common_id", characterCommonId);
+                    AddParameter(command, "quest_id", (uint)questId);
+                    AddParameter(command, "quest_type", (uint)questType);
+                    AddParameter(command, "clear_count", 1);
+                }) == 1;
+            });   
         }
 
-        public bool ReplaceCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, uint count = 1)
+        public bool ReplaceCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, uint count = 1, DbConnection? connectionIn = null)
         {
-            using TCon connection = OpenNewConnection();
-            return ReplaceCompletedQuest(connection, characterCommonId, questId, questType, count);
-        }
-
-        public bool ReplaceCompletedQuest(TCon connection, uint characterCommonId, QuestId questId, QuestType questType, uint count = 1)
-        {
-            if (!InsertIfNotExistCompletedQuest(connection, characterCommonId, questId, questType))
+            
+            if (!InsertIfNotExistCompletedQuest(characterCommonId, questId, questType, connectionIn))
             {
-                return UpdateCompletedQuest(connection, characterCommonId, questId, questType, count);
+                return UpdateCompletedQuest(characterCommonId, questId, questType, count, connectionIn);
             }
             return true;
         }
 
-        private bool UpdateCompletedQuest(TCon connection, uint characterCommonId, QuestId questId, QuestType questType, uint count = 1)
+        private bool UpdateCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, uint count = 1, DbConnection? connectionIn = null)
         {
-            return ExecuteNonQuery(connection, SqlUpdateCompletedQuestId, command =>
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
             {
-                AddParameter(command, "character_common_id", characterCommonId);
-                AddParameter(command, "quest_id", (uint)questId);
-                AddParameter(command, "quest_type", (uint)questType);
-                AddParameter(command, "clear_count", count);
-            }) == 1;
+                return ExecuteNonQuery(connection, SqlUpdateCompletedQuestId, command =>
+                {
+                    AddParameter(command, "character_common_id", characterCommonId);
+                    AddParameter(command, "quest_id", (uint)questId);
+                    AddParameter(command, "quest_type", (uint)questType);
+                    AddParameter(command, "clear_count", count);
+                }) == 1;
+            });
         }
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -131,6 +131,34 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             base.ExecuteReader((TCon) conn, sql, (command) => commandAction.Invoke((TCom) command), (reader) => readAction.Invoke((TReader) reader));
         }
 
+        public T ExecuteQuerySafe<T>(DbConnection? connectionIn, Func<TCon, T> work)
+        {
+            bool isTransaction = connectionIn is not null;
+            TCon connection = (TCon)(connectionIn ?? OpenNewConnection());
+            try
+            {
+                return work.Invoke(connection);
+            }
+            finally
+            {
+                if (!isTransaction) connection.Dispose();
+            }
+        }
+
+        public void ExecuteQuerySafe(DbConnection? connectionIn, Action<TCon> work)
+        {
+            bool isTransaction = connectionIn is not null;
+            TCon connection = (TCon)(connectionIn ?? OpenNewConnection());
+            try
+            {
+                work.Invoke(connection);
+            }
+            finally
+            {
+                if (!isTransaction) connection.Dispose();
+            }
+        }
+
         public bool MigrateDatabase(DatabaseMigrator migrator, uint toVersion)
         {
             uint currentVersion = GetMeta().DatabaseVersion;

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -476,7 +476,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
 
             foreach(CDataJobPlayPoint playPoint in character.PlayPointList)
             {
-                ReplaceCharacterPlayPointData(conn, character.ContentCharacterId, playPoint);
+                ReplaceCharacterPlayPointData(character.ContentCharacterId, playPoint, conn);
             }
 
             ExecuteNonQuery(conn, SqlInsertCharacterStamp, (Action<TCom>)(command =>

--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -14,6 +14,7 @@ using Arrowgene.Ddon.GameServer.Party;
 using System.IO;
 using System.Text;
 using System.Buffers.Text;
+using System.Data.Common;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -458,7 +459,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return JobData;
         }
 
-        public void AddExp(GameClient client, CharacterCommon characterToAddExpTo, uint gainedExp, RewardSource rewardType, QuestType questType = QuestType.All)
+        public void AddExp(GameClient client, CharacterCommon characterToAddExpTo, uint gainedExp, RewardSource rewardType, QuestType questType = QuestType.All, DbConnection? connectionIn = null)
         {
             var lvCap = (client.GameMode == GameMode.Normal) 
                 ? _Server.Setting.GameLogicSetting.JobLevelMax
@@ -564,11 +565,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 }
 
                 // PERSIST CHANGES IN DB
-                _Server.Database.UpdateCharacterJobData(characterToAddExpTo.CommonId, activeCharacterJobData);
+                _Server.Database.UpdateCharacterJobData(characterToAddExpTo.CommonId, activeCharacterJobData, connectionIn);
             }
         }
 
-        public void AddJp(GameClient client, CharacterCommon characterToJpExpTo, uint gainedJp, RewardSource rewardType, QuestType questType = QuestType.All)
+        public void AddJp(GameClient client, CharacterCommon characterToJpExpTo, uint gainedJp, RewardSource rewardType, QuestType questType = QuestType.All, DbConnection? connectionIn = null)
         {
             CDataCharacterJobData? activeCharacterJobData = characterToJpExpTo.ActiveCharacterJobData;
             activeCharacterJobData.JobPoint += gainedJp;
@@ -594,7 +595,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             // PERSIST CHANGES IN DB
-            _Server.Database.UpdateCharacterJobData(characterToJpExpTo.CommonId, activeCharacterJobData);
+            _Server.Database.UpdateCharacterJobData(characterToJpExpTo.CommonId, activeCharacterJobData, connectionIn);
         }
 
         public void ResetExpData(GameClient client, CharacterCommon characterCommon)

--- a/Arrowgene.Ddon.GameServer/Characters/PlayPointManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/PlayPointManager.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 using System;
+using System.Data.Common;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters
@@ -25,7 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         private readonly DdonGameServer _Server;
 
-        public void AddPlayPoint(GameClient client, uint gainedPoints, JobId? job = null, byte type = 1)
+        public void AddPlayPoint(GameClient client, uint gainedPoints, JobId? job = null, byte type = 1, DbConnection? connectionIn = null)
         {
             CDataJobPlayPoint? targetPlayPoint;
             if (job is null)
@@ -56,7 +57,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 
                 client.Send(ppNtc);
 
-                _Server.Database.UpdateCharacterPlayPointData(client.Character.CharacterId, targetPlayPoint);
+                _Server.Database.UpdateCharacterPlayPointData(client.Character.CharacterId, targetPlayPoint, connectionIn);
             }
         }
 

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -4,6 +4,8 @@ using Arrowgene.Logging;
 using System.Collections.Generic;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Database.Model;
+using System.Data.Common;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -19,27 +21,27 @@ namespace Arrowgene.Ddon.GameServer.Characters
             _Server = server;
         }
 
-        public bool AddQuestRewards(GameClient client, Quest quest)
+        public bool AddQuestRewards(GameClient client, Quest quest, DbConnection? connectionIn = null)
         {
             var rewards = quest.GenerateBoxRewards();
 
-            var currentRewards = GetQuestBoxRewards(client);
+            var currentRewards = GetQuestBoxRewards(client, connectionIn);
             if (currentRewards.Count >= MAX_REWARD_BOX_RESULTS)
             {
                 return false;
             }
 
-            return _Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards);
+            return _Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
         }
 
-        public List<QuestBoxRewards> GetQuestBoxRewards(GameClient client)
+        public List<QuestBoxRewards> GetQuestBoxRewards(GameClient client, DbConnection? connectionIn = null)
         {
-            return _Server.Database.SelectBoxRewardItems(client.Character.CommonId);
+            return _Server.Database.SelectBoxRewardItems(client.Character.CommonId, connectionIn);
         }
 
-        public bool DeleteQuestBoxReward(GameClient client, uint uniqId)
+        public bool DeleteQuestBoxReward(GameClient client, uint uniqId, DbConnection? connectionIn = null)
         {
-            return _Server.Database.DeleteBoxRewardItem(client.Character.CommonId, uniqId);
+            return _Server.Database.DeleteBoxRewardItem(client.Character.CommonId, uniqId, connectionIn);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -179,6 +179,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         gainedExp = 0;
                     }
 
+                    // TODO: Add transaction?
                     playerMember.QuestState.HandleEnemyHuntRequests(enemyKilled);
 
                     S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc();

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -7,6 +7,7 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using System.Data.Common;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -51,45 +52,47 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 res.QuestProcessState = quest.StateMachineExecute(Server, client, processState, out questProgressState);
                 questStateManager.UpdateProcessState(questScheduleId, res.QuestProcessState);
 
-                if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.World)
+                Server.Database.ExecuteInTransaction(connection =>
                 {
-                    foreach (var memberClient in client.Party.Clients)
+                    if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.World)
                     {
-                        var questProgress = Server.Database.GetQuestProgressByScheduleId(memberClient.Character.CommonId, questScheduleId);
-
-                        if (questProgress != null)
+                        foreach (var memberClient in client.Party.Clients)
                         {
-                            continue;
-                        }
+                            var questProgress = Server.Database.GetQuestProgressByScheduleId(memberClient.Character.CommonId, questScheduleId, connection);
+                            if (questProgress != null)
+                            {
+                                continue;
+                            }
 
-                        // Add a new world quest record for the player
-                        if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, questScheduleId, quest.QuestType, 0))
+                            // Add a new world quest record for the player
+                            if (!Server.Database.InsertQuestProgress(memberClient.Character.CommonId, questScheduleId, quest.QuestType, 0, connection))
+                            {
+                                Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
+                            }
+                        }
+                    }
+                    else if (questProgressState == QuestProgressState.Accepted &&
+                             (quest.QuestType == QuestType.Tutorial ||
+                              quest.QuestType == QuestType.WildHunt ||
+                              quest.QuestType == QuestType.Light))
+                    {
+                        // Add a new personal quest record for the player
+                        if (!Server.Database.InsertQuestProgress(client.Character.CommonId, questScheduleId, quest.QuestType, 0, connection))
                         {
                             Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
                         }
                     }
-                }
-                else if (questProgressState == QuestProgressState.Accepted && (
-                    quest.QuestType == QuestType.Tutorial 
-                    || quest.QuestType == QuestType.WildHunt
-                    || quest.QuestType == QuestType.Light))
-                {
-                    // Add a new personal quest record for the player
-                    if (!Server.Database.InsertQuestProgress(client.Character.CommonId, questScheduleId, quest.QuestType, 0))
-                    {
-                        Logger.Error($"Failed to insert progress for the quest {quest.QuestId}");
-                    }
-                }
 
-                if (questProgressState == QuestProgressState.Checkpoint || questProgressState == QuestProgressState.Accepted)
-                {
-                    questStateManager.UpdateQuestProgress(questScheduleId);
-                }
-                else if (questProgressState == QuestProgressState.Complete)
-                {
-                    res.QuestProgressResult = 3; // ProcessEnd
-                    CompleteQuest(quest, client, questStateManager);
-                }
+                    if (questProgressState == QuestProgressState.Checkpoint || questProgressState == QuestProgressState.Accepted)
+                    {
+                        questStateManager.UpdateQuestProgress(questScheduleId, connection);
+                    }
+                    else if (questProgressState == QuestProgressState.Complete)
+                    {
+                        res.QuestProgressResult = 3; // ProcessEnd
+                        CompleteQuest(quest, client, questStateManager, connection);
+                    }
+                });
 
                 if (res.QuestProcessState.Count > 0)
                 {
@@ -122,10 +125,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
             client.Send(res);
         }
 
-        private void CompleteQuest(Quest quest, GameClient client, QuestStateManager questState)
+        private void CompleteQuest(Quest quest, GameClient client, QuestStateManager questState, DbConnection? connectionIn = null)
         {
-            questState.DistributeQuestRewards(quest.QuestScheduleId);
-            questState.CompleteQuestProgress(quest.QuestScheduleId);
+            questState.DistributeQuestRewards(quest.QuestScheduleId, connectionIn);
+            questState.CompleteQuestProgress(quest.QuestScheduleId, connectionIn);
 
             S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
             {
@@ -146,13 +149,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 // Finishing personal quests as a non-leader shouldn't adjust the list.
                 if (client.Party.IsSolo || client.Party.Leader?.Client == client)
                 {
-                    client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client);
+                    client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client, connectionIn);
                 }
             }
             else
             {
                 client.Party.SendToAll(completeNtc);
-                client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client);
+                client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client, connectionIn);
             }
 
             if (quest.ResetPlayerAfterQuest)

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -191,7 +191,7 @@ namespace Arrowgene.Ddon.Test.Database
         public void CreateItems(DbConnection connection, Character character) { }
         public bool DeleteAccount(int accountId) { return true; }
         public int DeleteBazaarExhibition(ulong bazaarId) { return 1; }
-        public bool DeleteBoxRewardItem(uint commonId, uint uniqId) { return true; }
+        public bool DeleteBoxRewardItem(uint commonId, uint uniqId, DbConnection? connectionIn = null) { return true; }
         public bool DeleteCharacter(uint characterId) { return true; }
         public bool DeleteCommunicationShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
         public bool DeleteConnection(int serverId, int accountId) { return true; }
@@ -206,7 +206,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool DeleteEquippedCustomSkill(uint commonId, JobId job, byte slotNo) { return true; }
         public bool DeleteNormalSkillParam(uint commonId, JobId job, uint skillNo) { return true; }
         public bool DeletePawn(uint pawnId) { return true; }
-        public bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId) { return true; }
+        public bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return true; }
         public bool DeleteReleasedWarpPoint(uint characterId, uint warpPointId) { return true; }
         public bool DeleteShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
         public bool DeleteSpSkill(uint pawnId, JobId job, byte spSkillId) { return true; }
@@ -220,15 +220,15 @@ namespace Arrowgene.Ddon.Test.Database
         public void Execute(string sql) {}
         public void Execute(DbConnection conn, string sql) {}
         public List<BazaarExhibition> FetchCharacterBazaarExhibitions(uint characterId) { return new List<BazaarExhibition>(); }
-        public CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId) { return new CompletedQuest(); }
-        public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType) { return new List<CompletedQuest>(); }
+        public CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId, DbConnection? connectionIn = null) { return new CompletedQuest(); }
+        public List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null) { return new List<CompletedQuest>(); }
         public bool CreateMeta(DatabaseMeta meta) { return true; }
         public DatabaseMeta GetMeta() { return new DatabaseMeta(); }
-        public List<uint> GetPriorityQuestScheduleIds(uint characterCommonId) { return new List<uint>(); }
-        public QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId) { return new QuestProgress(); }
-        public List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType) { return new List<QuestProgress>(); }
+        public List<uint> GetPriorityQuestScheduleIds(uint characterCommonId, DbConnection? connectionIn = null) { return new List<uint>(); }
+        public QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return new QuestProgress(); }
+        public List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null) { return new List<QuestProgress>(); }
         public ulong InsertBazaarExhibition(BazaarExhibition exhibition) { return 1; }
-        public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards) { return true; }
+        public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards, DbConnection? connectionIn = null) { return true; }
         public bool InsertCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut) { return true; }
         public bool InsertConnection(Connection connection) { return true; }
         public int InsertContact(uint requestingCharacterId, uint requestedCharacterId, ContactListStatus status, ContactListType type, bool requesterFavorite, bool requestedFavorite) { return 1; }
@@ -237,7 +237,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertEquippedAbility(uint commonId, JobId equipptedToJob, byte slotNo, Ability ability) { return true; }
         public bool InsertEquippedCustomSkill(uint commonId, byte slotNo, CustomSkill skill) { return true; }
         public bool InsertGainExtendParam(uint commonId, CDataOrbGainExtendParam Param) { return true; }
-        public bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType) { return true; }
+        public bool InsertIfNotExistCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, DbConnection? connectionIn = null) { return true; }
         public bool InsertIfNotExistsDragonForceAugmentation(uint commonId, uint elementId, uint pageNo, uint groupNo, uint indexNo) { return true; }
         public bool InsertIfNotExistsNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
         public bool InsertIfNotExistsPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
@@ -247,8 +247,8 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertLearnedCustomSkill(uint commonId, CustomSkill skill) { return true; }
         public bool InsertNormalSkillParam(uint commonId, CDataNormalSkillParam normalSkillParam) { return true; }
         public bool InsertPawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
-        public bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId) { return true; }
-        public bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step) { return true; }
+        public bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return true; }
+        public bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null) { return true; }
         public bool InsertReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
         public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility) { return true; }
         public bool InsertShortcut(uint characterId, CDataShortCut shortcut) { return true; }
@@ -257,7 +257,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertStorage(uint characterId, StorageType storageType, Storage storage) { return true; }
         public bool InsertStorageItem(uint characterId, StorageType storageType, ushort slotNo, uint itemNum, Item item, DbConnection? connectionIn = null) { return true; }
         public bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
-        public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType) { return true; }
+        public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId, DbConnection? connectionIn = null) { return true; }
@@ -271,7 +271,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool ReplaceShortcut(uint characterId, CDataShortCut shortcut, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceStorageItem(uint characterId, StorageType storageType, ushort slotNo, uint itemNum, Item item, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
-        public bool ReplaceCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, uint count) { return true; }
+        public bool ReplaceCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, uint count, DbConnection? connectionIn = null) { return true; }
         public Account SelectAccountById(int accountId) { return new Account(); }
         public Account SelectAccountByLoginToken(string loginToken) { return new Account(); }
         public Account SelectAccountByName(string accountName) { return new Account(); }
@@ -279,7 +279,7 @@ namespace Arrowgene.Ddon.Test.Database
         public List<BazaarExhibition> SelectActiveBazaarExhibitionsByItemIdsExcludingOwn(List<uint> itemIds, uint excludedCharacterId) { return new List<BazaarExhibition>(); }
         public List<SecretAbility> SelectAllUnlockedSecretAbilities(uint commonId) { return new List<SecretAbility>(); }
         public BazaarExhibition SelectBazaarExhibitionByBazaarId(ulong bazaarId) { return new BazaarExhibition(); }
-        public List<QuestBoxRewards> SelectBoxRewardItems(uint commonId) { return new List<QuestBoxRewards>(); }
+        public List<QuestBoxRewards> SelectBoxRewardItems(uint commonId, DbConnection? connectionIn = null) { return new List<QuestBoxRewards>(); }
         public Character SelectCharacter(uint characterId) { return new Character(); }
         public List<Character> SelectCharactersByAccountId(int accountId, GameMode gameMode) { return new List<Character>(); }
         public List<Character> SelectAllCharacters() { return new List<Character>(); }
@@ -309,7 +309,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool UpdateCharacterArisenProfile(Character character) { return true; }
         public bool UpdateCharacterBaseInfo(Character character) { return true; }
         public bool UpdateCharacterCommonBaseInfo(CharacterCommon common, DbConnection? connectionIn = null) { return true; }
-        public bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData) { return true; }
+        public bool UpdateCharacterJobData(uint commonId, CDataCharacterJobData updatedCharacterJobData, DbConnection? connectionIn = null) { return true; }
         public bool UpdateCharacterMatchingProfile(Character character) { return true; }
         public bool UpdateCommunicationShortcut(uint characterId, uint oldPageNo, uint oldButtonNo, CDataCommunicationShortCut updatedCommunicationShortcut) { return true; }
         public int UpdateContact(uint requestingCharacterId, uint requestedCharacterId, ContactListStatus status, ContactListType type, bool requesterFavorite, bool requestedFavorite) { return 1; }
@@ -329,7 +329,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertIfNotExistsPawnCraftProgress(CraftProgress craftProgress) { return true; }
         public bool UpdatePawnCraftProgress(CraftProgress craftProgress) { return true; }
         public bool DeletePawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId) { return true; }
-        public bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step) { return true; }
+        public bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null) { return true; }
         public bool UpdateReleasedWarpPoint(uint characterId, ReleasedWarpPoint updatedReleasedWarpPoint) { return true; }
         public bool UpdateShortcut(uint characterId, uint oldPageNo, uint oldButtonNo, CDataShortCut updatedShortcut) { return true; }
         public bool UpdateStatusInfo(CharacterCommon character) { return true; }
@@ -359,8 +359,8 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertAddStatus(string itemUid, uint characterId, byte isAddStat1, byte isAddStat2, ushort addStat1, ushort addStat2) { return true; }
         public List<CDataAddStatusParam> GetAddStatusByUID(string itemUid) { return new List<CDataAddStatusParam>(); }
         public bool UpdateAddStatus(string itemUid, uint characterId, byte isAddStat1, byte isAddStat2, ushort addStat1, ushort addStat2) { return true; }
-        public bool ReplaceCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData) { return true; }
-        public bool UpdateCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData) { return true; }
+        public bool ReplaceCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData, DbConnection? connectionIn = null) { return true; }
+        public bool UpdateCharacterPlayPointData(uint id, CDataJobPlayPoint updatedCharacterPlayPointData, DbConnection? connectionIn = null) { return true; }
         public bool InsertCharacterStampData(uint id, CharacterStampBonus stampData) { return true; }
         public bool UpdateCharacterStampData(uint id, CharacterStampBonus stampData) { return true; }
         public bool InsertCrest(uint characterCommonId, string itemUId, uint slot, uint crestId, uint crestAmount, DbConnection? connectionIn = null) { return true; }


### PR DESCRIPTION
Add quest database interactions to transactions to prevent slowness when the database is being accessed by multiple users.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
