### PR TITLE
Configurable bazaar timers and bazaar related GP course effects

### DIFF
--- a/Arrowgene.Ddon.GameServer/BazaarManager.cs
+++ b/Arrowgene.Ddon.GameServer/BazaarManager.cs
@@ -11,10 +11,6 @@ namespace Arrowgene.Ddon.GameServer
     {
         private static readonly double TAXES = 0.05; // 5%, value taken from the ingame menu
 
-        // TODO: Make it configurable
-        private static readonly TimeSpan EXHIBITION_TIME_SPAN = TimeSpan.FromDays(3);
-        private static readonly TimeSpan COOLDOWN_TIME_SPAN = TimeSpan.FromDays(1);
-
         public BazaarManager(DdonGameServer server)
         {
             Server = server;
@@ -43,7 +39,7 @@ namespace Arrowgene.Ddon.GameServer
             exhibition.Info.ItemInfo.ExhibitionTime = now;
             exhibition.Info.State = BazaarExhibitionState.OnSale;
             exhibition.Info.Proceeds = calculateProceeds(exhibition.Info.ItemInfo.ItemBaseInfo);
-            exhibition.Info.Expire = now.Add(EXHIBITION_TIME_SPAN);
+            exhibition.Info.Expire = now.AddSeconds(Server.Setting.GameLogicSetting.BazaarExhibitionTimeSeconds);
 
             ulong bazaarId = Server.Database.InsertBazaarExhibition(exhibition);
             return bazaarId;
@@ -63,7 +59,7 @@ namespace Arrowgene.Ddon.GameServer
             exhibition.Info.ItemInfo.ItemBaseInfo.Price = newPrice;
             exhibition.Info.ItemInfo.ExhibitionTime = now;
             exhibition.Info.Proceeds = calculateProceeds(exhibition.Info.ItemInfo.ItemBaseInfo);
-            exhibition.Info.Expire = now.Add(EXHIBITION_TIME_SPAN);
+            exhibition.Info.Expire = now.AddSeconds(Server.Setting.GameLogicSetting.BazaarExhibitionTimeSeconds);
             Server.Database.UpdateBazaarExhibiton(exhibition);
 
             return exhibition.Info.ItemInfo.BazaarId;
@@ -158,7 +154,7 @@ namespace Arrowgene.Ddon.GameServer
             foreach (BazaarExhibition exhibition in exhibitionsToReceive)
             {
                 exhibition.Info.State = BazaarExhibitionState.Idle;
-                exhibition.Info.Expire = now.Add(COOLDOWN_TIME_SPAN);
+                exhibition.Info.Expire = now.AddSeconds(Server.Setting.GameLogicSetting.BazaarCooldownTimeSeconds);
                 Server.Database.UpdateBazaarExhibiton(exhibition);
             }
 

--- a/Arrowgene.Ddon.GameServer/BazaarManager.cs
+++ b/Arrowgene.Ddon.GameServer/BazaarManager.cs
@@ -154,7 +154,16 @@ namespace Arrowgene.Ddon.GameServer
             foreach (BazaarExhibition exhibition in exhibitionsToReceive)
             {
                 exhibition.Info.State = BazaarExhibitionState.Idle;
-                exhibition.Info.Expire = now.AddSeconds(Server.Setting.GameLogicSetting.BazaarCooldownTimeSeconds);
+                ulong totalCooldown;
+                try
+                {
+                    totalCooldown = Server.Setting.GameLogicSetting.BazaarCooldownTimeSeconds - Server.GpCourseManager.BazaarReExhibitShorten();
+                }
+                catch (OverflowException _)
+                {
+                    totalCooldown = 0;
+                }
+                exhibition.Info.Expire = now.AddSeconds(totalCooldown);
                 Server.Database.UpdateBazaarExhibiton(exhibition);
             }
 

--- a/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/GpCourseManager.cs
@@ -35,6 +35,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
             public bool DisablePartyExpAdjustment = false;
             public double EnemyBloodOrbMultiplier = 0.0;
             public bool InfiniteRevive = false;
+            public uint BazaarExhibitExtend = 0;
+            public ulong BazaarReExhibitShorten = 0;
         };
 
         private void ApplyCourseEffects(uint courseId)
@@ -72,6 +74,12 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             break;
                         case GPCourseId.InfiniteRevive:
                             _CourseBonus.InfiniteRevive = true;
+                            break;
+                        case GPCourseId.BazaarExhibitExtend:
+                            _CourseBonus.BazaarExhibitExtend += effect.Param0;
+                            break;
+                        case GPCourseId.BazaarReExhibitShorten:
+                            _CourseBonus.BazaarReExhibitShorten += effect.Param0;
                             break;
                     }
                 }
