### PR TITLE
fix: Add checks for null when setting prioirty quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
@@ -1,7 +1,6 @@
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -34,8 +33,26 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
 
                 var quest = QuestManager.GetQuestByScheduleId(questScheduleId);
+                if (quest == null)
+                {
+                    Logger.Error(client, $"No quest object exists for ${questScheduleId}");
+                    continue;
+                }
+
                 var questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                if (questStateManager == null)
+                {
+                    Logger.Error(client, $"Unable to fetch the quest state manager for ${questScheduleId}");
+                    continue;
+                }
+
                 var questState = questStateManager.GetQuestState(questScheduleId);
+                if (questState == null)
+                {
+                    Logger.Error(client, $"Failed to find quest state for ${questScheduleId}");
+                    continue;
+                }
+
                 ntc.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState.Step));
             }
 


### PR DESCRIPTION
Added some checks and logs round priority quests to help track down some bugs which cause a NPE to occur.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
