### PR TITLE
fix for postgres

### DIFF
--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -22,7 +22,7 @@
     <ItemGroup>
         <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />
         <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
-        <PackageReference Include="Npgsql" Version="7.0.6" />
+        <PackageReference Include="Npgsql" Version="7.0.7" />
         <PackageReference Include="MySqlConnector" Version="2.2.7" />
     </ItemGroup>
 

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -48,6 +48,7 @@ namespace Arrowgene.Ddon.Database
 
         public static string AdaptSQLiteSchemaToPostgreSQL(string schema)
         {
+            schema = Regex.Replace(schema, @"TINYINT", "SMALLINT", RegexOptions.IgnoreCase);
             schema = Regex.Replace(schema, @"(\s)DATETIME(\s|,)", "$1TIMESTAMP WITH TIME ZONE$2", RegexOptions.IgnoreCase);
             schema = Regex.Replace(schema, @"(\s)INTEGER PRIMARY KEY AUTOINCREMENT(\s|,)", "$1SERIAL PRIMARY KEY$2", RegexOptions.IgnoreCase);
             schema = Regex.Replace(schema, @"(\s)BLOB(\s|,)", "$1BYTEA$2", RegexOptions.IgnoreCase);


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

postgress does not support the tinyint data type, so it gets replaced in the sql file with smallint

the Npgsql lib has an sql injection vuln so I also upgraded it to a version that has it patched

# Checklist:
- [x ] The project compiles
- [x ] The PR targets `develop` branch
