### PR TITLE
enhance: Add new global modifiers

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -906,13 +906,13 @@ namespace Arrowgene.Ddon.GameServer.Characters
             switch (type)
             {
                 case ExpType.ExperiencePoints:
-                    modifier = (source == RewardSource.Enemy) ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+                    modifier = (source == RewardSource.Enemy) ? _GameSettings.EnemyExpModifier.Value : _GameSettings.QuestExpModifier.Value;
                     break;
                 case ExpType.JobPoints:
-                    modifier = _GameSettings.JpModifier;
+                    modifier = _GameSettings.JpModifier.Value;
                     break;
                 case ExpType.PlayPoints:
-                    modifier = _GameSettings.PpModifier;
+                    modifier = _GameSettings.PpModifier.Value;
                     break;
                 default:
                     modifier = 1.0;

--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -10,6 +10,7 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Drawing;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters
@@ -509,7 +510,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                     if (client.GameMode == GameMode.Normal)
                     {
-                        addJobPoint += (uint)(LEVEL_UP_JOB_POINTS_EARNED[targetLevel] * _Server.Setting.GameLogicSetting.JpModifier);
+                        addJobPoint += GetScaledPointAmount(RewardSource.None, ExpType.JobPoints, LEVEL_UP_JOB_POINTS_EARNED[targetLevel]);
                     }
                 }
 
@@ -899,16 +900,32 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return multiplier;
         }
 
-        private double ModifierBasedOnSource(RewardSource source)
+        public uint GetScaledPointAmount(RewardSource source, ExpType type, uint amount)
         {
-            return source == RewardSource.Enemy ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+            double modifier = 1.0;
+            switch (type)
+            {
+                case ExpType.ExperiencePoints:
+                    modifier = (source == RewardSource.Enemy) ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+                    break;
+                case ExpType.JobPoints:
+                    modifier = _GameSettings.JpModifier;
+                    break;
+                case ExpType.PlayPoints:
+                    modifier = _GameSettings.PpModifier;
+                    break;
+                default:
+                    modifier = 1.0;
+                    break;
+            }
+            return (uint)(amount * modifier);
         }
 
         public uint GetAdjustedExp(GameMode gameMode, RewardSource source, PartyGroup party, uint baseExpAmount, uint targetLv)
         {
             if (_Server.GpCourseManager.DisablePartyExpAdjustment())
             {
-                return (uint)(baseExpAmount * ModifierBasedOnSource(source));
+                return baseExpAmount;
             }
 
             double multiplier = 1.0;
@@ -923,7 +940,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 // Currently no adjustments
             }
 
-            return (uint)(multiplier * baseExpAmount * ModifierBasedOnSource(source));
+            return (uint)(multiplier * baseExpAmount);
         }
 
         private uint GetMaxAllowedPartyRange()
@@ -1005,13 +1022,13 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             if (!_GameSettings.EnablePawnCatchup || gameMode == GameMode.BitterblackMaze)
             {
-                return (uint)(baseExpAmount * ModifierBasedOnSource(source));
+                return baseExpAmount;
             }
 
             var targetMultiplier = CalculatePawnCatchupTargetLvMultiplier(gameMode, pawn, targetLv);
             var multiplier = _GameSettings.PawnCatchupMultiplier * targetMultiplier;
 
-            return (uint)(multiplier * baseExpAmount * ModifierBasedOnSource(source));
+            return (uint)(multiplier * baseExpAmount);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -32,13 +32,15 @@ namespace Arrowgene.Ddon.GameServer.Characters
         private static Dictionary<uint, HashSet<uint>> gTutorialQuests = new Dictionary<uint, HashSet<uint>>();
         private static Dictionary<QuestAreaId, HashSet<QuestId>> gWorldQuests = new Dictionary<QuestAreaId, HashSet<QuestId>>();
 
