### PR TITLE
feat: Add enemy constraints for event drop systems

### DIFF
--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceEventDropItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceEventDropItemManager.cs
@@ -38,6 +38,16 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
                 return false;
             }
 
+            if (item.EmLvConstraint != EventItemConstraint.None && !EvaluateEmLvConstraint(item, enemy))
+            {
+                return false;
+            }
+
+            if (!EvaluateEmClassConstraint(item, enemy))
+            {
+                return false;
+            }
+
             if (item.RequiredItemsEquipped.Count > 0)
             {
                 if (item.ItemConstraint == EventItemConstraint.All)
@@ -77,6 +87,52 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
             }
 
             return true;
+        }
+
+        private bool EvaluateEmLvConstraint(EventItem item, Enemy enemy)
+        {
+            if (item.EmLvConstraint == EventItemConstraint.InRange)
+            {
+                return enemy.Lv >= item.EmLvConstraintParams.MinLv && enemy.Lv <= item.EmLvConstraintParams.MaxLv;
+            }
+            else if (item.EmLvConstraint == EventItemConstraint.LessThan)
+            {
+                return enemy.Lv < item.EmLvConstraintParams.Lv;
+            }
+            else if (item.EmLvConstraint == EventItemConstraint.LessThanOrEqual)
+            {
+                return enemy.Lv <= item.EmLvConstraintParams.Lv;
+            }
+            else if (item.EmLvConstraint == EventItemConstraint.GreaterThan)
+            {
+                return enemy.Lv > item.EmLvConstraintParams.Lv;
+            }
+            else if (item.EmLvConstraint == EventItemConstraint.GreaterThanOrEqual)
+            {
+                return enemy.Lv >= item.EmLvConstraintParams.Lv;
+            }
+
+            // An invalid constraint type was passed
+            return false;
+        }
+
+        private bool EvaluateEmClassConstraint(EventItem item, Enemy enemy)
+        {
+            if (item.EmClassConstraint == EventItemConstraint.None)
+            {
+                return true;
+            }
+            else if (item.EmClassConstraint == EventItemConstraint.IsBoss)
+            {
+                return enemy.IsBossGauge;
+            }
+            else if (item.EmClassConstraint == EventItemConstraint.IsNotBoss)
+            {
+                return !enemy.IsBossGauge;
+            }
+
+            // An invalid constraint type was passed 
+            return false;
         }
 
         public List<InstancedGatheringItem> FetchEventItems(GameClient client, CDataStageLayoutId layoutId, uint posId)

--- a/Arrowgene.Ddon.Shared/Asset/EventDropsAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/EventDropsAsset.cs
@@ -23,6 +23,11 @@ namespace Arrowgene.Ddon.Shared.Asset
         public HashSet<uint> StageIds { get; set; }
         public HashSet<uint> EnemyIds { get; set; }
 
+        public EventItemConstraint EmClassConstraint; // Boss or Regular Enemy
+
+        public EventItemConstraint EmLvConstraint;
+        public (uint Lv, uint MinLv, uint MaxLv) EmLvConstraintParams { get; set; }
+
         public bool RequiresLanternLit { get; set; }
 
         public EventItemConstraint ItemConstraint { get; set; }

--- a/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
@@ -79,8 +79,84 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                             else
                             {
                                 Logger.Error($"Failed to parse item constraint {jConstraint.GetString()}");
+                                continue;
                             }
                         }
