### PR TITLE
Add separate exp modifier for BBM enemies

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -510,7 +510,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                     if (client.GameMode == GameMode.Normal)
                     {
-                        addJobPoint += GetScaledPointAmount(RewardSource.None, PointType.JobPoints, LEVEL_UP_JOB_POINTS_EARNED[targetLevel]);
+                        addJobPoint += GetScaledPointAmount(client.GameMode, RewardSource.None, PointType.JobPoints, LEVEL_UP_JOB_POINTS_EARNED[targetLevel]);
                     }
                 }
 
@@ -895,13 +895,19 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return multiplier;
         }
 
-        public uint GetScaledPointAmount(RewardSource source, PointType type, uint amount)
+        public uint GetScaledPointAmount(GameMode gameMode, RewardSource source, PointType type, uint amount)
         {
             double modifier = 1.0;
             switch (type)
             {
                 case PointType.ExperiencePoints:
-                    modifier = (source == RewardSource.Enemy) ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+                    if(gameMode == GameMode.Normal) {
+                        modifier = (source == RewardSource.Enemy) ? _GameSettings.EnemyExpModifier : _GameSettings.QuestExpModifier;
+                    }
+                    //No quests in BBM, reward source should always be Enemy
+                    else if(gameMode == GameMode.BitterblackMaze) {
+                        modifier =  _GameSettings.BBMEnemyExpModifier;
+                    }
                     break;
                 case PointType.JobPoints:
                     modifier = _GameSettings.JpModifier;

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -180,10 +180,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var expCurveMixin = Server.ScriptManager.MixinModule.Get<IExpMixin>("exp");
 
                 uint baseEnemyExp = expCurveMixin.GetExpValue(enemyKilled);
-                baseEnemyExp = _gameServer.ExpManager.GetScaledPointAmount(RewardSource.Enemy, PointType.ExperiencePoints, baseEnemyExp);
+                baseEnemyExp = _gameServer.ExpManager.GetScaledPointAmount(client.GameMode, RewardSource.Enemy, PointType.ExperiencePoints, baseEnemyExp);
                 
                 uint calcExp = _gameServer.ExpManager.GetAdjustedExp(client.GameMode, RewardSource.Enemy, client.Party, baseEnemyExp, enemyKilled.Lv);
-                uint calcPP = _gameServer.ExpManager.GetScaledPointAmount(RewardSource.Enemy, PointType.PlayPoints, enemyKilled.GetDroppedPlayPoints());
+                uint calcPP = _gameServer.ExpManager.GetScaledPointAmount(client.GameMode, RewardSource.Enemy, PointType.PlayPoints, enemyKilled.GetDroppedPlayPoints());
 
                 foreach (PartyMember member in client.Party.Members)
                 {

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -122,7 +122,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 result.Add(new CDataQuestExp()
                 {
                     Type = pointReward.Type,
-                    Reward = Server.ExpManager.GetScaledPointAmount(RewardSource.Quest, pointReward.Type, pointReward.Reward)
+                    Reward = Server.ExpManager.GetScaledPointAmount(GameMode.Normal, RewardSource.Quest, pointReward.Type, pointReward.Reward)
                 });
             }
             return result;

--- a/Arrowgene.Ddon.Server/Scripting/interfaces/GameLogicSetting.cs
+++ b/Arrowgene.Ddon.Server/Scripting/interfaces/GameLogicSetting.cs
@@ -314,13 +314,24 @@ namespace Arrowgene.Ddon.Server.Scripting.interfaces
         }
 
         /// <summary>
-        /// Global modifier for enemy exp calculations to scale up or down.
+        /// Global modifier for enemy exp calculations to scale up or down (does not apply to Bitterblack Maze).
         /// </summary>
         public double EnemyExpModifier
         {
             get
             {
                 return GetSetting<double>("EnemyExpModifier");
+            }
+        }
+
+        /// <summary>
+        /// Global modifier for BBM enemy exp calculations to scale up or down.
+        /// </summary>
+        public double BBMEnemyExpModifier
+        {
+            get
+            {
+                return GetSetting<double>("BBMEnemyExpModifier");
             }
         }
 

--- a/Arrowgene.Ddon.Shared/Files/Assets/scripts/settings/GameLogicSettings.csx
+++ b/Arrowgene.Ddon.Shared/Files/Assets/scripts/settings/GameLogicSettings.csx
@@ -102,6 +102,7 @@ uint PlayPointMax = 2000;
 
 // Global Point Modifiers
 double EnemyExpModifier = 1;
+double BBMEnemyExpModifier = 1;
 double QuestExpModifier = 1;
 double PpModifier = 1;
 double GoldModifier = 1;


### PR DESCRIPTION
Separate exp modifiers for enemies in and outside of Bitterblack Maze game mode.

Tested settings below:
**EnemyExpModifer: 2.0
BBMEnemyExpModifer: 1.0**
goblin (lv1): 20 exp
Netherworld Familiar (lv8, BBM): 175 exp
A Man Eating Ogre (enemy): 15200 exp
A Man Eating Ogre (Quest): 1020 exp

**EnemyExpModifer: 1.0
BBMEnemyExpModifer: 2.0**
goblin (lv1): 10 exp
Netherworld Familiar (lv8, BBM): 350 exp
A Man Eating Ogre (enemy): 7600 exp
A Man Eating Ogre (Quest): 1020 exp

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
