### PR TITLE
Include RpcPort field in the server status endpoint response

### DIFF
--- a/Arrowgene.Ddon.Rpc.Web/Route/ServerStatusRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/ServerStatusRoute.cs
@@ -29,6 +29,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route
             public uint LoginNum { get; set; }
             public string Addr { get; set; }
             public ushort Port { get; set; }
+            public ushort RpcPort { get; set; }
             public bool IsHide { get; set; }
 
             public ServerStatus()
@@ -42,6 +43,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route
                 LoginNum = 0;
                 Addr = "";
                 Port = 0;
+                RpcPort = 0;
                 IsHide = false;
             }
         }
@@ -73,6 +75,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route
                         LoginNum = (uint)connections.Count(x => x.ServerId == server.Id && x.Type == ConnectionType.GameServer),
                         Addr = server.Addr,
                         Port = server.Port,
+                        RpcPort = server.RpcPort,
                         IsHide = server.IsHide
                     });
                 }


### PR DESCRIPTION
This will allow DDOn Tools to query all other servers in the cluster without having to guess the RPC port or be made aware of them beforehand

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