-        public static void LoadQuests(AssetRepository assetRepository)
+        public static void LoadQuests(DdonGameServer server)
         {
+            var assetRepository = server.AssetRepository;
+
             // TODO: Quests should probably operate on the QuestScheduleID instead of QuestId so the global list can still contain all quests
             // TODO: Then quests can be distributed to different lists for faster lookup (like world by area id or personal by stageno)
             foreach (var questAsset in assetRepository.QuestAssets.Quests)
             {
-                gQuests[questAsset.QuestScheduleId] = GenericQuest.FromAsset(questAsset);
+                gQuests[questAsset.QuestScheduleId] = GenericQuest.FromAsset(server, questAsset);
 
                 var quest = gQuests[questAsset.QuestScheduleId];
                 if (!quest.Enabled)

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             var rewards = quest.GenerateBoxRewards();
 
             var currentRewards = GetQuestBoxRewards(client, connectionIn);
-            if (currentRewards.Count >= _Server.Setting.GameLogicSetting.RewardBoxMax)
+            if (currentRewards.Count >= _Server.Setting.GameLogicSetting.RewardBoxMax.Value)
             {
                 return false;
             }

--- a/Arrowgene.Ddon.GameServer/Characters/WalletManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/WalletManager.cs
@@ -100,5 +100,30 @@ namespace Arrowgene.Ddon.GameServer.Characters
             CDataWalletPoint Wallet = Character.WalletPointList.Where(wp => wp.Type == Type).Single();
             return Wallet.Value;
         }
+
+        public uint GetScaledWalletAmount(WalletType type, uint amount)
+        {
+            double modifier = 1.0;
+            switch (type)
+            {
+                case WalletType.Gold:
+                    modifier = Server.Setting.GameLogicSetting.GoldModifier;
+                    break;
+                case WalletType.RiftPoints:
+                    modifier = Server.Setting.GameLogicSetting.RiftModifier;
+                    break;
+                case WalletType.BloodOrbs:
+                    modifier = Server.Setting.GameLogicSetting.BoModifier;
+                    break;
+                case WalletType.HighOrbs:
+                    modifier = Server.Setting.GameLogicSetting.HoModifier;
+                    break;
+                default:
+                    modifier = 1.0;
+                    break;
+            }
+
+            return (uint)(amount * modifier);
+        }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Characters/WalletManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/WalletManager.cs
@@ -107,16 +107,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
             switch (type)
             {
                 case WalletType.Gold:
-                    modifier = Server.Setting.GameLogicSetting.GoldModifier;
+                    modifier = Server.Setting.GameLogicSetting.GoldModifier.Value;
                     break;
                 case WalletType.RiftPoints:
-                    modifier = Server.Setting.GameLogicSetting.RiftModifier;
+                    modifier = Server.Setting.GameLogicSetting.RiftModifier.Value;
                     break;
                 case WalletType.BloodOrbs:
-                    modifier = Server.Setting.GameLogicSetting.BoModifier;
+                    modifier = Server.Setting.GameLogicSetting.BoModifier.Value;
                     break;
                 case WalletType.HighOrbs:
-                    modifier = Server.Setting.GameLogicSetting.HoModifier;
+                    modifier = Server.Setting.GameLogicSetting.HoModifier.Value;
                     break;
                 default:
                     modifier = 1.0;

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -127,7 +127,7 @@ namespace Arrowgene.Ddon.GameServer
 
         public override void Start()
         {
-            QuestManager.LoadQuests(this.AssetRepository);
+            QuestManager.LoadQuests(this);
             GpCourseManager.EvaluateCourses();
             LoadChatHandler();
             LoadPacketHandler();

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -174,7 +174,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
 
                 uint calcExp = _gameServer.ExpManager.GetAdjustedExp(client.GameMode, RewardSource.Enemy, client.Party, enemyKilled.GetDroppedExperience(), enemyKilled.Lv);
-                uint calcPP = (uint)(enemyKilled.GetDroppedPlayPoints() * _gameServer.Setting.GameLogicSetting.PpModifier);
+                uint calcPP = _gameServer.ExpManager.GetScaledPointAmount(RewardSource.Enemy, ExpType.PlayPoints, enemyKilled.GetDroppedPlayPoints());
 
                 foreach (PartyMember member in client.Party.Members)
                 {

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -209,7 +209,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         if (enemyKilled.BloodOrbs > 0)
                         {
                             // Drop BO
-                            uint gainedBo = (uint) (enemyKilled.BloodOrbs * _gameServer.Setting.GameLogicSetting.BoModifier);
+                            uint gainedBo = (uint) (enemyKilled.BloodOrbs * _gameServer.Setting.GameLogicSetting.BoModifier.Value);
                             uint bonusBo = (uint) (gainedBo * _gameServer.GpCourseManager.EnemyBloodOrbBonus());
                             CDataUpdateWalletPoint boUpdateWalletPoint = _gameServer.WalletManager.AddToWallet(memberClient.Character, WalletType.BloodOrbs, gainedBo + bonusBo, bonusBo, connectionIn: connectionIn);
                             updateCharacterItemNtc.UpdateWalletList.Add(boUpdateWalletPoint);
@@ -218,7 +218,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         if (enemyKilled.HighOrbs > 0)
                         {
                             // Drop HO
-                            uint gainedHo = (uint)(enemyKilled.HighOrbs * _gameServer.Setting.GameLogicSetting.HoModifier);
+                            uint gainedHo = (uint)(enemyKilled.HighOrbs * _gameServer.Setting.GameLogicSetting.HoModifier.Value);
                             CDataUpdateWalletPoint hoUpdateWalletPoint = _gameServer.WalletManager.AddToWallet(memberClient.Character, WalletType.HighOrbs, gainedHo, connectionIn: connectionIn);
                             updateCharacterItemNtc.UpdateWalletList.Add(hoUpdateWalletPoint);
                         }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetCycleContentsStateListHandler.cs
@@ -36,8 +36,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             ntc.WorldManageQuestOrderList = pcap.WorldManageQuestOrderList; // Recover paths + change vocation
 
             ntc.QuestDefine = pcap.QuestDefine; // Recover quest log data to be able to accept quests
-            ntc.QuestDefine.OrderMaxNum = Server.Setting.GameLogicSetting.QuestOrderMax;
-            ntc.QuestDefine.RewardBoxMaxNum = Server.Setting.GameLogicSetting.RewardBoxMax;
+            ntc.QuestDefine.OrderMaxNum = Server.Setting.GameLogicSetting.QuestOrderMax.Value;
+            ntc.QuestDefine.RewardBoxMaxNum = Server.Setting.GameLogicSetting.RewardBoxMax.Value;
 
             // pcap.MainQuestIdList; (this will add back all missing functionality which depends on complete MSQ)
             var completedMsq = client.Character.CompletedQuests.Values.Where(x => x.QuestType == QuestType.Main);

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -14,7 +14,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(GenericQuest));
 
-        public static GenericQuest FromAsset(QuestAssetData questAsset)
+        public static GenericQuest FromAsset(DdonGameServer server, QuestAssetData questAsset)
         {
             var quest = new GenericQuest(questAsset.QuestId, questAsset.QuestScheduleId, questAsset.Type, questAsset.Discoverable);
 
@@ -40,19 +40,21 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
             foreach (var pointReward in questAsset.PointRewards)
             {
+                var reward = server.ExpManager.GetScaledPointAmount(RewardSource.Quest, pointReward.ExpType, pointReward.ExpReward);
                 quest.ExpRewards.Add(new CDataQuestExp()
                 {
                     Type = pointReward.ExpType,
-                    Reward = pointReward.ExpReward
+                    Reward = reward
                 });
             }
 
             foreach (var walletReward in questAsset.RewardCurrency)
             {
+                var amount = server.WalletManager.GetScaledWalletAmount(walletReward.WalletType, walletReward.Amount);
                 quest.WalletRewards.Add(new CDataWalletPoint()
                 {
                     Type = walletReward.WalletType,
-                    Value = walletReward.Amount
+                    Value = amount
                 });
             }
 

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -562,17 +562,10 @@ namespace Arrowgene.Ddon.GameServer.Quests
         private uint CalculateTotalPointAmount(DdonGameServer server, GameClient client, CDataQuestExp point)
         {
             uint amount = point.Reward;
-            double modifier = 1.0;
             switch (point.Type)
             {
                 case ExpType.ExperiencePoints:
                     amount = server.ExpManager.GetAdjustedExp(client.GameMode, RewardSource.Quest, null, point.Reward, 0);
-                    break;
-                case ExpType.JobPoints:
-                    modifier = (uint)(amount * server.Setting.GameLogicSetting.JpModifier);
-                    break;
-                case ExpType.PlayPoints:
-                    amount = (uint)(amount * server.Setting.GameLogicSetting.PpModifier);
                     break;
                 default:
                     break;

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -182,40 +182,50 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 29)] public double PpModifier { get; set; }
 
         /// <summary>
+        /// Global modifier for Gold calculations to scale up or down.
+        /// </summary>
+        [DataMember(Order = 30)] public double GoldModifier { get; set; }
+
+        /// <summary>
+        /// Global modifier for Rift calculations to scale up or down.
+        /// </summary>
+        [DataMember(Order = 31)] public double RiftModifier { get; set; }
+
+        /// <summary>
         /// Global modifier for BO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 30)] public double BoModifier { get; set; }
+        [DataMember(Order = 32)] public double BoModifier { get; set; }
 
         /// <summary>
         /// Global modifier for HO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 31)] public double HoModifier { get; set; }
+        [DataMember(Order = 33)] public double HoModifier { get; set; }
 
         /// <summary>
         /// Global modifier for JP calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 32)] public double JpModifier { get; set; }
+        [DataMember(Order = 34)] public double JpModifier { get; set; }
 
         /// <summary>
         /// Configures the maximum amount of reward box slots.
         /// </summary>
-        [DataMember(Order = 33)] public byte RewardBoxMax { get; set; }
+        [DataMember(Order = 35)] public byte RewardBoxMax { get; set; }
 
         /// <summary>
         /// Configures the maximum amount of quests that can be ordered at one time.
         /// </summary>
-        [DataMember(Order = 34)] public byte QuestOrderMax { get; set; }
+        [DataMember(Order = 36)] public byte QuestOrderMax { get; set; }
 
         /// <summary>
         /// Configures if epitaph rewards are limited once per weekly reset.
         /// </summary>
-        [DataMember(Order = 35)] public bool EnableEpitaphWeeklyRewards { get; set; }
+        [DataMember(Order = 37)] public bool EnableEpitaphWeeklyRewards { get; set; }
 
         /// Enables main pawns in party to gain EXP and JP from quests
         /// Original game apparantly did not have pawns share quest reward, so will set to false for default, 
         /// change as needed
         /// </summary>
-        [DataMember(Order = 36)] public bool EnableMainPartyPawnsQuestRewards { get; set; }
+        [DataMember(Order = 38)] public bool EnableMainPartyPawnsQuestRewards { get; set; }
 
         /// <summary>
         /// Various URLs used by the client.
@@ -303,6 +313,8 @@ namespace Arrowgene.Ddon.Server
             EnemyExpModifier = 1.0;
             QuestExpModifier = 1.0;
             PpModifier = 1.0;
+            GoldModifier = 1.0;
+            RiftModifier = 1.0;
             BoModifier = 1.0;
             HoModifier = 1.0;
             JpModifier = 1.0;
@@ -367,6 +379,8 @@ namespace Arrowgene.Ddon.Server
             EnemyExpModifier = setting.EnemyExpModifier;
             QuestExpModifier = setting.QuestExpModifier;
             PpModifier = setting.PpModifier;
+            GoldModifier = setting.GoldModifier;
+            RiftModifier = setting.RiftModifier;
             BoModifier = setting.BoModifier;
             HoModifier = setting.HoModifier;
             JpModifier = setting.JpModifier;
@@ -461,6 +475,14 @@ namespace Arrowgene.Ddon.Server
             if (PpModifier < 0)
             {
                 PpModifier = 1.0;
+            }
+            if (GoldModifier < 0)
+            {
+                GoldModifier = 1.0;
+            }
+            if (RiftModifier < 0)
+            {
+                RiftModifier = 1.0;
             }
             if (BoModifier < 0)
             {

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -1,10 +1,30 @@
 using Arrowgene.Ddon.Shared.Model;
+using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Runtime.Serialization;
+using YamlDotNet.Serialization;
 
 namespace Arrowgene.Ddon.Server
 {
+    [DataContract]
+    public class DefaultDataMember<T>
+    {
+        private T _DefaultValue;
+        private T? _Value;
+
+        [DataMember]
+        public T Value { 
+            get => _Value ?? _DefaultValue;
+            set => _Value = Value;
+        }
+
+        public DefaultDataMember(T defaultValue)
+        {
+            _DefaultValue = defaultValue;
+        }
+    }
+
+
     [DataContract]
     public class GameLogicSetting
     {
@@ -167,54 +187,55 @@ namespace Arrowgene.Ddon.Server
         [DataMember(Order = 26)] public bool DisableExpCorrectionForMyPawn { get; set; }
 
         /// <summary>
-        /// Global modifier for exp calculations to scale up or down.
+        /// Global modifier for enemy exp calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 27)] public double EnemyExpModifier { get; set; }
+        [DataMember(Order = 27)] public double? EnemyExpModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for quest exp calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 28)] public double QuestExpModifier { get; set; }
+        
+        [DataMember(Order = 28)] public double? QuestExpModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for pp calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 29)] public double PpModifier { get; set; }
+        [DataMember(Order = 29)] public double? PpModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for Gold calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 30)] public double GoldModifier { get; set; }
+        [DataMember(Order = 30)] public double? GoldModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for Rift calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 31)] public double RiftModifier { get; set; }
+        [DataMember(Order = 31)] public double? RiftModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for BO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 32)] public double BoModifier { get; set; }
+        [DataMember(Order = 32)] public double? BoModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for HO calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 33)] public double HoModifier { get; set; }
+        [DataMember(Order = 33)] public double? HoModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Global modifier for JP calculations to scale up or down.
         /// </summary>
