### PR TITLE
Fix/misc quest changes

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -899,11 +899,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return multiplier;
         }
 
+        private double ModifierBasedOnSource(RewardSource source)
+        {
+            return source == RewardSource.Enemy ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+        }
+
         public uint GetAdjustedExp(GameMode gameMode, RewardSource source, PartyGroup party, uint baseExpAmount, uint targetLv)
         {
             if (_Server.GpCourseManager.DisablePartyExpAdjustment())
             {
-                return (uint)(baseExpAmount * _GameSettings.ExpModifier);
+                return (uint)(baseExpAmount * ModifierBasedOnSource(source));
             }
 
             double multiplier = 1.0;
@@ -913,8 +918,12 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 var partyRangeMultiplier = CalculatePartyRangeMultipler(gameMode, party);
                 multiplier = Math.Min(partyRangeMultiplier, targetMultiplier);
             }
-            
-            return (uint)(multiplier * baseExpAmount * _GameSettings.ExpModifier);
+            else if (source == RewardSource.Quest)
+            {
+                // Currently no adjustments
+            }
+
+            return (uint)(multiplier * baseExpAmount * ModifierBasedOnSource(source));
         }
 
         private uint GetMaxAllowedPartyRange()
@@ -996,13 +1005,13 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             if (!_GameSettings.EnablePawnCatchup || gameMode == GameMode.BitterblackMaze)
             {
-                return (uint)(baseExpAmount * _GameSettings.ExpModifier);
+                return (uint)(baseExpAmount * ModifierBasedOnSource(source));
             }
 
             var targetMultiplier = CalculatePawnCatchupTargetLvMultiplier(gameMode, pawn, targetLv);
             var multiplier = _GameSettings.PawnCatchupMultiplier * targetMultiplier;
 
-            return (uint)(multiplier * baseExpAmount * _GameSettings.ExpModifier);
+            return (uint)(multiplier * baseExpAmount * ModifierBasedOnSource(source));
         }
     }
 }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -169,43 +169,53 @@ namespace Arrowgene.Ddon.Server
         /// <summary>
         /// Global modifier for exp calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 26)] public double ExpModifier { get; set; }
+        [DataMember(Order = 27)] public double EnemyExpModifier { get; set; }
+
+        /// <summary>
+        /// Global modifier for quest exp calculations to scale up or down.
+        /// </summary>
+        [DataMember(Order = 28)] public double QuestExpModifier { get; set; }
 
         /// <summary>
         /// Global modifier for pp calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 26)] public double PpModifier { get; set; }
+        [DataMember(Order = 29)] public double PpModifier { get; set; }
 
         /// <summary>
         /// Global modifier for BO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 26)] public double BoModifier { get; set; }
+        [DataMember(Order = 30)] public double BoModifier { get; set; }
 
         /// <summary>
         /// Global modifier for HO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 26)] public double HoModifier { get; set; }
+        [DataMember(Order = 31)] public double HoModifier { get; set; }
 
         /// <summary>
         /// Global modifier for JP calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 26)] public double JpModifier { get; set; }
+        [DataMember(Order = 32)] public double JpModifier { get; set; }
 
         /// <summary>
         /// Configures the maximum amount of reward box slots.
         /// </summary>
-        [DataMember(Order = 27)] public byte RewardBoxMax { get; set; }
+        [DataMember(Order = 33)] public byte RewardBoxMax { get; set; }
 
         /// <summary>
         /// Configures the maximum amount of quests that can be ordered at one time.
         /// </summary>
-        [DataMember(Order = 27)] public byte QuestOrderMax { get; set; }
+        [DataMember(Order = 34)] public byte QuestOrderMax { get; set; }
 
         /// <summary>
         /// Configures if epitaph rewards are limited once per weekly reset.
         /// </summary>
-        [DataMember(Order = 28)] public bool EnableEpitaphWeeklyRewards { get; set; }
+        [DataMember(Order = 35)] public bool EnableEpitaphWeeklyRewards { get; set; }
 
