### PR TITLE
quest: Allow ItemId enum for quest files

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/BitterblackMazeManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/BitterblackMazeManager.cs
@@ -306,7 +306,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     results.Add(new InstancedGatheringItem()
                     {
-                        ItemId = rareItem,
+                        ItemId = (ItemId) rareItem,
                         ItemNum = 1,
                         Quality = 1,
                     });
@@ -335,7 +335,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     }
                     results.Add(new InstancedGatheringItem()
                     {
-                        ItemId = itemId,
+                        ItemId = (ItemId) itemId,
                         ItemNum = 1,
                         Quality = quality
                     });
@@ -361,7 +361,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     {
                         results.Add(new InstancedGatheringItem()
                         {
-                            ItemId = itemId,
+                            ItemId = (ItemId)itemId,
                             ItemNum = 1,
                         });
                     }
@@ -375,7 +375,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 uint itemId = BitterblackMazeManager.SelectGear(server, items, chestType, stageId);
                 results.Add(new InstancedGatheringItem()
                 {
-                    ItemId = itemId,
+                    ItemId = (ItemId) itemId,
                     ItemNum = 1,
                 });
             }
@@ -396,7 +396,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                         // Stick consumable in the front of the list
                         results.Insert(0, new InstancedGatheringItem()
                         {
-                            ItemId = item.Item1,
+                            ItemId = (ItemId) item.Item1,
                             ItemNum = numItems
                         });
                     }
@@ -410,7 +410,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 uint numItems = (uint)Random.Shared.Next((int)(item.Amount + 1));
                 results.Add(new InstancedGatheringItem()
                 {
-                    ItemId = item.ItemId,
+                    ItemId = (ItemId) item.ItemId,
                     ItemNum = numItems > 0 ? numItems : 1
                 });
             }

--- a/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
@@ -1235,7 +1235,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     results.Add(new InstancedGatheringItem()
                     {
-                        ItemId = rolledItem.ItemId,
+                        ItemId = (ItemId) rolledItem.ItemId,
                         ItemNum = rolledItem.ItemNum,
                         IsHidden = rolledItem.IsHidden,
                         Quality = rolledItem.Quality,
@@ -1313,7 +1313,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     // TODO: Make this configurable
                     results.Add(new InstancedGatheringItem()
                     {
-                        ItemId = (gatheringPoint == null) ? 9393 : dungeonInfo.SoulItemId,
+                        ItemId = (gatheringPoint == null) ? ItemId.WaterFlask : (ItemId) dungeonInfo.SoulItemId,
                         ItemNum = (uint) Random.Shared.Next(1, 4)
                     });
                 }

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -50,100 +50,120 @@ namespace Arrowgene.Ddon.GameServer.Characters
         };
         public static readonly List<StorageType> BbmEmbodyStorages = new List<StorageType> { StorageType.StorageBoxNormal, StorageType.ItemBagConsumable, StorageType.ItemBagMaterial, StorageType.ItemBagEquipment, StorageType.ItemBagJob };
 
