### PR TITLE
feat: Implement a generic task scheduler

### DIFF
--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -41,5 +41,8 @@
       <None Update="Files\Database\Script\migration_epitaph_road.sql">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="Files\Database\Script\migration_scheduling.sql">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 </Project>

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -14,7 +14,7 @@ namespace Arrowgene.Ddon.Database
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-        public const uint Version = 26;
+        public const uint Version = 27;
 
         public static IDatabase Build(DatabaseSetting settings)
         {

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_scheduling.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_scheduling.sql
@@ -1,0 +1,7 @@
+CREATE TABLE ddon_schedule_next (
+	"type"	INTEGER NOT NULL,
+	"timestamp"	BIGINT NOT NULL,
+	PRIMARY KEY("type")
+);
+
+INSERT INTO ddon_schedule_next(type, timestamp) VALUES (19, 0);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -782,3 +782,11 @@ CREATE TABLE IF NOT EXISTS ddon_epitaph_claimed_weekly_rewards (
     CONSTRAINT "pk_ddon_epitaph_claimed_weekly_rewards" PRIMARY KEY ("character_id", "epitaph_id"),
 	CONSTRAINT "fk_ddon_epitaph_claimed_weekly_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character"("character_id") ON DELETE CASCADE
 );
+
+
+CREATE TABLE IF NOT EXISTS ddon_schedule_next (
+	"type"	INTEGER NOT NULL,
+	"timestamp"	BIGINT NOT NULL,
+	PRIMARY KEY("type")
+);
+INSERT INTO ddon_schedule_next(type, timestamp) VALUES (19, 0);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -11,6 +11,7 @@ using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.BattleContent;
 using Arrowgene.Ddon.Shared.Model.Clan;
 using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
 
 namespace Arrowgene.Ddon.Database
 {
@@ -590,6 +591,10 @@ namespace Arrowgene.Ddon.Database
 
         bool InsertEpitaphWeeklyReward(uint characterId, uint epitaphId, DbConnection? connectionIn = null);
         HashSet<uint> GetEpitaphClaimedWeeklyRewards(uint characterId, DbConnection? connectionIn = null);
-        void DeleteWeeklyRewards(DbConnection? connectionIn = null);
+        void DeleteWeeklyEpitaphClaimedRewards(DbConnection? connectionIn = null);
+
+        // Scheduler
+        Dictionary<TaskType, SchedulerTaskEntry> SelectAllTaskEntries();
+        bool UpdateScheduleInfo(TaskType type, long timestamp);
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbEpitaphRoadClaimedWeeklyRewards.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbEpitaphRoadClaimedWeeklyRewards.cs
@@ -49,7 +49,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return results;
         }
 
-        public void DeleteWeeklyRewards(DbConnection? connectionIn = null)
+        public void DeleteWeeklyEpitaphClaimedRewards(DbConnection? connectionIn = null)
         {
             ExecuteQuerySafe(connectionIn, (connection) =>
             {

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbScheduleNext.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbScheduleNext.cs
@@ -1,0 +1,49 @@
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        protected static readonly string[] ScheduleNextFields = new string[]
+        {
+            "type", "timestamp"
+        };
+
+        private static readonly string SqlUpdateScheduleNext = $"UPDATE \"ddon_schedule_next\" SET \"timestamp\"=@timestamp WHERE \"type\"=@type;";
+        private static readonly string SqlSelectScheduleNext = $"SELECT {BuildQueryField(ScheduleNextFields)} FROM \"ddon_schedule_next\";";
+
+
+        public Dictionary<TaskType, SchedulerTaskEntry> SelectAllTaskEntries()
+        {
+            Dictionary<TaskType, SchedulerTaskEntry> results = new Dictionary<TaskType, SchedulerTaskEntry>();
+            ExecuteReader(SqlSelectScheduleNext, command => { }, reader =>
+            {
+                while (reader.Read())
+                {
+                    TaskType type = (TaskType) GetUInt32(reader, "type");
+                    results[type] = new SchedulerTaskEntry()
+                    {
+                        Type = type,
+                        Timestamp = GetInt64(reader, "timestamp")
+                    };
+                }
+            });
+            return results;
+        }
+
+        public bool UpdateScheduleInfo(TaskType type, long timestamp)
+        {
+            return ExecuteNonQuery(SqlUpdateScheduleNext, command =>
+            {
+                AddParameter(command, "@type", (uint) type);
+                AddParameter(command, "@timestamp", timestamp);
+            }) == 1;
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000026_TaskSchedulerMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000026_TaskSchedulerMigration.cs
@@ -1,0 +1,25 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class TaskSchedulerMigration : IMigrationStrategy
+    {
+        public uint From => 25;
+        public uint To => 26;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public TaskSchedulerMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(DatabaseSetting, "Script/migration_scheduling.sql");
+            db.Execute(conn, adaptedSchema);
+            return true;
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000026_TaskSchedulerMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000026_TaskSchedulerMigration.cs
@@ -4,8 +4,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core.Migration
 {
     public class TaskSchedulerMigration : IMigrationStrategy
     {
-        public uint From => 25;
-        public uint To => 26;
+        public uint From => 26;
+        public uint To => 27;
 
         private readonly DatabaseSetting DatabaseSetting;
 

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -61,7 +61,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             character.EpitaphRoadState.UnlockedContent = _Server.Database.GetEpitaphRoadUnlocks(character.CharacterId, connectionIn);
 
-            if (_Server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards)
+            if (_Server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards.Value)
             {
                 character.EpitaphRoadState.WeeklyRewardsClaimed = _Server.Database.GetEpitaphClaimedWeeklyRewards(character.CharacterId, connectionIn);
             }

--- a/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
@@ -1321,5 +1321,22 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             return results;
         }
+
+        /// <summary>
+        /// Called by the task manager. The main task will signal all channels
+        /// to flush the cached information queried by the player when first
+        /// logging in and send a notification to all players that the action
+        /// occurred.
+        /// </summary>
+        public void PerformWeeklyReset()
+        {
+            _Server.ChatManager.BroadcastMessage(LobbyChatMsgType.ManagementAlertN, "Epitaph Road Weekly Rewards Reset");
+
+            // Clear out cached data related to epitaph weekly rewards
+            foreach (var client in _Server.ClientLookup.GetAll())
+            {
+                client.Character.EpitaphRoadState.WeeklyRewardsClaimed.Clear();
+            }
+        }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
@@ -1290,7 +1290,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             {
                 results.AddRange(RollWeeklyChestReward(dungeonInfo, reward));
 
-                if (_Server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards)
+                if (_Server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards.Value)
                 {
                     character.EpitaphRoadState.WeeklyRewardsClaimed.Add(reward.EpitaphId);
                     _Server.Database.InsertEpitaphWeeklyReward(character.CharacterId, reward.EpitaphId);

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -130,8 +130,13 @@ namespace Arrowgene.Ddon.GameServer
         public override void Start()
         {
             QuestManager.LoadQuests(this);
-            ScheduleManager.Start();
             GpCourseManager.EvaluateCourses();
+
+            if (ServerUtils.IsHeadServer(this))
+            {
+                ScheduleManager.StartServerTasks();
+            }
+            
             LoadChatHandler();
             LoadPacketHandler();
             base.Start();

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -79,6 +79,7 @@ namespace Arrowgene.Ddon.GameServer
             ClanManager = new ClanManager(this);
             RpcManager = new RpcManager(this);
             EpitaphRoadManager = new EpitaphRoadManager(this);
+            ScheduleManager = new ScheduleManager(this);
 
             // Orb Management is slightly complex and requires updating fields across multiple systems
             OrbUnlockManager = new OrbUnlockManager(database, WalletManager, JobManager, CharacterManager);
@@ -115,6 +116,7 @@ namespace Arrowgene.Ddon.GameServer
         public ClanManager ClanManager { get; }
         public RpcManager RpcManager { get; }
         public EpitaphRoadManager EpitaphRoadManager { get; }
+        private ScheduleManager ScheduleManager { get; }
 
         public ChatLogHandler ChatLogHandler { get; }
 
@@ -128,6 +130,7 @@ namespace Arrowgene.Ddon.GameServer
         public override void Start()
         {
             QuestManager.LoadQuests(this);
+            ScheduleManager.Start();
             GpCourseManager.EvaluateCourses();
             LoadChatHandler();
             LoadPacketHandler();

--- a/Arrowgene.Ddon.GameServer/RpcManager.cs
+++ b/Arrowgene.Ddon.GameServer/RpcManager.cs
@@ -9,9 +9,11 @@ using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -140,6 +142,11 @@ namespace Arrowgene.Ddon.GameServer
         public List<CDataGameServerListInfo> ServerListInfo()
         {
             return ChannelInfo.Keys.Select(x => ServerListInfo(x)).ToList();
+        }
+
+        public ServerInfo HeadServer()
+        {
+            return ChannelInfo.Values.ToList().OrderBy(x => x.Id).ToList()[0];
         }
 
         public CDataGameServerListInfo ServerListInfo(ushort channelId)
@@ -411,6 +418,11 @@ namespace Arrowgene.Ddon.GameServer
             {
                 AnnounceClan(clanId, "internal/packet", RpcInternalCommand.AnnouncePacketClan, data);
             }
+        }
+
+        public void AnnounceEpitaphWeeklyReset()
+        {
+            AnnounceAll("internal/packet", RpcInternalCommand.EpitaphRoadWeeklyReset, null);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -45,7 +45,7 @@ namespace Arrowgene.Ddon.GameServer
             }
         }
 
-        public void Start()
+        public void StartServerTasks()
         {
             Dictionary<TaskType, SchedulerTaskEntry> entries = Server.Database.SelectAllTaskEntries();
 

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -1,0 +1,89 @@
+using Arrowgene.Ddon.GameServer.Tasks;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Arrowgene.Ddon.GameServer
+{
+    public class ScheduleManager
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScheduleManager));
+
+        private List<SchedulerTask> Tasks;
+        private DdonGameServer Server;
+
+        private static readonly int TIMER_TICK_HOURLY = 1 * 1000; // 1 second
+        private static readonly int TIMER_TICK_DAILY = 10 * 1000; // 10 seconds
+        private static readonly int TIMER_TICK_WEEKLY = 30 * 1000; // 30 seconds
+
+        public ScheduleManager(DdonGameServer server)
+        {
+            Server = server;
+
+            // TODO: Load from server config
+            Tasks = new List<SchedulerTask>()
+            {
+                new EpitaphSchedulerTask(DayOfWeek.Monday, 5, 0)
+            };
+        }
+
+        private int GetTimerTick(ScheduleInterval interval)
+        {
+            switch (interval)
+            {
+                case ScheduleInterval.Hourly:
+                    return TIMER_TICK_HOURLY;
+                case ScheduleInterval.Daily:
+                    return TIMER_TICK_DAILY;
+                case ScheduleInterval.Weekly:
+                    return TIMER_TICK_WEEKLY;
+                default:
+                    return TIMER_TICK_HOURLY;
+            }
+        }
+
+        public void Start()
+        {
+            Dictionary<TaskType, SchedulerTaskEntry> entries = Server.Database.SelectAllTaskEntries();
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            foreach (var task in Tasks)
+            {
+                if (!entries.ContainsKey(task.Type))
+                {
+                    Logger.Error($"Task '{task.Type}' has no record in the database. Skipping.");
+                    continue;
+                }
+
+                if (!task.IsEnabled(Server))
+                {
+                    // This task is not enabled so skip it
+                    continue;
+                }
+
+                long nextAction = entries[task.Type].Timestamp;
+                if (now >= nextAction)
+                {
+                    task.RunTask(Server);
+                    entries[task.Type].Timestamp = task.NextTimestamp();
+                    Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                }
+
+                var timerTick = GetTimerTick(task.Interval);
+                var Timer = new Timer(state =>
+                {
+                    long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                    if (now >= entries[task.Type].Timestamp)
+                    {
+                        task.RunTask(Server);
+                        entries[task.Type].Timestamp = task.NextTimestamp();
+                        Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                    }
+                }, null, timerTick, timerTick);
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/ServerUtils.cs
+++ b/Arrowgene.Ddon.GameServer/ServerUtils.cs
@@ -1,0 +1,12 @@
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer
+{
+    public class ServerUtils
+    {
+        public static bool IsHeadServer(DdonGameServer server)
+        {
+            return server.RpcManager.HeadServer().Id == server.Id;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/DailyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/DailyTask.cs
@@ -1,0 +1,23 @@
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public abstract class DailyTask : SchedulerTask
+    {
+        public uint Hour { get; }
+        public uint Minute { get; }
+
+        public DailyTask(TaskType scheduleType, uint hour, uint minute) : base(ScheduleInterval.Daily, scheduleType)
+        {
+            Hour = hour;
+            Minute = minute;
+        }
+
+        public override long NextTimestamp()
+        {
+            var tomorrow = DateTime.Today.AddDays(1);
+            return new DateTimeOffset(new DateTime(tomorrow.Year, tomorrow.Month, tomorrow.Day, (int)Hour, (int)Minute, 0)).ToUnixTimeSeconds();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Ddon.Shared.Model.Scheduler;
 using Arrowgene.Logging;
 using System;
@@ -23,14 +24,9 @@ namespace Arrowgene.Ddon.GameServer.Tasks
         public override void RunTask(DdonGameServer server)
         {
             Logger.Info("Performing weekly epitaph reset");
-            server.ChatManager.SendMessage("Performing weekly epitaph reset", string.Empty, string.Empty, LobbyChatMsgType.ManagementAlertN, server.ClientLookup.GetAll());
-
             server.Database.DeleteWeeklyEpitaphClaimedRewards();
 
-            foreach (var client in server.ClientLookup.GetAll())
-            {
-                client.Character.EpitaphRoadState.WeeklyRewardsClaimed.Clear();
-            }
+            server.RpcManager.AnnounceEpitaphWeeklyReset();
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
@@ -18,7 +18,7 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 
         public override bool IsEnabled(DdonGameServer server)
         {
-            return server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards;
+            return server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards.Value;
         }
 
         public override void RunTask(DdonGameServer server)

--- a/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/EpitaphSchedulerTask.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public class EpitaphSchedulerTask : WeeklyTask
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(EpitaphSchedulerTask));
+
+        public EpitaphSchedulerTask(DayOfWeek day, uint hour, uint minute) : base(TaskType.EpitaphRoadRewardsReset, day, hour, minute)
+        {
+
+        }
+
+        public override bool IsEnabled(DdonGameServer server)
+        {
+            return server.Setting.GameLogicSetting.EnableEpitaphWeeklyRewards;
+        }
+
+        public override void RunTask(DdonGameServer server)
+        {
+            Logger.Info("Performing weekly epitaph reset");
+            server.ChatManager.SendMessage("Performing weekly epitaph reset", string.Empty, string.Empty, LobbyChatMsgType.ManagementAlertN, server.ClientLookup.GetAll());
+
+            server.Database.DeleteWeeklyEpitaphClaimedRewards();
+
+            foreach (var client in server.ClientLookup.GetAll())
+            {
+                client.Character.EpitaphRoadState.WeeklyRewardsClaimed.Clear();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
@@ -5,13 +5,20 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 {
     public abstract class HourlyTask : SchedulerTask
     {
+        /// <summary>
+        /// Task which is always scheduled to run on the hour in the timezone of the server currently running.
+        /// </summary>
+        /// <param name="type">The task type associated with this task</param>
         public HourlyTask(TaskType type) : base(ScheduleInterval.Hourly, type)
         {
         }
 
         public override long NextTimestamp()
         {
-            return new DateTimeOffset(DateTime.Now.AddHours(1)).ToUnixTimeSeconds();
+            var now = DateTime.Now;
+            var next = now.AddHours(1);
+            var nextTime = new DateTime(next.Year, next.Month, next.Day, next.Hour, 0, 0);
+            return new DateTimeOffset(now.Add(nextTime - now)).ToUnixTimeSeconds();
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
@@ -1,0 +1,17 @@
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public abstract class HourlyTask : SchedulerTask
+    {
+        public HourlyTask(TaskType type) : base(ScheduleInterval.Hourly, type)
+        {
+        }
+
+        public override long NextTimestamp()
+        {
+            return new DateTimeOffset(DateTime.Now.AddHours(1)).ToUnixTimeSeconds();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/NextTimeAmountTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/NextTimeAmountTask.cs
@@ -1,0 +1,22 @@
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public abstract class NextTimeAmountTask : SchedulerTask
+    {
+        public uint Hours { get; }
+        public uint Minutes { get; }
+
+        public NextTimeAmountTask(TaskType type, uint hours, uint minutes = 0) : base(ScheduleInterval.Hourly, type)
+        {
+            Hours = hours;
+            Minutes = minutes;
+        }
+
+        public override long NextTimestamp()
+        {
+            return new DateTimeOffset(DateTime.Now.AddHours(Hours).AddMinutes(Minutes)).ToUnixTimeSeconds();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
@@ -7,6 +7,14 @@ namespace Arrowgene.Ddon.GameServer.Tasks
         public TaskType Type { get; }
         public ScheduleInterval Interval { get; }
 
+        /// <summary>
+        /// Constructor for SchedulerTask.
+        /// </summary>
+        /// <param name="interval">Hint for the type of interval this task is expected to occur at.</param>
+        /// <param name="type">
+        ///     The task type which is stored in the DB and used to resume the scheduler
+        ///     timer when the head server starts.
+        /// </param>
         public SchedulerTask(ScheduleInterval interval, TaskType type)
         {
             Type = type;
@@ -18,10 +26,21 @@ namespace Arrowgene.Ddon.GameServer.Tasks
         /// Should use the RPC manage if it is required to update clients on different channels
         /// or send annoucements to players.
         /// </summary>
-        /// <param name="server"></param>
+        /// <param name="server">The head server object</param>
         public abstract void RunTask(DdonGameServer server);
+
+        /// <summary>
+        /// Generates the next unix timestamp to store in the database for the task.
+        /// </summary>
+        /// <returns>Returns the unix timestamp which represents the next time this task should activate.</returns>
         public abstract long NextTimestamp();
 
+        /// <summary>
+        /// By default, all tasks will return that they are enabled. A child class can override
+        /// this function to provide custom checks for enablement.
+        /// </summary>
+        /// <param name="server">The head server object</param>
+        /// <returns>Returns true if this task is enabled, otherwise false.</returns>
         public virtual bool IsEnabled(DdonGameServer server)
         {
             return true;

--- a/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
@@ -1,0 +1,24 @@
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public abstract class SchedulerTask
+    {
+        public TaskType Type { get; }
+        public ScheduleInterval Interval { get; }
+
+        public SchedulerTask(ScheduleInterval interval, TaskType type)
+        {
+            Type = type;
+            Interval = interval;
+        }
+
+        public abstract void RunTask(DdonGameServer server);
+        public abstract long NextTimestamp();
+
+        public virtual bool IsEnabled(DdonGameServer server)
+        {
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
@@ -13,6 +13,12 @@ namespace Arrowgene.Ddon.GameServer.Tasks
             Interval = interval;
         }
 
+        /// <summary>
+        /// Runs on the head server. Should deal with things like modifying the database.
+        /// Should use the RPC manage if it is required to update clients on different channels
+        /// or send annoucements to players.
+        /// </summary>
+        /// <param name="server"></param>
         public abstract void RunTask(DdonGameServer server);
         public abstract long NextTimestamp();
 

--- a/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
@@ -12,6 +12,7 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 
         /// <summary>
         /// Creates a task which runs on a weekly cadence.
+        /// Uses the timezone of the head server when calculating times.
         /// </summary>
         /// <param name="scheduleType">The type of event this is associated with</param>
         /// <param name="day">The day during the week the reset should occur.</param>

--- a/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Ddon.GameServer.Utils;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks
+{
+    public abstract class WeeklyTask : SchedulerTask
+    {
+        public DayOfWeek Day { get; }
+        public uint Hour { get; }
+        public uint Minute { get; }
+
+        /// <summary>
+        /// Creates a task which runs on a weekly cadence.
+        /// </summary>
+        /// <param name="scheduleType">The type of event this is associated with</param>
+        /// <param name="day">The day during the week the reset should occur.</param>
+        /// <param name="hour">The hour the reset should occur in a 24 hour format</param>
+        public WeeklyTask(TaskType scheduleType, DayOfWeek day, uint hour, uint minute) : base(ScheduleInterval.Weekly, scheduleType)
+        {
+            Day = day;
+            Hour = hour;
+            Minute = minute;
+        }
+
+        /// <summary>
+        /// Calculates the next timestamp for this task in unix seconds
+        /// </summary>
+        /// <returns>Returns the next timestamp in unix seconds</returns>
+        public override long NextTimestamp()
+        {
+            var nextDate = DateUtils.GetNextWeekday(DateTime.Today.AddDays(1), Day);
+            return new DateTimeOffset(new DateTime(nextDate.Year, nextDate.Month, nextDate.Day, (int)Hour, (int)Minute, 0)).ToUnixTimeSeconds();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Utils/DateUtils.cs
+++ b/Arrowgene.Ddon.GameServer/Utils/DateUtils.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Utils
+{
+    public class DateUtils
+    {
+        public static DateTime GetNextWeekday(DateTime start, DayOfWeek day)
+        {
+            // The (... + 7) % 7 ensures we end up with a value in the range [0, 6]
+            int daysToAdd = ((int)day - (int)start.DayOfWeek + 7) % 7;
+            return start.AddDays(daysToAdd);
+        }
+    }
+}

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/PacketRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/PacketRoute.cs
@@ -168,6 +168,9 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                                 Message = $"AnnouncePacketClan Ch.{_entry.Origin} ClanID {data.ClanId} -> {packet.Id}"
                             };
                         }
+                    case RpcInternalCommand.EpitaphRoadWeeklyReset:
+                        gameServer.EpitaphRoadManager.PerformWeeklyReset();
+                        return new RpcCommandResult(this, true);
                     default:
                         return new RpcCommandResult(this, false);
                 }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -240,7 +240,7 @@ namespace Arrowgene.Ddon.Server
         /// <summary>
         /// Configures if epitaph rewards are limited once per weekly reset.
         /// </summary>
-        [DataMember(Order = 37)] public bool EnableEpitaphWeeklyRewards { get; set; }
+        [DataMember(Order = 37)] public bool? EnableEpitaphWeeklyRewards { get; set; } = true;
 
         /// Enables main pawns in party to gain EXP and JP from quests
         /// Original game apparantly did not have pawns share quest reward, so will set to false for default, 
@@ -449,6 +449,8 @@ namespace Arrowgene.Ddon.Server
             UrlCampaign ??= string.Empty;
             UrlChargeB ??= string.Empty;
             UrlCompanionImage ??= string.Empty;
+
+            EnableEpitaphWeeklyRewards ??= true;
 
             EnemyExpModifier ??= 1;
             QuestExpModifier ??= 1;

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
@@ -10,5 +10,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
 
         AnnouncePacketAll, // RpcPacketData
         AnnouncePacketClan, // RpcPacketData
+
+        EpitaphRoadWeeklyReset
     }
 }

--- a/Arrowgene.Ddon.Shared/Model/Scheduler/ScheduleInterval.cs
+++ b/Arrowgene.Ddon.Shared/Model/Scheduler/ScheduleInterval.cs
@@ -1,0 +1,11 @@
+namespace Arrowgene.Ddon.Shared.Model.Scheduler
+{
+    public enum ScheduleInterval : uint
+    {
+        Unknown = 0,
+        Hourly = 1,
+        Daily = 2,
+        Weekly = 3,
+        Monthly = 4
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Scheduler/SchedulerTaskEntry.cs
+++ b/Arrowgene.Ddon.Shared/Model/Scheduler/SchedulerTaskEntry.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Model.Scheduler
+{
+    public class SchedulerTaskEntry
+    {
+        public TaskType Type { get; set; }
+        public long Timestamp { get; set; }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
@@ -1,0 +1,34 @@
+namespace Arrowgene.Ddon.Shared.Model.Scheduler
+{
+    public enum TaskType : uint
+    {
+        // Types derived from http://ddon.wikidot.com/gameplay:home
+        // Possible to add new types other than from this list
+        // Try not to change values as this will confuse the scheduler
+        // in an existing database (unless they are not being used yet)
+        Unknown = 0,
+        RevivalGreenGemstones = 1,
+        LoginStamps = 2,
+        WeakenedStatusRecovery = 3,
+        AreaPointReset = 4,
+        AreaMasterSupportItems = 5,
+        BoardQuestRotation = 6,
+        SpecialBoardQuestRotation = 7,
+        WorldQuestRotation = 8,
+        ClanQuestRotation = 9,
+        SubstoryQuestRotation = 10,
+        ExtremeMissionRewardUpdate = 11,
+        PawnExpedition = 12,
+        PawnAffectionIncreaseInteraction = 13,
+        PawnTrainingExperiencePoints = 14,
+        ClanDungeonReset = 15,
+        MandragoraGrowth = 16,
+        GoldenTreasureChestReset = 17,
+        VioletTreasureChestReset = 18,
+        EpitaphRoadRewardsReset = 19,
+        AwardBitterblackMazeResetTickets = 20,
+        TimeLockedDungeons = 21,
+        // Others not from above webpage
+        SeasonalEventSchedule = 22
+    }
+}

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -8,6 +8,7 @@ using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.BattleContent;
 using Arrowgene.Ddon.Shared.Model.Clan;
 using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -419,6 +420,9 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertEpitaphWeeklyReward(uint characterId, uint epitaphId, DbConnection? connectionIn = null) { return true; }
         public HashSet<uint> GetEpitaphClaimedWeeklyRewards(uint characterId, DbConnection? connectionIn = null) { return new(); }
 
+        public Dictionary<TaskType, SchedulerTaskEntry> SelectAllTaskEntries() { return new(); }
+        public bool UpdateScheduleInfo(TaskType type, long timestamp) { return true; }
+
         public void AddParameter(DbCommand command, string name, object? value, DbType type) { }
         public void AddParameter(DbCommand command, string name, string value) { }
         public void AddParameter(DbCommand command, string name, Int32 value) { }
@@ -443,7 +447,7 @@ namespace Arrowgene.Ddon.Test.Database
         public byte[] GetBytes(DbDataReader reader, string column, int size) { return null; }
         public List<CDataRegisterdPawnList> SelectRegisteredPawns(Character searchingCharacter, CDataPawnSearchParameter searchParams) { return new List<CDataRegisterdPawnList>(); }
         public List<CDataRegisterdPawnList> SelectRegisteredPawns(DbConnection conn, Character searchingCharacter, CDataPawnSearchParameter searchParams) { return new List<CDataRegisterdPawnList>(); }
-        public void DeleteWeeklyRewards(DbConnection? connectionIn = null) { }
+        public void DeleteWeeklyEpitaphClaimedRewards(DbConnection? connectionIn = null) { }
     }
 
     class MockMigrationStrategy : IMigrationStrategy


### PR DESCRIPTION
Implemented a light weight mechanism for scheduling recurring tasks. This can be used to implement, hourly, daily or weekly resets. There is also an intention to use the mechanism to check for seasonal events and turn on/off depending on the date.

Added example of a weekly reset for Epitaph Weekly rewards.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