+        /// Enables main pawns in party to gain EXP and JP from quests
+        /// Original game apparantly did not have pawns share quest reward, so will set to false for default, 
+        /// change as needed
+        /// </summary>
+        [DataMember(Order = 36)] public bool EnableMainPartyPawnsQuestRewards { get; set; }
 
         /// <summary>
         /// Various URLs used by the client.
@@ -290,7 +300,8 @@ namespace Arrowgene.Ddon.Server
             DefaultMaxBazaarExhibits = 5;
             DefaultWarpFavorites = 3;
 
-            ExpModifier = 1.0;
+            EnemyExpModifier = 1.0;
+            QuestExpModifier = 1.0;
             PpModifier = 1.0;
             BoModifier = 1.0;
             HoModifier = 1.0;
@@ -299,6 +310,7 @@ namespace Arrowgene.Ddon.Server
             QuestOrderMax = 20;
 
             EnableEpitaphWeeklyRewards = false;
+            EnableMainPartyPawnsQuestRewards = false;
 
             string urlDomain = $"http://localhost:{52099}";
             UrlManual = $"{urlDomain}/manual_nfb/";
@@ -352,7 +364,8 @@ namespace Arrowgene.Ddon.Server
             DefaultMaxBazaarExhibits = setting.DefaultMaxBazaarExhibits;
             DefaultWarpFavorites = setting.DefaultWarpFavorites;
 
-            ExpModifier = setting.ExpModifier;
+            EnemyExpModifier = setting.EnemyExpModifier;
+            QuestExpModifier = setting.QuestExpModifier;
             PpModifier = setting.PpModifier;
             BoModifier = setting.BoModifier;
             HoModifier = setting.HoModifier;
@@ -361,6 +374,7 @@ namespace Arrowgene.Ddon.Server
             QuestOrderMax = setting.QuestOrderMax;
 
             EnableEpitaphWeeklyRewards = setting.EnableEpitaphWeeklyRewards;
+            EnableMainPartyPawnsQuestRewards = setting.EnableMainPartyPawnsQuestRewards;
 
             UrlManual = setting.UrlManual;
             UrlShopDetail = setting.UrlShopDetail;
@@ -436,9 +450,13 @@ namespace Arrowgene.Ddon.Server
             {
                 PawnCatchupMultiplier = 1.0;
             }
-            if (ExpModifier < 0)
+            if (EnemyExpModifier < 0)
             {
-                ExpModifier = 1.0;
+                EnemyExpModifier = 1.0;
+            }
+            if (QuestExpModifier < 0)
+            {
+                QuestExpModifier = 1.0;
             }
             if (PpModifier < 0)
             {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 9456,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 200
                 }
             ]
         },
@@ -290,7 +294,6 @@
                     "named_enemy_params_id": 631,
                     "level": 58,
                     "exp": 0,
-                    "blood_orbs": 200,
                     "is_boss": true
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50102020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50102020.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 9457,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 200
                 }
             ]
         },
@@ -204,7 +208,6 @@
                     "index": 0,
                     "level": 60,
                     "exp": 0,
-                    "blood_orbs": 200,
                     "named_enemy_params_id": 682,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50103020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50103020.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 9788,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 200
                 }
             ]
         },
@@ -185,7 +189,6 @@
                     "enemy_id": "0x015711",
                     "level": 60,
                     "exp": 0,
-                    "blood_orbs": 100,
                     "is_boss": true
                 },
                 {
@@ -193,7 +196,6 @@
                     "enemy_id": "0x015840",
                     "level": 60,
                     "exp": 0,
-                    "blood_orbs": 100,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 9789,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 1000
                 }
             ]
         },
@@ -49,7 +53,6 @@
                     "enemy_id": "0x021002",
                     "level": 60,
                     "exp": 0,
-                    "blood_orbs": 1000,
                     "named_enemy_params_id": 440,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 11780,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 500
                 }
             ]
         },