-        private static readonly Dictionary<uint, (WalletType Type, uint Quantity)> ItemIdWalletTypeAndQuantity = new Dictionary<uint, (WalletType Type, uint Amount)>() {
-            {7789, (WalletType.Gold, 1)},
-            {7790, (WalletType.Gold, 10)},
-            {7791, (WalletType.Gold, 100)},
-            {7792, (WalletType.RiftPoints,1)},
-            {7793, (WalletType.RiftPoints,10)},
-            {7794, (WalletType.RiftPoints,100)},
-            {7795, (WalletType.BloodOrbs,1)}, // Doesn't show up
-            {7796, (WalletType.BloodOrbs,10)}, // Doesn't show up
-            {7797, (WalletType.BloodOrbs,100)}, // Doesn't show up
-            {18742, (WalletType.HighOrbs,1)},
-            {18743, (WalletType.HighOrbs,10)},
-            {18744, (WalletType.HighOrbs,100)},
-            {18828,(WalletType.Gold,7500)},
-            {18829,(WalletType.RiftPoints,1250)},
-            {18830,(WalletType.BloodOrbs,750)},
-            {19508,(WalletType.Gold,1000)},
-            {19509,(WalletType.Gold,10000)},
-            {19510,(WalletType.RiftPoints,1000)},
-            {19511,(WalletType.BloodOrbs,1000)},
+        private static readonly Dictionary<ItemId, (WalletType Type, uint Quantity)> ItemIdWalletTypeAndQuantity = new Dictionary<ItemId, (WalletType Type, uint Amount)>() {
+            {ItemId.CoinPouch1G, (WalletType.Gold, 1)},
+            {ItemId.CoinPouch10G, (WalletType.Gold, 10)},
+            {ItemId.CoinPouch100G, (WalletType.Gold, 100)},
+            {ItemId.RiftCrystal1Rp, (WalletType.RiftPoints, 1)},
+            {ItemId.RiftCrystal10Rp, (WalletType.RiftPoints, 10)},
+            {ItemId.RiftCrystal100Rp, (WalletType.RiftPoints, 100)},
+            {ItemId.BloodOrb1Bo, (WalletType.BloodOrbs,1)}, // Doesn't show up in loot pool
+            {ItemId.BloodOrb10Bo, (WalletType.BloodOrbs, 10)}, // Doesn't show up in loot pool
+            {ItemId.BloodOrb100Bo, (WalletType.BloodOrbs, 100)}, // Doesn't show up in loot pool
+            {ItemId.HighOrb1Ho, (WalletType.HighOrbs, 1)},
+            {ItemId.HighOrb10Ho, (WalletType.HighOrbs, 10)},
+            {ItemId.HighOrb100Ho, (WalletType.HighOrbs, 100)},
+            {ItemId.CoinPouch7500G, (WalletType.Gold, 7500)},
+            {ItemId.RiftCrystal1250Rp, (WalletType.RiftPoints, 1250)},
+            {ItemId.BloodOrb750Bo, (WalletType.BloodOrbs, 750)},
+            {ItemId.CoinPouch1000G, (WalletType.Gold, 1000)},
+            {ItemId.CoinPouch10000G, (WalletType.Gold, 10000)},
+            {ItemId.RiftCrystal1000Rp, (WalletType.RiftPoints, 1000)},
+            {ItemId.BloodOrb1000Bo, (WalletType.BloodOrbs, 1000)},
             // TODO: Requires special item notice type 47, could be offered in adventure pass shop
-            {11262,(WalletType.ResetCraftSkills,1)}
+            {ItemId.CurrencyForResettingCraftP, (WalletType.ResetCraftSkills, 1)}
             // TODO: Find all items that add wallet points
         };
 
-        private static readonly Dictionary<uint, uint> AbilityItems = new Dictionary<uint, uint>()
+        private static readonly Dictionary<ItemId, uint> AbilityItems = new Dictionary<ItemId, uint>()
         {
-            {16100, 448}, // 習得の書【友癒】,Book of Acquisition (Companion Healing),
-            {16101, 449}, // 習得の書【重歩 軽】,Book of Acquisition (Heavy Steps: Light),
-            {16102, 450},// 習得の書【穿歩 軽】,Book of Acquisition (Deft Footing: Light),
-            {16103, 451}, // 習得の書【延泉 軽】,Book of Acquisition (Extended Springs: Light),
-            {16104, 452}, // 習得の書【探採 軽】,Book of Acquisition (Gathering: Light),
-            {16105, 453}, // 習得の書【薬効 軽】,Book of Acquisition (Efficacy: Light),
-            {16106, 454}, // 習得の書【効延 軽】,Book of Acquisition (Effect Extension: Light),
-            {16107, 455}, // 習得の書【巧掘 軽】,Book of Acquisition (Expert Excavator: Light),
-            {16108, 456}, // 習得の書【流断 軽】,Book of Acquisition (Flow: Light),
-            {16109, 457}, // 習得の書【宝眼 軽】,Book of Acquisition (Treasure Eye: Light),
-            {16110, 458}, // 習得の書【根性 軽】,Book of Acquisition (Willpower: Light),
-            {16111, 459}, // 習得の書【安着 軽】,Book of Acquisition (Safe Landing: Light),
-            {19199, 248}, // 習得の書【抗毒】,Book of Acquisition (Resist Poison),
-            {19200, 249}, // 習得の書【抗遅】,Book of Acquisition (Anti-slow),
-            {19201, 250}, // 習得の書【抗眠】,Book of Acquisition (Anti-sleep),
-            {19202, 251}, // 習得の書【抗絶】,Book of Acquisition (Anti-stun),
-            {19203, 252}, // 習得の書【抗水】,Book of Acquisition (Anti-drench),
-            {19204, 253}, // 習得の書【抗油】,Book of Acquisition (Anti-oil),
-            {19205, 254}, // 習得の書【抗封】,Book of Acquisition (Anti-seal),
-            {19206, 255}, // 習得の書【抗軟】,Book of Acquisition (Anti-subdue),
-            {19207, 256}, // 習得の書【抗石】,Book of Acquisition (Anti-petrify),
-            {19208, 257}, // 習得の書【抗金】,Book of Acquisition (Anti-goldify),
-            {19209, 258}, // 習得の書【親炎】,Book of Acquisition (Close to Fire),
-            {19210, 259}, // 習得の書【親氷】,Book of Acquisition (Close to Ice),
-            {19211, 260}, // 習得の書【親雷】,Book of Acquisition (Close to Thunder),
-            {19212, 261}, // 習得の書【親聖】,Book of Acquisition (Close to Holy),
-            {19213, 262}, // 習得の書【親闇】,Book of Acquisition (Close to Dark),
-            {19214, 263}, // 習得の書【制毒】,Book of Acquisition (Control Poison),
-            {19215, 264}, // 習得の書【制遅】,Book of Acquisition (Control Slow),
-            {19216, 265}, // 習得の書【制眠】,Book of Acquisition (Control Sleep),
-            {19217, 266}, // 習得の書【制絶】,Book of Acquisition (Control Stun),
-            {19218, 267}, // 習得の書【速乾】,Book of Acquisition (Quick Drying),
-            {19219, 268}, // 習得の書【速清】,Book of Acquisition (Quick Clean),
-            {19220, 269}, // 習得の書【縮封】,Book of Acquisition (Quick Seal),
-            {19221, 270}, // 習得の書【縮軟】,Book of Acquisition (Reduce Subdue),
-            {19222, 273}, // 習得の書【縮焼】,Book of Acquisition (Reduce Tar),
-            {19223, 274}, // 習得の書【縮凍】,Book of Acquisition (Reduce Freeze),
-            {19224, 275}, // 習得の書【縮霧】,Book of Acquisition (Reduce Blind),
-            {19225, 276}, // 習得の書【縮炎】,Book of Acquisition (Reduce Fire),
-            {19226, 277}, // 習得の書【縮氷】,Book of Acquisition (Reduce Ice),
-            {19227, 278}, // 習得の書【縮雷】,Book of Acquisition (Reduce Thunder),
-            {19228, 279}, // 習得の書【縮聖】,Book of Acquisition (Reduce Holy),
-            {19229, 280}, // 習得の書【縮闇】,Book of Acquisition (Reduce Dark),
-            {19230, 281}, // 習得の書【縮攻】,Book of Acquisition (Reduce Physical Attack Down),
-            {19231, 282}, // 習得の書【縮防】,Book of Acquisition (Reduce Defense Down),
-            {19232, 283}, // 習得の書【縮念】,Book of Acquisition (Reduce Magick Attack Down),
-            {19233, 284}, // 習得の書【縮衰】,Book of Acquisition (Reduce Magick Defense Down),
-            {19234, 271}, // 習得の書【縮石】,Book of Acquisition (Reduce Petrify),
-            {19235, 272}, // 習得の書【縮金】,Book of Acquisition (Reduce Goldify),
+            {ItemId.BookOfAcquisitionCompanionHealing, 448},
+            {ItemId.BookOfAcquisitionHeavyStepsLight, 449},
+            {ItemId.BookOfAcquisitionDeftFootingLight, 450},
+            {ItemId.BookOfAcquisitionExtendedSpringsLight, 451},
+            {ItemId.BookOfAcquisitionGatheringLight, 452},
+            {ItemId.BookOfAcquisitionEfficacyLight, 453},
+            {ItemId.BookOfAcquisitionEffectExtensionLight, 454},
+            {ItemId.BookOfAcquisitionExpertExcavatorLight, 455},
+            {ItemId.BookOfAcquisitionFlowLight, 456},
+            {ItemId.BookOfAcquisitionTreasureEyeLight, 457},
+            {ItemId.BookOfAcquisitionWillpowerLight, 458},
+            {ItemId.BookOfAcquisitionSafeLandingLight, 459},
+            {ItemId.BookOfAcquisitionResistPoison, 248},
+            {ItemId.BookOfAcquisitionAntiSlow, 249},
+            {ItemId.BookOfAcquisitionAntiSleep, 250},
+            {ItemId.BookOfAcquisitionAntiStun, 251},
+            {ItemId.BookOfAcquisitionAntiDrench, 252},
+            {ItemId.BookOfAcquisitionAntiOil, 253},
+            {ItemId.BookOfAcquisitionAntiSeal, 254},
+            {ItemId.BookOfAcquisitionAntiSubdue, 255},
+            {ItemId.BookOfAcquisitionAntiPetrify, 256},
+            {ItemId.BookOfAcquisitionAntiGoldify, 257},
+            {ItemId.BookOfAcquisitionCloseToFire, 258},
+            {ItemId.BookOfAcquisitionCloseToIce, 259},
+            {ItemId.BookOfAcquisitionCloseToThunder, 260},
+            {ItemId.BookOfAcquisitionCloseToHoly, 261},
+            {ItemId.BookOfAcquisitionCloseToDark, 262},
+            {ItemId.BookOfAcquisitionControlPoison, 263},
+            {ItemId.BookOfAcquisitionControlSlow, 264},
+            {ItemId.BookOfAcquisitionControlSleep, 265},
+            {ItemId.BookOfAcquisitionControlStun, 266},
+            {ItemId.BookOfAcquisitionQuickDrying, 267},
+            {ItemId.BookOfAcquisitionQuickClean, 268},
+            {ItemId.BookOfAcquisitionQuickSeal, 269},
+            {ItemId.BookOfAcquisitionReduceSubdue, 270},
+            {ItemId.BookOfAcquisitionReduceTar, 273},
+            {ItemId.BookOfAcquisitionReduceFreeze, 274},
+            {ItemId.BookOfAcquisitionReduceBlind, 275},
+            {ItemId.BookOfAcquisitionReduceFire, 276},
+            {ItemId.BookOfAcquisitionReduceIce, 277},
+            {ItemId.BookOfAcquisitionReduceThunder, 278},
+            {ItemId.BookOfAcquisitionReduceHoly, 279},
+            {ItemId.BookOfAcquisitionReduceDark, 280},
+            {ItemId.BookOfAcquisitionReducePhysicalAttackDown, 281},
+            {ItemId.BookOfAcquisitionReduceDefenseDown, 282},
+            {ItemId.BookOfAcquisitionReduceMagickAttackDown, 283},
+            {ItemId.BookOfAcquisitionReduceMagickDefenseDown, 284},
+            {ItemId.BookOfAcquisitionReducePetrify, 271},
+            {ItemId.BookOfAcquisitionReduceGoldify, 272},
         };
 
-        public bool IsSecretAbilityItem(uint itemId)
+        public bool IsSecretAbilityItem(ItemId itemId)
         {
             return AbilityItems.ContainsKey(itemId);
         }
 
-        public uint GetAbilityId(uint itemId)
+        public bool IsSecretAbilityItem(uint itemId)
+        {
+            return IsSecretAbilityItem((ItemId)itemId);
+        }
+
+        public uint GetAbilityId(ItemId itemId)
         {
             return AbilityItems[itemId];
         }
 
-        public bool IsItemWalletPoint(uint itemId)
+        public uint GetAbilityId(uint itemId)
+        {
+            return GetAbilityId((ItemId)itemId);
+        }
+
+        public bool IsItemWalletPoint(ItemId itemId)
         {
             return ItemIdWalletTypeAndQuantity.ContainsKey(itemId);
         }
 
+        public bool IsItemWalletPoint(uint itemId)
+        {
+            return IsItemWalletPoint((ItemId)itemId);
+        }
+
         public (WalletType walletType, uint itemId) ItemToWalletPoint(uint itemId)
+        {
+            return ItemToWalletPoint((ItemId) itemId);
+        }
+
+        public (WalletType walletType, uint itemId) ItemToWalletPoint(ItemId itemId)
         {
             if (!IsItemWalletPoint(itemId))
             {
@@ -184,9 +204,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public void GatherItem(Character character, S2CItemUpdateCharacterItemNtc ntc, InstancedGatheringItem gatheringItem, uint pickedGatherItems, DbConnection? connectionIn = null)
         {
-            if (ItemIdWalletTypeAndQuantity.ContainsKey(gatheringItem.ItemId)) 
+            if (ItemIdWalletTypeAndQuantity.ContainsKey((ItemId) gatheringItem.ItemId)) 
             {
-                var walletTypeAndQuantity = ItemIdWalletTypeAndQuantity[gatheringItem.ItemId];
+                var walletTypeAndQuantity = ItemIdWalletTypeAndQuantity[(ItemId) gatheringItem.ItemId];
                 uint totalQuantityToAdd = walletTypeAndQuantity.Quantity * gatheringItem.ItemNum;
 
                 ntc.UpdateWalletList.Add(
@@ -204,7 +224,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             } 
             else 
             {
-                List<CDataItemUpdateResult> results = AddItem(_Server, character, true, gatheringItem.ItemId, pickedGatherItems, connectionIn:connectionIn);
+                List<CDataItemUpdateResult> results = AddItem(_Server, character, true, (uint) gatheringItem.ItemId, pickedGatherItems, connectionIn:connectionIn);
                 ntc.UpdateItemList.AddRange(results);
 
                 uint totalRemoved = (uint)results.Select(result => result.UpdateItemNum).Sum();

--- a/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyEpitaphRoadDropGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyEpitaphRoadDropGenerator.cs
@@ -60,7 +60,7 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems.Generators
                     {
                         results.Add(new InstancedGatheringItem()
                         {
-                            ItemId = itemId,
+                            ItemId = (ItemId) itemId,
                             ItemNum = amount
                         });
                     }

--- a/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyEventDropGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyEventDropGenerator.cs
@@ -145,7 +145,7 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems.Generators
                 {
                     results.Add(new InstancedGatheringItem()
                     {
-                        ItemId = item.ItemId,
+                        ItemId = (ItemId) item.ItemId,
                         ItemNum = (uint)Random.Shared.Next((int)item.MinAmount, (int)(item.MaxAmount + 1)),
                     });
                 }

--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
@@ -85,13 +85,13 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
 
         public string Report(StageId stageId, uint index)
         {
-            var infoStrings = Fetch(stageId, index).Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, x.ItemId).Name} x{x.ItemNum}");
+            var infoStrings = Fetch(stageId, index).Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, (uint) x.ItemId).Name} x{x.ItemNum}");
             return string.Join("\n\t", infoStrings);
         }
 
         public string Report(Dictionary<Type, List<InstancedGatheringItem>> generateResult)
         {
-            var infoStrings = generateResult.SelectMany(t => t.Value.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, x.ItemId).Name}\tx{x.ItemNum}\t({t.Key.Name})"));
+            var infoStrings = generateResult.SelectMany(t => t.Value.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, (uint) x.ItemId).Name}\tx{x.ItemNum}\t({t.Key.Name})"));
             return string.Join("\n\t", infoStrings);
         }
     }