@@ -248,6 +256,22 @@ namespace Arrowgene.Ddon.GameServer.Characters
             lock (_CourseBonus)
             {
                 return _CourseBonus.InfiniteRevive;
+            }
+        }
+
+        public uint BazaarExhibitExtend()
+        {
+            lock (_CourseBonus)
+            {
+                return _CourseBonus.BazaarExhibitExtend;
+            }
+        }
+
+        public ulong BazaarReExhibitShorten()
+        {
+            lock (_CourseBonus)
+            {
+                return _CourseBonus.BazaarReExhibitShorten;
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/BazaarGetExhibitPossibleNumHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/BazaarGetExhibitPossibleNumHandler.cs
@@ -16,8 +16,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             return new S2CBazaarGetExhibitPossibleNumRes()
             {
-                Num = client.Character.MaxBazaarExhibits,
-                Add = 0 // TODO: Figure out
+                Num = client.Character.MaxBazaarExhibits + Server.GpCourseManager.BazaarExhibitExtend(),
+                Add = Server.GpCourseManager.BazaarExhibitExtend() // Not sure what the purpose of this value is
             };
         }
     }

--- a/Arrowgene.Ddon.Server/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/GameLogicSetting.cs
@@ -242,11 +242,24 @@ namespace Arrowgene.Ddon.Server
         /// </summary>
         [DataMember(Order = 37)] public bool? EnableEpitaphWeeklyRewards { get; set; } = true;
 
+        /// <summary>
         /// Enables main pawns in party to gain EXP and JP from quests
         /// Original game apparantly did not have pawns share quest reward, so will set to false for default, 
         /// change as needed
         /// </summary>
         [DataMember(Order = 38)] public bool EnableMainPartyPawnsQuestRewards { get; set; }
+
+        /// <summary>
+        /// Specifies the time in seconds that a bazaar exhibit will last.
+        /// By default, the equivalent of 3 days
+        /// </summary>
+        [DataMember(Order = 37)] public ulong BazaarExhibitionTimeSeconds { get; set; }
+
+        /// <summary>
+        /// Specifies the time in seconds that a slot in the bazaar won't be able to be used again.
+        /// By default, the equivalent of 1 day
+        /// </summary>
+        [DataMember(Order = 38)] public ulong BazaarCooldownTimeSeconds { get; set; }
 
         /// <summary>
         /// Various URLs used by the client.
@@ -334,6 +347,9 @@ namespace Arrowgene.Ddon.Server
             EnableEpitaphWeeklyRewards = false;
             EnableMainPartyPawnsQuestRewards = false;
 
+            BazaarExhibitionTimeSeconds = (ulong) TimeSpan.FromDays(3).TotalSeconds;
+            BazaarCooldownTimeSeconds = (ulong) TimeSpan.FromDays(1).TotalSeconds;
+
             string urlDomain = $"http://localhost:{52099}";
             UrlManual = $"{urlDomain}/manual_nfb/";
             UrlShopDetail = $"{urlDomain}/shop/ingame/stone/detail";
@@ -399,6 +415,9 @@ namespace Arrowgene.Ddon.Server
 
             EnableEpitaphWeeklyRewards = setting.EnableEpitaphWeeklyRewards;
             EnableMainPartyPawnsQuestRewards = setting.EnableMainPartyPawnsQuestRewards;
+
+            BazaarExhibitionTimeSeconds = setting.BazaarExhibitionTimeSeconds;
+            BazaarCooldownTimeSeconds = setting.BazaarCooldownTimeSeconds;
 
             UrlManual = setting.UrlManual;
             UrlShopDetail = setting.UrlShopDetail;


### PR DESCRIPTION
Adds new game server settings for the bazaar timers BazaarExhibitionTimeSeconds and BazaarCooldownTimeSeconds, with default values of 3 days and 1 day.
Implements the GP course effects that extend bazaar slots and reduces new bazaar cooldown timer

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
