### PR TITLE
fixes: Adjust enemy spawn behavior for quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -33,8 +33,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
             foreach (var questScheduleId in QuestManager.CollectQuestScheduleIds(client, stageId))
             {
                 quest = QuestManager.GetQuestByScheduleId(questScheduleId);
-                // if (client.Party.QuestState.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
-                if (quest.HasEnemiesInInCurrentStage(stageId))
+
+                var questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                if (quest.OverrideEnemySpawn && quest.HasEnemiesInInCurrentStage(stageId))
+                {
+                    IsQuestControlled = true;
+                    break;
+                }
+                else if (!quest.OverrideEnemySpawn && questStateManager.HasEnemiesInCurrentStageGroup(quest, stageId, subGroupId))
                 {
                     IsQuestControlled = true;
                     break;

--- a/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
@@ -29,9 +29,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
                 var questStateManager = QuestManager.GetQuestStateManager(client, quest);
                 var questState = questStateManager.GetQuestState(questScheduleId);
-                if (quest is null || questState is null)
+                if (!QuestManager.IsQuestEnabled(questScheduleId) || questState is null)
                 {
-                    Logger.Error(client, $"Priority quest for quest state which doesn't exist, schedule {questScheduleId}");
+                    Logger.Error(client, $"Priority quest for quest state which doesn't exist or is not enabled, schedule {questScheduleId}");
                     Server.Database.DeletePriorityQuest(client.Character.CommonId, questScheduleId);
                     continue;
                 }

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -33,9 +33,10 @@ namespace Arrowgene.Ddon.GameServer.Quests
             quest.StageId = questAsset.StageId;
             quest.MissionParams = questAsset.MissionParams;
             quest.ServerActions = questAsset.ServerActions;
-            quest.Enabled = questAsset.Enabled;
             quest.QuestOrderBackgroundImage = questAsset.QuestOrderBackgroundImage;
             quest.LightQuestDetail = questAsset.LightQuestDetail;
+            quest.Enabled = questAsset.Enabled;
+            quest.OverrideEnemySpawn = questAsset.OverrideEnemySpawn;
 
             foreach (var pointReward in questAsset.PointRewards)
             {

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -89,6 +89,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public HashSet<StageId> UniqueEnemyGroups { get; protected set; }
         public List<QuestServerAction> ServerActions { get; protected set; }
         public bool Enabled { get; protected set; }
+        public bool OverrideEnemySpawn { get; protected set; }
 
         public bool IsPersonal { get
             {

--- a/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
@@ -35,6 +35,7 @@ namespace Arrowgene.Ddon.Shared.Asset
         public ushort BaseLevel { get; set; }
         public byte MinimumItemRank { get; set; }
         public bool Enabled { get; set; }
+        public bool OverrideEnemySpawn { get; set; }
 
         public List<PointReward> PointRewards { get; set; }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -114,6 +114,12 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 assetData.QuestScheduleId = jQuestScheduleId.GetUInt32();
             }
 
+            assetData.OverrideEnemySpawn = (assetData.Type == QuestType.Main || assetData.Type == QuestType.ExtremeMission);
+            if (jQuest.TryGetProperty("override_enemy_spawn", out JsonElement jOverrideEnemySpawn))
+            {
+                assetData.OverrideEnemySpawn = jOverrideEnemySpawn.GetBoolean();
+            }
+
             if (jQuest.TryGetProperty("quest_layout_set_info_flags", out JsonElement jLayoutSetInfoFlags))
             {
                 foreach (var layoutFlag in jLayoutSetInfoFlags.EnumerateArray())

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
@@ -134,6 +134,7 @@
         "id": 1,
         "group_id": 6
       },
+      "starting_index": 6,
       "enemies": [
         {
           "enemy_id": "0x011110",


### PR DESCRIPTION
- If an active quest is a main story quest or EXM, these quests will override all behavior of a spawn group for the duration of the quest.
- If any other type of quest is activated, the spawns will only be overridden if the current step of the quest requires the spawn group.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