--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceGatheringItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceGatheringItemManager.cs
@@ -77,13 +77,13 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
 
         public string Report(StageId stageId, uint index)
         {
-            var infoStrings = FetchOrGenerate(stageId, index).Items.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, x.ItemId).Name} x{x.ItemNum}");
+            var infoStrings = FetchOrGenerate(stageId, index).Items.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, (uint) x.ItemId).Name} x{x.ItemNum}");
             return string.Join("\n\t", infoStrings);
         }
 
         public string Report(Dictionary<Type, List<InstancedGatheringItem>> generateResult)
         {
-            var infoStrings = generateResult.SelectMany(t => t.Value.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, x.ItemId).Name}\tx{x.ItemNum}\t({t.Key.Name})"));
+            var infoStrings = generateResult.SelectMany(t => t.Value.Select(x => $"{ClientItemInfo.GetInfoForItemId(Server.AssetRepository.ClientItemInfos, (uint) x.ItemId).Name}\tx{x.ItemNum}\t({t.Key.Name})"));
             return string.Join("\n\t", infoStrings);
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetDropItemListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetDropItemListHandler.cs
@@ -26,7 +26,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ItemList = items.Select((dropItem, index) => new CDataGatheringItemElement()
                 {
                     SlotNo = (uint) index,
-                    ItemId = dropItem.ItemId,
+                    ItemId = (uint) dropItem.ItemId,
                     ItemNum = dropItem.ItemNum
                     // TODO: Other properties
                 }).ToList()

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetGatheringItemListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetGatheringItemListHandler.cs
@@ -44,7 +44,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 .Select((asset, index) => new CDataGatheringItemElement()
                 {
                     SlotNo = (uint)index,
-                    ItemId = asset.ItemId,
+                    ItemId = (uint) asset.ItemId,
                     ItemNum = asset.ItemNum,
                     Quality = asset.Quality,
                     IsHidden = asset.IsHidden

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
@@ -64,7 +64,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             var distinctRewards = packet.GetRewardBoxItemList.Select(x => x.UID).Distinct().ToList();
 
-            var slotCount = coalescedRewards.Sum(x => distinctRewards.Contains(x.Key) ? Server.ItemManager.PredictAddItemSlots(client.Character, StorageType.StorageBoxNormal, x.Value.ItemId, x.Value.Num) : 0);
+            var slotCount = coalescedRewards.Sum(x => distinctRewards.Contains(x.Key) ? Server.ItemManager.PredictAddItemSlots(client.Character, StorageType.StorageBoxNormal, (uint) x.Value.ItemId, x.Value.Num) : 0);
             if (slotCount > client.Character.Storage.GetStorage(StorageType.StorageBoxNormal).EmptySlots())
             {
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_STORAGE_OVERFLOW);
@@ -83,7 +83,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     }
                     else if (reward.Num > 0)
                     {
-                        var result = Server.ItemManager.AddItem(Server, client.Character, false, reward.ItemId, reward.Num, connectionIn: connection);
+                        var result = Server.ItemManager.AddItem(Server, client.Character, false, (uint) reward.ItemId, reward.Num, connectionIn: connection);
                         updateCharacterItemNtc.UpdateItemList.AddRange(result);
                     }
                 }

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -532,7 +532,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             result.Restrictions.Unk5List.Add(new CDataCommonU8() { Value = 2 });
 #endif
 
