### PR TITLE
docs: Add Quest Endgame Content document

### DIFF
--- a/docs/quests/endgame_content.md
+++ b/docs/quests/endgame_content.md
@@ -1,0 +1,128 @@
+
+## EXM
+
+### 4 Player
+
+#### Always
+| Quest Id | Quest Name | Starting NPC | Recommended Level | Content Type | References | Implemented  |
+|:---------|:----------:|:------------:|:-----------------:|:------------:|:----------:|:------------:|
+| 50101020 | The Call of the Catacombs, 地下墓場の誘い | Seneca | 58 | EM1 | https://h1g.jp/dd-on/?%E5%9C%B0%E4%B8%8B%E5%A2%93%E5%A0%B4%E3%81%AE%E8%AA%98%E3%81%84 | ✓
+| 50102020 | Drawn to Ancient Power, 古き力に魅かれし者 | Senaca | 60 | EM2 | https://h1g.jp/dd-on/?%E5%8F%A4%E3%81%8D%E5%8A%9B%E3%81%AB%E9%AD%85%E3%81%8B%E3%82%8C%E3%81%97%E8%80%85 | ✓
+| 50103020 | The Ancient City's Legacy, 古都の賜物 | Senaca | 60 | EM3 | https://h1g.jp/dd-on/?%E5%8F%A4%E9%83%BD%E3%81%AE%E8%B3%9C%E7%89%A9 | ✓
+| 50104000 | The Shining Gate, 輝く扉 | Senaca | 60 | EM4 | https://h1g.jp/dd-on/?%E8%BC%9D%E3%81%8F%E6%89%89 | ✓
+| 50201000 | Agent of Corruption, 歪みの執行人 | Issac | 65 | EM5 | https://h1g.jp/dd-on/?%E6%AD%AA%E3%81%BF%E3%81%AE%E5%9F%B7%E8%A1%8C%E4%BA%BA | ✓
+| 50202000 | Phantasmic Great Dragon, 淀みし大竜力 | Issac | 70 | EM6 | https://h1g.jp/dd-on/?%E6%B7%80%E3%81%BF%E3%81%97%E5%A4%A7%E7%AB%9C%E5%8A%9B%28EM%29 | ✓
+| 50202003 | With the Myrmidons, 戦徒と共に | Seneca | 70 || https://h1g.jp/dd-on/?%E6%88%A6%E5%BE%92%E3%81%A8%E5%85%B1%E3%81%AB | ✓
+| 50203000 | Earth's Fury, 大地の怒り | Issac | 75 | EM7 | https://h1g.jp/dd-on/?%E5%A4%A7%E5%9C%B0%E3%81%AE%E6%80%92%E3%82%8A | ✓
+| 50204002 | Onset of Darkness, 降臨せし闇 | Issac | 80 | EM8 | https://h1g.jp/dd-on/?%E9%99%8D%E8%87%A8%E3%81%9B%E3%81%97%E9%97%87 | ✓
+| 50301001 | Breakneck Destruction: Dacreim Fortress, 速壊の極み　ダクレイム砦 | Endale | 85 || https://www.youtube.com/watch?v=bj8ldt9ThRs
+| 50400000 | Gatekeeper of the Dark World, 黒界の門番 | Travers | 100 || https://h1g.jp/dd-on/?%E9%BB%92%E7%95%8C%E3%81%AE%E9%96%80%E7%95%AA
+| 50400001 | High Difficulty: Gatekeeper of the Dark World, 【高難度】黒界の門番 | Travers | 100 || https://h1g.jp/dd-on/?%E3%80%90%E9%AB%98%E9%9B%A3%E5%BA%A6%E3%80%91%E9%BB%92%E7%95%8C%E3%81%AE%E9%96%80%E7%95%AA
+| 50400002 | Blue Shadow Dancing in Revelry, 狂宴に舞う蒼影 | Travers | 100 || https://h1g.jp/dd-on/?%E7%8B%82%E5%AE%B4%E3%81%AB%E8%88%9E%E3%81%86%E8%92%BC%E5%BD%B1
+| 50400003 | High Difficulty: Blue Shadow Dancing in Revelry, 【高難度】狂宴に舞う蒼影 | Travers | 100 || https://h1g.jp/dd-on/?%E3%80%90%E9%AB%98%E9%9B%A3%E5%BA%A6%E3%80%91%E7%8B%82%E5%AE%B4%E3%81%AB%E8%88%9E%E3%81%86%E8%92%BC%E5%BD%B1
+| 50400004 | Arisen of the Black Darkness, 黒き闇の覚者 | Travers | 100 || https://h1g.jp/dd-on/?%E9%BB%92%E3%81%8D%E9%97%87%E3%81%AE%E8%A6%9A%E8%80%85 | ✓
+| 50400005 | High Difficulty: Arisen of the Black Darkness, 【高難度】黒き闇の覚者 | Travers | 100 || https://www.youtube.com/watch?v=budlFzoFj5M
+| 50400006 | Power that Destroys Reason, 理を破壊する力 | Travers | 100 || https://h1g.jp/dd-on/?%E7%90%86%E3%82%92%E7%A0%B4%E5%A3%8A%E3%81%99%E3%82%8B%E5%8A%9B
+| 50400007 | High Difficulty: Power that Destroys Reason, 【高難度】理を破壊する力 | Travers | 100 || https://h1g.jp/dd-on/?%E3%80%90%E9%AB%98%E9%9B%A3%E5%BA%A6%E3%80%91%E7%90%86%E3%82%92%E7%A0%B4%E5%A3%8A%E3%81%99%E3%82%8B%E5%8A%9B
+| 50400013 | Demon Forces Thundering Through the Fortress, 砦に轟く戦鬼連合 | Issac | 105 || https://h1g.jp/dd-on/?%E7%A0%A6%E3%81%AB%E8%BD%9F%E3%81%8F%E6%88%A6%E9%AC%BC%E9%80%A3%E5%90%88
+| 50400014 | The Black Martyr, 黒の殉教者 | Issac | 110 || https://h1g.jp/dd-on/?%E9%BB%92%E3%81%AE%E6%AE%89%E6%95%99%E8%80%85
+| 50400015 | Legend of Lestania, レジェンドオブレスタニア | Issac | 149 || https://www.youtube.com/watch?v=2MGAD0j-O00
+| 50302001 | Breakneck Speed: Jifule Fortress, 速移の極み　ジフール砦 |||| https://www.youtube.com/watch?v=wX00LtgulxE
+| 50400008 | The Great Dragon Crystal War：The Resisting Land, 大竜晶破壊戦：抗う大地 | Travers || Chain | https://h1g.jp/dd-on/?%E5%A4%A7%E7%AB%9C%E6%99%B6%E7%A0%B4%E5%A3%8A%E6%88%A6%EF%BC%9A%E6%8A%97%E3%81%86%E5%A4%A7%E5%9C%B0
+| 50400009 | The Great Dragon Crystal War：Captured Palace, 大竜晶破壊戦：奪われた王宮 | Travers || Chain | https://h1g.jp/dd-on/?%E5%A4%A7%E7%AB%9C%E6%99%B6%E7%A0%B4%E5%A3%8A%E6%88%A6%EF%BC%9A%E5%A5%AA%E3%82%8F%E3%82%8C%E3%81%9F%E7%8E%8B%E5%AE%AE
+| 50400010 | The Great Dragon Crystal War：Castle with No Lord, 大竜晶破壊戦：主無き古城 | Travers || Chain | https://h1g.jp/dd-on/?%E5%A4%A7%E7%AB%9C%E6%99%B6%E7%A0%B4%E5%A3%8A%E6%88%A6%EF%BC%9A%E4%B8%BB%E7%84%A1%E3%81%8D%E5%8F%A4%E5%9F%8E
+| 50400011 | The Great Dragon Crystal War：The Sacrificed Capital, 大竜晶破壊戦：捧げられし廃都 | Travers || Chain | https://h1g.jp/dd-on/?%E5%A4%A7%E7%AB%9C%E6%99%B6%E7%A0%B4%E5%A3%8A%E6%88%A6%EF%BC%9A%E6%8D%A7%E3%81%92%E3%82%89%E3%82%8C%E3%81%97%E5%BB%83%E9%83%BD
+
+
+#### Limited
+
+| Quest Id | Quest Name | Starting NPC | Recommended Level | Period | References | Implemented  |
+|:---------|:----------:|:------------:|:-----------------:|:------:|:----------:|:------------:|
+| 50101021 | Ghosts 'n Goblins Collaboration: Special Mission, 魔界村コラボ 特別ミッション | Issac | 60 | 9/1/2017 - 9/28/2017 | https://h1g.jp/dd-on/?%E9%AD%94%E7%95%8C%E6%9D%91%E3%82%B3%E3%83%A9%E3%83%9C%20%E7%89%B9%E5%88%A5%E3%83%9F%E3%83%83%E3%82%B7%E3%83%A7%E3%83%B3
+| 50105000 | Lestania War Chronicles, レスタニア追懐戦記 || 60 | | https://h1g.jp/dd-on/?%E3%83%AC%E3%82%B9%E3%82%BF%E3%83%8B%E3%82%A2%E8%BF%BD%E6%87%90%E6%88%A6%E8%A8%98
+| 50201001 | Agent of Corruption: Restricted Stage, 歪みの執行人・限界域 | Issac | 65 || https://h1g.jp/dd-on/?%E6%AD%AA%E3%81%BF%E3%81%AE%E5%9F%B7%E8%A1%8C%E4%BA%BA%E3%83%BB%E9%99%90%E7%95%8C%E5%9F%9F
+| 50209000 | 1st Anniversary: White Dragon Cup, 【１周年記念】 白竜杯 | Seneca | 65 (IR20) || https://h1g.jp/dd-on/?%E3%80%901%E5%91%A8%E5%B9%B4%E8%A8%98%E5%BF%B5%E3%80%91%E7%99%BD%E7%AB%9C%E6%9D%AF
+| 50202002 | Battle Competition: Dragon Battle, 戦技闘会・竜伐戦 | Seneca | 70 || https://h1g.jp/dd-on/?%E6%88%A6%E6%8A%80%E9%97%98%E4%BC%9A%E3%83%BB%E7%AB%9C%E4%BC%90%E6%88%A6
+| 50202001 | Phantasmic Great Dragon: Restricted Stage, 淀みし大竜力・限界域 | Issac | 70 || https://h1g.jp/dd-on/?%E6%B7%80%E3%81%BF%E3%81%97%E5%A4%A7%E7%AB%9C%E5%8A%9B%20%E9%99%90%E7%95%8C%E5%9F%9F
+| 50203001 | Earth's Fury: Restricted Stage, 大地の怒り・限界域 | Issac | 75 || https://h1g.jp/dd-on/?%E5%A4%A7%E5%9C%B0%E3%81%AE%E6%80%92%E3%82%8A%E3%83%BB%E9%99%90%E7%95%8C%E5%9F%9F
+| 50206000 | Phindym War Chronicles, フィンダム追懐戦記 | Issac | 80 || https://h1g.jp/dd-on/?%E3%83%95%E3%82%A3%E3%83%B3%E3%83%80%E3%83%A0%E8%BF%BD%E6%87%90%E6%88%A6%E8%A8%98 | ✓
+| 50204001 | Onset of Darkness: Restricted Stage, 降臨せし闇・限界域 | Issac | 80 || https://h1g.jp/dd-on/?%E9%99%8D%E8%87%A8%E3%81%9B%E3%81%97%E9%97%87%E3%83%BB%E9%99%90%E7%95%8C%E5%9F%9F | ✓
+| 50204000 | Recurrence of Darkness, 闇の再動 | Issac | 80 || https://h1g.jp/dd-on/?%E9%97%87%E3%81%AE%E5%86%8D%E5%8B%95
+| 50301000 | Enfilade of Despair and Tragedy: Restricted Stage, 絶望と惨劇の砲声 限界域 | Endale | IR 90 || https://h1g.jp/dd-on/?%E7%B5%B6%E6%9C%9B%E3%81%A8%E6%83%A8%E5%8A%87%E3%81%AE%E7%A0%B2%E5%A3%B0%20%E9%99%90%E7%95%8C%E5%9F%9F
+| 50302000 | The Inviting Eye: Restricted Stage, 誘う眼　限界域 | Area Master | IR 100 || https://h1g.jp/dd-on/?%E8%AA%98%E3%81%86%E7%9C%BC%20%E9%99%90%E7%95%8C%E5%9F%9F
+| 50303000 | Flames of Darkness: Restricted Stage, 暗晦の炎　限界域 | Doris | IR 110 | New Years? | https://h1g.jp/dd-on/?%E6%9A%97%E6%99%A6%E3%81%AE%E7%82%8E%20%E9%99%90%E7%95%8C%E5%9F%9F | ✓
+| 50209001 | 2nd Anniversary: White Dragon Cup, 【２周年記念】白竜杯 | Seneca | ??? ||
+| 50309000 | 3rd Anniversary: White Dragon Cup, 【３周年記念】白竜杯 | Issac || 8/30 - 9/6 | https://youtu.be/0f8KOG6HsZs
+| 50309001 | 3rd Anniversary: Breakneck Speed, 【３周年記念】速移の極み |||
+
+### 8 Player
+
+#### Always
+
+| Quest Id | Quest Name | Starting NPC | Recommended Level | References | Implemented  |
+|:---------|:----------:|:------------:|:-----------------:|:----------:|:------------:|
+| 50300000 | Battle for Gritten Fort: Fierce Battle, グリッテン砦攻防戦　戦況：激戦 | Alan | 40 | https://www.youtube.com/watch?v=fcfXF3PprIE
+| 50300001 | Ancient Warrior, 太古の強者 | Alan | 45 | https://h1g.jp/dd-on/?%E5%A4%AA%E5%8F%A4%E3%81%AE%E5%BC%B7%E8%80%85 | ✓
+| 50300002 | Battle for Gritten Fort: Mystery Battle, グリッテン砦攻防戦　戦況：怪戦 | Alan | 50 | https://www.youtube.com/watch?v=Q1wBdkpT62M
+| 50300003 | The Lost Order, 失われた秩序 | Alan | 55 | https://h1g.jp/dd-on/?%E5%A4%B1%E3%82%8F%E3%82%8C%E3%81%9F%E7%A7%A9%E5%BA%8F | ✓
+| 50300005 | The Crucible of Demons, 魔物のるつぼ | Alan | 60 | https://h1g.jp/dd-on/?%E9%AD%94%E7%89%A9%E3%81%AE%E3%82%8B%E3%81%A4%E3%81%BC
+| 50300006 | The Dazzling Gold, 眩き黄金 | Alan | 60 | https://h1g.jp/dd-on/?%E7%9C%A9%E3%81%8D%E9%BB%84%E9%87%91 | ✓
+| 50300004 | Battle for Gritten Fort: Recapture Battle, グリッテン砦攻防戦　戦況：奪回戦 | Alan | 60 | https://h1g.jp/dd-on/?%E3%82%B0%E3%83%AA%E3%83%83%E3%83%86%E3%83%B3%E7%A0%A6%E6%94%BB%E9%98%B2%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A5%AA%E5%9B%9E%E6%88%A6
+| 50300007 | The Demon of Darkness Awakens, 目覚めし闇の魔物 | Alan | 65 | https://h1g.jp/dd-on/?%E7%9B%AE%E8%A6%9A%E3%82%81%E3%81%97%E9%97%87%E3%81%AE%E9%AD%94%E7%89%A9
+| 50300008 | Bloodbane Isle's Feast of Madness, 魔赤島の狂宴 | Alan | 70 | https://h1g.jp/dd-on/?%E9%AD%94%E8%B5%A4%E5%B3%B6%E3%81%AE%E7%8B%82%E5%AE%B4
+| 50300009 | The Deathly Battle of the Ancient Temple, 古代神殿の死闘 | Alan | 75 | https://h1g.jp/dd-on/?%E5%8F%A4%E4%BB%A3%E7%A5%9E%E6%AE%BF%E3%81%AE%E6%AD%BB%E9%97%98
+| 50300010 | The Dragon Awakened, 呼び覚まされし竜 | Alan | 80 | https://h1g.jp/dd-on/?%E5%91%BC%E3%81%B3%E8%A6%9A%E3%81%BE%E3%81%95%E3%82%8C%E3%81%97%E7%AB%9C | ✓
+| 50400012 | Restricted Stage: Power that Destroys Reason, 【限界域】理を破壊する力 | Travers | 100 | https://h1g.jp/dd-on/?%E3%80%90%E9%99%90%E7%95%8C%E5%9F%9F%E3%80%91%E7%90%86%E3%82%92%E7%A0%B4%E5%A3%8A%E3%81%99%E3%82%8B%E5%8A%9B
+
+## Clan Dungeons
+
+| Quest Id | Quest Name                                      | Starting NPC | Recommended Level | References | Implemented  |
+|:---------|:-----------------------------------------------:|:------------:|:-----------------:|:----------:|:------------:|
+| 50205000 | The Foreigner's Remains, 異人の遺跡              | Clan Dungeon | 75                | https://h1g.jp/dd-on/?%E7%95%B0%E4%BA%BA%E3%81%AE%E9%81%BA%E8%B7%A1
+| 50205001 | The Foreigner's Cave, 異人の洞窟                 | Clan Dungeon | 75                | https://h1g.jp/dd-on/?%E7%95%B0%E4%BA%BA%E3%81%AE%E6%B4%9E%E7%AA%9F
+| 50205002 | The Foreigner's Underground Tomb, 異人の地下墓所 | Clan Dungeon | 75                | https://h1g.jp/dd-on/?%E7%95%B0%E4%BA%BA%E3%81%AE%E5%9C%B0%E4%B8%8B%E5%A2%93%E6%89%80
+| 50205003 | The Foreigner's Tower, 異人の塔                 | Clan Dungeon | 80                 | https://h1g.jp/dd-on/?%E7%95%B0%E4%BA%BA%E3%81%AE%E5%A1%94
+
+## War Mission
+
+| Quest Id | Quest Name                        | Recommended Level | References | Implemented  |
+|:---------|:---------------------------------:|:-----------------:|:----------:|:------------:|
+|          | ダクレイム砦奪還戦 戦況：大将討滅 | 85 (IR86) | https://h1g.jp/dd-on/?%E3%83%80%E3%82%AF%E3%83%AC%E3%82%A4%E3%83%A0%E7%A0%A6%E5%A5%AA%E9%82%84%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E8%A8%8E%E6%BB%85
+|          | ダクレイム砦奪還戦 戦況：敵軍殲滅 | 85 (IR86) | https://h1g.jp/dd-on/?%E3%83%80%E3%82%AF%E3%83%AC%E3%82%A4%E3%83%A0%E7%A0%A6%E5%A5%AA%E9%82%84%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E6%95%B5%E8%BB%8D%E6%AE%B2%E6%BB%85
+|          | ジフール砦攻略戦 戦況：大将討滅 | 90 (IR96) | https://h1g.jp/dd-on/?%E3%82%B8%E3%83%95%E3%83%BC%E3%83%AB%E7%A0%A6%E6%94%BB%E7%95%A5%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E6%95%B5%E8%BB%8D%E6%AE%B2%E6%BB%85
+|          | ジフール砦攻略戦 戦況：敵軍殲滅 | 90 (IR96) | https://h1g.jp/dd-on/?%E3%82%B8%E3%83%95%E3%83%BC%E3%83%AB%E7%A0%A6%E6%94%BB%E7%95%A5%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E6%95%B5%E8%BB%8D%E6%AE%B2%E6%BB%85
+|          | 霧の森の死闘 戦況：大将討滅 | 95 (IR106) | https://h1g.jp/dd-on/?%E9%9C%A7%E3%81%AE%E6%A3%AE%E3%81%AE%E6%AD%BB%E9%97%98%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E8%A8%8E%E6%BB%85
+|          | 霧の森の死闘 戦況：敵軍殲滅 | 95 (IR106) | https://h1g.jp/dd-on/?%E9%9C%A7%E3%81%AE%E6%A3%AE%E3%81%AE%E6%AD%BB%E9%97%98%20%E6%88%A6%E6%B3%81%EF%BC%9A%E6%95%B5%E8%BB%8D%E6%AE%B2%E6%BB%85
+|          | 蘇りし絶望の炎 戦況：限界域 | 100 (IR120) | https://h1g.jp/dd-on/?%E8%98%87%E3%82%8A%E3%81%97%E7%B5%B6%E6%9C%9B%E3%81%AE%E7%82%8E%20%E6%88%A6%E6%B3%81%EF%BC%9A%E9%99%90%E7%95%8C%E5%9F%9F
+|          | 蘇りし絶望の炎 戦況：火垂れ山頂上 | 100 (IR116) | https://h1g.jp/dd-on/?%E8%98%87%E3%82%8A%E3%81%97%E7%B5%B6%E6%9C%9B%E3%81%AE%E7%82%8E%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E8%A8%8E%E6%BB%85
+|          | 蘇りし絶望の炎 戦況：悪しき竜再誕 | 100 (IR116) | https://h1g.jp/dd-on/?%E8%98%87%E3%82%8A%E3%81%97%E7%B5%B6%E6%9C%9B%E3%81%AE%E7%82%8E%20%E6%88%A6%E6%B3%81%EF%BC%9A%E6%82%AA%E3%81%97%E3%81%8D%E7%AB%9C%E5%86%8D%E8%AA%95
+|          | 戦の将との闘い：展望城 | 100 (IR130) |
+|          | 闇の将との闘い：霧の森 | 100 (IR130) |
+|          | 骸の将との闘い：ジフール砦 | 100 (IR130) |
+|          | 獣の将との闘い：ダクレイム砦 | 100 (IR130) |
+| 90040000 | Acre Selund War Chronicles, アッカーシェラン追懐戦記 | 100 (IR130) | https://h1g.jp/dd-on/?%E3%82%A2%E3%83%83%E3%82%AB%E3%83%BC%E3%82%B7%E3%82%A7%E3%83%A9%E3%83%B3%E8%BF%BD%E6%87%90%E6%88%A6%E8%A8%98
+|          | ダクレイム砦奪還戦 戦況：大将奮起 | 100 (IR135) | https://h1g.jp/dd-on/?%E3%83%80%E3%82%AF%E3%83%AC%E3%82%A4%E3%83%A0%E7%A0%A6%E5%A5%AA%E9%82%84%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E5%A5%AE%E8%B5%B7
+|          | ジフール砦奪還戦 戦況：大将奮起 | 105 (IR140) | https://h1g.jp/dd-on/?%E3%82%B8%E3%83%95%E3%83%BC%E3%83%AB%E7%A0%A6%E5%A5%AA%E9%82%84%E6%88%A6%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E5%A5%AE%E8%B5%B7
+|          | 霧の森の死闘 戦況：大将奮起 | 110 (IR145) | https://h1g.jp/dd-on/?%E9%9C%A7%E3%81%AE%E6%A3%AE%E3%81%AE%E6%AD%BB%E9%97%98%20%E6%88%A6%E6%B3%81%EF%BC%9A%E5%A4%A7%E5%B0%86%E5%A5%AE%E8%B5%B7
+
+> [!NOTE]
+> These quests seem to contain multiple quest files, for example "Acre Selund War Chronicles" has `q90040000`, `q90040001`, `q90040002`, `q90040003` and `q90040004`.
+>
+> q90030100_00: Dacreim Fortress Recapture Battle                                        | ダクレイム砦奪還戦                                                                                                      
+> q90030101_00: Dacreim Fortress Recapture Battle                                        | ダクレイム砦奪還戦                                                                                                      
+> q90030102_00: Dacreim Fortress Recapture Battle                                        | ダクレイム砦奪還戦                                                                                                      
+> q90030103_00: Dacreim Fortress Recapture Battle                                        | ダクレイム砦奪還戦                                                                                                      
+> q90030104_00: Dacreim Fortress Recapture Battle: Enemy Annihilation                    | ダクレイム砦奪還戦　戦況：敵軍殲滅                                                                                      
+> q90030105_00: Dacreim Fortress Recapture Battle: Boss Annihilation                     | ダクレイム砦奪還戦　戦況：大将討滅                                                                                      
+> q90030200_00: Jifule Fortress Capture Battle                                           | ジフール砦攻略戦                                                                                                        
+> q90030201_00: Jifule Fortress Capture Battle                                           | ジフール砦攻略戦                                                                                                        
+> q90030202_00: Jifule Fortress Capture Battle                                           | ジフール砦攻略戦                                                                                                        
+> q90030203_00: Jifule Fortress Capture Battle                                           | ジフール砦攻略戦                                                                                                        
+> q90030204_00: Jifule Fortress Capture Battle: Enemy Annihilation                       | ジフール砦攻略戦　戦況：敵軍殲滅                                                                                        
+> q90030205_00: Jifule Fortress Capture Battle: Boss Annihilation                        | ジフール砦攻略戦　戦況：大将討滅                                                                                        
+> q90030300_00: The Deathly Battle of the Forest of Mist: Management                     | 霧の森の死闘：管理用                                                                                                    
+> q90030301_00: The Deathly Battle of the Forest of Mist: Main Event                     | 霧の森の死闘：本開催                                                                                                    
+> q90030302_00: The Deathly Battle of the Forest of Mist: Ranking                        | 霧の森の死闘：ランキング                                                                                                
+> q90030303_00: The Deathly Battle of the Forest of Mist: Receive Reward                 | 霧の森の死闘：報酬受取                                                                                                  
+> q90030304_00: The Deathly Battle of the Forest of Mist: Enemy Annihilation             | 霧の森の死闘　戦況：敵軍殲滅                                                                                            
+> q90030305_00: The Deathly Battle of the Forest of Mist: Boss Annihilation              | 霧の森の死闘　戦況：大将討滅 


### PR DESCRIPTION
Created a document which tracks the different endgame contents which are implemented using the quest system. Intended to track which EXMs, Clan Quests and War Missions still need to be implemented.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