-        [DataMember(Order = 34)] public double JpModifier { get; set; }
+        [DataMember(Order = 34)] public double? JpModifier { get; set; } = 1.0;
 
         /// <summary>
         /// Configures the maximum amount of reward box slots.
         /// </summary>
-        [DataMember(Order = 35)] public byte RewardBoxMax { get; set; }
+        [DataMember(Order = 35)] public byte? RewardBoxMax { get; set; } = 100;
 
         /// <summary>
         /// Configures the maximum amount of quests that can be ordered at one time.
         /// </summary>
-        [DataMember(Order = 36)] public byte QuestOrderMax { get; set; }
+        [DataMember(Order = 36)] public byte? QuestOrderMax { get; set; } = 20;
 
         /// <summary>
         /// Configures if epitaph rewards are limited once per weekly reset.
@@ -309,17 +330,6 @@ namespace Arrowgene.Ddon.Server
 
             DefaultMaxBazaarExhibits = 5;
             DefaultWarpFavorites = 3;
-
-            EnemyExpModifier = 1.0;
-            QuestExpModifier = 1.0;
-            PpModifier = 1.0;
-            GoldModifier = 1.0;
-            RiftModifier = 1.0;
-            BoModifier = 1.0;
-            HoModifier = 1.0;
-            JpModifier = 1.0;
-            RewardBoxMax = 100;
-            QuestOrderMax = 20;
 
             EnableEpitaphWeeklyRewards = false;
             EnableMainPartyPawnsQuestRewards = false;