+                    }
+
+                    eventItem.EmClassConstraint = EventItemConstraint.None;
+                    if (jRequirements.TryGetProperty("enemy_class", out JsonElement jEnemyClass))
+                    {
+                        if (!Enum.TryParse(jEnemyClass.ToString(), out eventItem.EmClassConstraint))
+                        {
+                            Logger.Error("Failed to parse the 'enemy_class' constraint.");
+                            continue;
+                        }
+
+                        if (eventItem.EmClassConstraint != EventItemConstraint.None ||
+                            eventItem.EmClassConstraint != EventItemConstraint.IsBoss ||
+                            eventItem.EmClassConstraint != EventItemConstraint.IsNotBoss)
+                        {
+                            Logger.Error($"The constraint '{eventItem.EmClassConstraint}' is not a valid constraint for 'enemy_class'.");
+                            continue;
+                        }
+                    }
+
+                    eventItem.EmLvConstraint = EventItemConstraint.None;
+                    if (jRequirements.TryGetProperty("enemy_level", out JsonElement jEnemyLevel))
+                    {
+                        if (!Enum.TryParse(jEnemyLevel.GetProperty("constraint").ToString(), out eventItem.EmLvConstraint))
+                        {
+                            Logger.Error("Required element 'constraint' does not exist or is an invalid value.");
+                            continue;
+                        }
+
+                        switch (eventItem.EmLvConstraint)
+                        {
+                            case EventItemConstraint.LessThan:
+                            case EventItemConstraint.LessThanOrEqual:
+                            case EventItemConstraint.GreaterThan:
+                            case EventItemConstraint.GreaterThanOrEqual:
+                            case EventItemConstraint.InRange:
+                                break;
+                            default:
+                                Logger.Error($"The constraint '{eventItem.EmLvConstraint}' is not a valid constraint for 'enemy_level'.");
+                                continue;
+                        }
+
+                        uint Lv = 0;
+                        if (jEnemyLevel.TryGetProperty("min_lv", out JsonElement jEmLv))
+                        {
+                            Lv = jEmLv.GetUInt32();
+                        }
+
+                        uint minLv = 0;
+                        if (jEnemyLevel.TryGetProperty("min_lv", out JsonElement jEmMinLv))
+                        {
+                            minLv = jEmMinLv.GetUInt32();
+                        }
+
+                        uint maxLv = 0;
+                        if (jEnemyLevel.TryGetProperty("max_lv", out JsonElement jEmMaxLv))
+                        {
+                            maxLv = jEmMaxLv.GetUInt32();
+                        }
+
+                        if ((eventItem.EmLvConstraint == EventItemConstraint.LessThan ||
+                             eventItem.EmLvConstraint == EventItemConstraint.LessThanOrEqual ||
+                             eventItem.EmLvConstraint == EventItemConstraint.GreaterThan ||
+                             eventItem.EmLvConstraint == EventItemConstraint.GreaterThanOrEqual) && Lv == 0)
+                        {
+                            Logger.Error($"The constraint '{eventItem.EmLvConstraint}' requires the field 'lv' to be present with a value > 0.");
+                            continue;
+                        }
+                        else if(eventItem.EmLvConstraint == EventItemConstraint.InRange && (minLv == 0 || maxLv == 0))
+                        {
+                            Logger.Error($"The constraint '{eventItem.EmLvConstraint}' requires the field 'min_lv' and 'max_lv' to be present with a value > 0.");
+                            continue;
+                        }
+
+                        eventItem.EmLvConstraintParams = (Lv, minLv, maxLv);
                     }
                 }
 

--- a/Arrowgene.Ddon.Shared/Files/Assets/EventDrops.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/EventDrops.json
@@ -112,6 +112,23 @@
         "quest_ids": [60301057],
         "stage_ids": [],
         "enemy_ids": []
+    },
+    {
+        "item_id": 7790,
+        "comment": "Adds randomized gold drop of 10-200 gold to all enemies between level 1-10",
+        "min_num": 1,
+        "max_num": 20,
+        "drop_chance": 0.3,
+        "quest_ids": [],
+        "stage_ids": [],
+        "enemy_ids": [],
+        "requirements": {
+            "enemy_level": {
+                "constraint": "InRange",
+                "min_lv": 1,
+                "max_lv": 10
+            }
+        }
     }
 ]
 

--- a/Arrowgene.Ddon.Shared/Model/EventItemConstraint.cs
+++ b/Arrowgene.Ddon.Shared/Model/EventItemConstraint.cs
@@ -10,6 +10,13 @@ namespace Arrowgene.Ddon.Shared.Model
     {
         None,
         All,
-        AtLeastOne
+        AtLeastOne,
+        LessThan,           // The value is < a
+        LessThanOrEqual,    // The value <= a
+        GreaterThan,        // The value is > a
+        GreaterThanOrEqual, // The value is >= a
+        InRange,            // The Value is in the range [a, b]
+        IsBoss,
+        IsNotBoss,
     }
 }


### PR DESCRIPTION
- Added new EventItemConstraint values
    - LessThan
    - LessThanOrEqual
    - GreaterThan
    - GreaterThanOrEqual
    - InRange
- Added the ability to define constraints based on enemy level
    - If the constraint is 'InRange' the fields 'min_lv' and 'max_lv' are required.
        - "requirements": {"enemy_level" : {"constraint": "InRange", "min_lv": x, "max_lv": y}}
    - If the constraint is any of the other types the field 'lv' is required.
      - "requirements": {"enemy_level" : {"constraint": "LessThan|LessThanOrEqual|GreaterThan|GreaterThanOrEqual", "lv": x}}
- Added the ability to define constraints based on if the enemy is a boss or not.
    - "requirements": {"enemy_class": "None|IsBoss|IsNotBoss"}

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