@@ -50,7 +54,6 @@
                     "level": 65,
                     "exp": 0,
                     "is_boss": true,
-                    "blood_orbs": 500,
                     "named_enemy_params_id": 1674
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 11810,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 650
                 }
             ]
         },
@@ -49,7 +53,6 @@
                     "enemy_id": "0x021003",
                     "level": 70,
                     "exp": 0,
-                    "blood_orbs": 650,
                     "named_enemy_params_id": 942,
                     "is_boss": true
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50203000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50203000.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 15940,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 750
                 }
             ]
         },
@@ -49,7 +53,6 @@
                     "enemy_id": "0x080600",
                     "level": 75,
                     "exp": 0,
-                    "blood_orbs": 750,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204001.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 41,
                     "num": 1
+                },
+                {
+                    "item_id": 7795,
+                    "num": 2000
                 }
             ]
         },
@@ -74,7 +78,6 @@
                     "enemy_id": "0x080502",
                     "level": 80,
                     "exp": 0,
-                    "blood_orbs": 2000,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50204002.json
@@ -24,6 +24,10 @@
                 {
                     "item_id": 15997,
                     "num": 3
+                },
+                {
+                    "item_id": 7795,
+                    "num": 1000
                 }
             ]
         },
@@ -49,7 +53,6 @@
                     "enemy_id": "0x080501",
                     "level": 80,
                     "exp": 0,
-                    "blood_orbs": 1000,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300001.json
@@ -20,11 +20,15 @@
     "rewards": [
         {
             "type": "fixed",
-            "comment": "Green Dye",
+            "comment": "Green Dye, Blood Orb",
             "loot_pool": [
                 {
                     "item_id": 8136,
                     "num": 1
+                },
+                {
+                    "item_id": 7795,
+                    "num": 200
                 }
             ]
         },
@@ -159,7 +163,6 @@
                     "enemy_id": "0x080200",
                     "level": 45,
                     "exp": 0,
-                    "blood_orbs": 200,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300003.json
@@ -20,11 +20,15 @@
     "rewards": [
         {
             "type": "fixed",
-            "comment": "Pink Dye",
+            "comment": "Pink Dye, Blood Orb",
             "loot_pool": [
                 {
                     "item_id": 8139,
                     "num": 1
+                },
+                {
+                    "item_id": 7795,
+                    "num": 500
                 }
             ]
         },
@@ -159,8 +163,7 @@
                     "enemy_id": "0x080300",
                     "level": 55,
                     "exp": 0,
-                    "is_boss": true,
-                    "blood_orbs": 500
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300006.json
@@ -20,11 +20,15 @@
     "rewards": [
         {
             "type": "fixed",
-            "comment": "Yellow Dye",
+            "comment": "Yellow Dye, Blood Orb",
             "loot_pool": [
                 {
                     "item_id": 8138,
                     "num": 1
+                },
+                {
+                    "item_id": 7795,
+                    "num": 1000
                 }
             ]
         },
@@ -159,7 +163,6 @@
                     "enemy_id": "0x080100",
                     "level": 60,
                     "exp": 0,
-                    "blood_orbs": 1000,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50300010.json
@@ -19,6 +19,16 @@
     "order_conditions": [],
     "rewards": [
         {
+            "type": "fixed",
+            "comment": "Blood Orb",
+            "loot_pool": [
+                {
+                    "item_id": 7795,
+                    "num": 1500
+                }
+            ]
+        },
+        {
             "type": "random",
             "loot_pool": [
                 {
@@ -136,7 +146,6 @@
                     "level": 80,
                     "exp": 0,
                     "is_boss": true,
-                    "blood_orbs": 1500,
                     "named_enemy_params_id": 1564
                 }
             ]


### PR DESCRIPTION
Move EXM BO rewards from enemy drop to quest reward
Add config to allow pawns to get quest rewards (EXP/JP) (disabled by default to match original game behavior)

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
