### PR TITLE
fix: Fix printing $ in error message

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSetPriorityQuestHandler.cs
@@ -41,14 +41,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var questStateManager = QuestManager.GetQuestStateManager(client, quest);
                 if (questStateManager == null)
                 {
-                    Logger.Error(client, $"Unable to fetch the quest state manager for ${questScheduleId}");
+                    Logger.Error(client, $"Unable to fetch the quest state manager for {questScheduleId}");
                     continue;
                 }
 
                 var questState = questStateManager.GetQuestState(questScheduleId);
                 if (questState == null)
                 {
-                    Logger.Error(client, $"Failed to find quest state for ${questScheduleId}");
+                    Logger.Error(client, $"Failed to find quest state for {questScheduleId}");
                     continue;
                 }
                 ntc.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState?.Step ?? 0));


### PR DESCRIPTION
Fixed an issue where $ is printed when printing the quest schedule id during an error message.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