-            HashSet<uint> items = new HashSet<uint>();
+            var items = new HashSet<ItemId>();
             List<QuestRewardItem> rewards = this.ItemRewards.Concat(this.SelectableRewards).ToList();
             // Rewards for EXM seem to show up independently
             foreach (var rewardData in rewards)
@@ -602,7 +602,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 EndDistributionDate = uint.MaxValue, // ulong.MaxValue causes some math on the client to overflow and report it as ending soon, so we use uint here.
                 ContentJoinItemRank = (ushort)(OrderConditions.Find(x => x.Type == QuestOrderConditionType.ItemRank)?.Param01 ?? 0),
                 RandomRewardNum = RandomRewardNum(),
-                SelectRewardItemIdList = GetQuestSelectableRewards().Select(x => new CDataCommonU32(x.ItemId)).ToList(),
+                SelectRewardItemIdList = GetQuestSelectableRewards().Select(x => new CDataCommonU32((uint) x.ItemId)).ToList(),
                 //DiscoverRewardWalletPoint = WalletRewards, // These are not the same as the regular rewards?
                 //DiscoverRewardExp = ExpRewards, // These are not the same as the regular rewards?
                 QuestLayoutFlagSetInfoList = QuestLayoutFlagSetInfo.Select(x => x.AsCDataQuestLayoutFlagSetInfo()).ToList(),

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
@@ -77,7 +77,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
             }
         }
 