@@ -439,6 +449,17 @@ namespace Arrowgene.Ddon.Server
             UrlCampaign ??= string.Empty;
             UrlChargeB ??= string.Empty;
             UrlCompanionImage ??= string.Empty;
+
+            EnemyExpModifier ??= 1;
+            QuestExpModifier ??= 1;
+            PpModifier ??= 1;
+            GoldModifier ??= 1;
+            RiftModifier ??= 1;
+            BoModifier ??= 1;
+            HoModifier ??= 1;
+            JpModifier ??= 1;
+            RewardBoxMax ??= 100;
+            QuestOrderMax ??= 20;
 
             if (RookiesRingBonus < 0)
             {

--- a/Arrowgene.Ddon.Shared/Model/RewardSource.cs
+++ b/Arrowgene.Ddon.Shared/Model/RewardSource.cs
@@ -8,7 +8,8 @@ namespace Arrowgene.Ddon.Shared.Model
 {
     public enum RewardSource : byte
     {
-        Enemy = 0,
+        None = 0,
+        Enemy = 1,
         Quest = 2,
     }
 }


### PR DESCRIPTION
- Added modifiers for gold and rift rewards from quests
- Fixed a bug where JP was not modified correctly for quest rewards.
- Fixed a bug where exp amounts were not displayed correctly in quest amounts.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