-        public void AddFixedItemReward(uint itemId, ushort amount)
+        public void AddFixedItemReward(ItemId itemId, ushort amount)
         {
             var reward = new QuestFixedRewardItem();
             reward.LootPool.Add(new FixedLootPoolItem()
@@ -89,9 +89,9 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
             AddItemReward(reward);
         }
 
-        public void AddFixedItemReward(ItemId itemId, ushort amount)
+        public void AddFixedItemReward(uint itemId, ushort amount)
         {
-            AddFixedItemReward((uint)itemId, amount);
+            AddFixedItemReward((ItemId) itemId, amount);
         }
 
         public void AddPointReward(QuestPointReward reward)

--- a/Arrowgene.Ddon.Shared/AssetReader/AssetCommonDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/AssetCommonDeserializer.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
+using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 
 namespace Arrowgene.Ddon.Shared.AssetReader
@@ -117,7 +118,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         {
                             GatheringItem dropItems = new()
                             {
-                                ItemId = items.GetProperty("item_id").GetUInt32(),
+                                ItemId = AssetCommonDeserializer.ParseItemId(items.GetProperty("item_id")),
                                 ItemNum = items.GetProperty("item_min").GetUInt32(),
                                 MaxItemNum = items.GetProperty("item_max").GetUInt32(),
                                 Quality = items.GetProperty("quality").GetUInt32(),
@@ -284,6 +285,25 @@ namespace Arrowgene.Ddon.Shared.AssetReader
             }
 
             return new StageId(id, layerNo, groupId);
+        }
+
+        public static ItemId ParseItemId(JsonElement jItemId)
+        {
+            ItemId result = ItemId.HealingPotion;
+
+            if (jItemId.ValueKind == JsonValueKind.Number)
+            {
+                result = (ItemId) jItemId.GetUInt32();
+            }
+            else if (jItemId.ValueKind == JsonValueKind.String)
+            {
+                if (!Enum.TryParse(jItemId.GetString(), true, out result))
+                {
+                    throw new Exception("Failed to parse item reward. Skipping.");
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
@@ -58,7 +58,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 {
                     List<JsonElement> row = dropsTableItemsRow.EnumerateArray().ToList();
                     GatheringItem gatheringItem = new GatheringItem();
-                    gatheringItem.ItemId = row[dropsTableSchemaIndexes["ItemId"]].GetUInt32();
+                    gatheringItem.ItemId = (ItemId) row[dropsTableSchemaIndexes["ItemId"]].GetUInt32();
                     gatheringItem.ItemNum = row[dropsTableSchemaIndexes["ItemNum"]].GetUInt32();
                     gatheringItem.MaxItemNum = row[dropsTableSchemaIndexes["MaxItemNum"]].GetUInt32();
                     gatheringItem.Quality = row[dropsTableSchemaIndexes["Quality"]].GetUInt32();

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -316,7 +316,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                             {
                                 rewardItem.LootPool.Add(new RandomLootPoolItem()
                                 {
-                                    ItemId = item.GetProperty("item_id").GetUInt32(),
+                                    ItemId = AssetCommonDeserializer.ParseItemId(item.GetProperty("item_id")),
                                     Num = item.GetProperty("num").GetUInt16(),
                                     Chance = item.GetProperty("chance").GetDouble()
                                 });
@@ -329,7 +329,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                             {
                                 rewardItem.LootPool.Add(new SelectLootPoolItem()
                                 {
-                                    ItemId = item.GetProperty("item_id").GetUInt32(),
+                                    ItemId = AssetCommonDeserializer.ParseItemId(item.GetProperty("item_id")),
                                     Num = item.GetProperty("num").GetUInt16(),
                                 });
                             }
@@ -341,7 +341,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                             {
                                 rewardItem.LootPool.Add(new FixedLootPoolItem()
                                 {
-                                    ItemId = item.GetProperty("item_id").GetUInt32(),
+                                    ItemId = AssetCommonDeserializer.ParseItemId(item.GetProperty("item_id")),
                                     Num = item.GetProperty("num").GetUInt16(),
                                 });
                             };

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestDropAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestDropAssetDeserializer.cs
@@ -65,7 +65,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
                     GatheringItem gatheringItem = new()
                     {
-                        ItemId = row[(int)QuestEnemyDropHeaders.ItemId].GetUInt32(),
+                        ItemId = (ItemId) row[(int)QuestEnemyDropHeaders.ItemId].GetUInt32(),
                         ItemNum = row[(int)QuestEnemyDropHeaders.ItemNum].GetUInt32(),
                         MaxItemNum = row[(int)QuestEnemyDropHeaders.MaxItemNum].GetUInt32(),
                         Quality = row[(int)QuestEnemyDropHeaders.Quality].GetUInt32(),

--- a/Arrowgene.Ddon.Shared/Csv/GatheringItemCsv.cs
+++ b/Arrowgene.Ddon.Shared/Csv/GatheringItemCsv.cs
@@ -20,7 +20,7 @@ namespace Arrowgene.Ddon.Shared.Csv
                 List<GatheringItem> itemsInSpot = dict.GetValueOrDefault((row.StageId, row.SubGroupId)) ?? new List<GatheringItem>();
                 itemsInSpot.Add(new GatheringItem()
                 {
-                    ItemId = row.ItemId,
+                    ItemId = (ItemId) row.ItemId,
                     ItemNum = row.ItemNum,
                     MaxItemNum = row.MaxItemNum,
                     Quality = row.Quality,

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardBoxItem.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardBoxItem.cs
@@ -1,7 +1,6 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 using System;
-using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure;
 
@@ -12,7 +11,7 @@ public class CDataRewardBoxItem
         UID = "";
     }
 
-    public UInt32 ItemId { get; set; }
+    public ItemId ItemId { get; set; }
     public UInt16 Num {  get; set; }
     public string UID {  get; set; }
     public byte Type { get; set; }
@@ -23,7 +22,7 @@ public class CDataRewardBoxItem
     {
         public override void Write(IBuffer buffer, CDataRewardBoxItem obj)
         {
-            WriteUInt32(buffer, obj.ItemId);
+            WriteUInt32(buffer, (uint) obj.ItemId);
             WriteUInt16(buffer, obj.Num);
             WriteMtString(buffer, obj.UID);
             WriteByte(buffer, obj.Type);
@@ -34,7 +33,7 @@ public class CDataRewardBoxItem
         public override CDataRewardBoxItem Read(IBuffer buffer)
         {
             CDataRewardBoxItem obj = new CDataRewardBoxItem();
-            obj.ItemId = ReadUInt32(buffer);
+            obj.ItemId = (ItemId) ReadUInt32(buffer);
             obj.Num = ReadUInt16(buffer);
             obj.UID = ReadMtString(buffer);
             obj.Type = ReadByte(buffer);

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardItem.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardItem.cs
@@ -1,24 +1,25 @@
-﻿using Arrowgene.Buffers;
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure;
 
 public class CDataRewardItem
 {
-    public uint ItemId { get; set; }
+    public ItemId ItemId { get; set; }
     public ushort Num { get; set; }
     
     public class Serializer : EntitySerializer<CDataRewardItem>
     {
         public override void Write(IBuffer buffer, CDataRewardItem obj)
         {
-            WriteUInt32(buffer, obj.ItemId);
+            WriteUInt32(buffer, (uint) obj.ItemId);
             WriteUInt16(buffer, obj.Num);
         }
 
         public override CDataRewardItem Read(IBuffer buffer)
         {
             CDataRewardItem obj = new CDataRewardItem();
-            obj.ItemId = ReadUInt32(buffer);
+            obj.ItemId = (ItemId)ReadUInt32(buffer);
             obj.Num = ReadUInt16(buffer);
             return obj;
         }

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardItemDetail.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardItemDetail.cs
@@ -1,10 +1,11 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure;
 
 public class CDataRewardItemDetail
 {
-    public uint ItemId { get; set; }
+    public ItemId ItemId { get; set; }
     public ushort Num { get; set; }
     public byte Type {  get; set; }
 
@@ -12,7 +13,7 @@ public class CDataRewardItemDetail
     {
         public override void Write(IBuffer buffer, CDataRewardItemDetail obj)
         {
-            WriteUInt32(buffer, obj.ItemId);
+            WriteUInt32(buffer, (uint) obj.ItemId);
             WriteUInt16(buffer, obj.Num);
             WriteByte(buffer, obj.Type);
         }
@@ -20,7 +21,7 @@ public class CDataRewardItemDetail
         public override CDataRewardItemDetail Read(IBuffer buffer)
         {
             CDataRewardItemDetail obj = new CDataRewardItemDetail();
-            obj.ItemId = ReadUInt32(buffer);
+            obj.ItemId = (ItemId) ReadUInt32(buffer);
             obj.Num = ReadUInt16(buffer);
             obj.Type = ReadByte(buffer);
             return obj;

--- a/Arrowgene.Ddon.Shared/Model/DropsTable.cs
+++ b/Arrowgene.Ddon.Shared/Model/DropsTable.cs
@@ -18,7 +18,7 @@ public class DropsTable
     {
         Items.Add(new GatheringItem()
         {
-            ItemId = (uint)itemId,
+            ItemId = itemId,
             ItemNum = minAmount,
             MaxItemNum = maxAmount,
             DropChance = dropChance

--- a/Arrowgene.Ddon.Shared/Model/GatheringItem.cs
+++ b/Arrowgene.Ddon.Shared/Model/GatheringItem.cs
@@ -3,7 +3,7 @@ namespace Arrowgene.Ddon.Shared.Model
 {
     public class GatheringItem
     {
-        public uint ItemId { get; set; }
+        public ItemId ItemId { get; set; }
         public uint ItemNum { get; set; }
         public uint MaxItemNum { get; set; }
         public uint Quality { get; set; }

--- a/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
@@ -193,7 +193,7 @@ namespace Arrowgene.Ddon.Shared.Model
         {
             DropsTable.Items.Add(new GatheringItem()
             {
-                ItemId = (uint) itemId,
+                ItemId = itemId,
                 ItemNum = minAmount,
                 MaxItemNum = maxAmount,
                 DropChance = chance,

--- a/Arrowgene.Ddon.Shared/Model/InstancedGatheringItem.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedGatheringItem.cs
@@ -23,7 +23,7 @@ public class InstancedGatheringItem
         }
     }
 
-    public uint ItemId { get; set; }
+    public ItemId ItemId { get; set; }
     public uint ItemNum { get; set; }
     public uint Quality { get; set; }
     public bool IsHidden { get; set; }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
@@ -8,12 +8,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
     public abstract class LootPoolItem
     {
         public ushort Num { get; set; }
-        public uint ItemId { get; set; }
+        public ItemId ItemId { get; set; }
 
         public virtual string GetUID()
         {
             IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
-            hash.AppendData(BitConverter.GetBytes(ItemId));
+            hash.AppendData(BitConverter.GetBytes((uint) ItemId));
             hash.AppendData(BitConverter.GetBytes(Num));
             return BitConverter.ToString(hash.GetHashAndReset()).Replace("-", string.Empty).Substring(0, 8);
         }
@@ -34,7 +34,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public override string GetUID()
         {
             IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
-            hash.AppendData(BitConverter.GetBytes(ItemId));
+            hash.AppendData(BitConverter.GetBytes((uint) ItemId));
             hash.AppendData(BitConverter.GetBytes(Num));
             return BitConverter.ToString(hash.GetHashAndReset()).Replace("-", string.Empty).Substring(0, 8);
         }


### PR DESCRIPTION
Added the ability to provide reward items using the ItemId enum instead of numeric literals in quest JSON files.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
