### PR TITLE
fix: World Quest Fixes

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "A Dubious Remedy",
   "quest_id": 20070001,
-  "base_level": 44,
+  "base_level": 45,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
@@ -11,32 +11,42 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1180
+      "amount": 1480
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1410
+      "amount": 1480
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 180
+      "amount": 190
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 7958,
+          "item_id": 7751,
           "num": 1
         },
         {
-          "item_id": 9390,
+          "item_id": 7958,
           "num": 1
         },
         {
           "item_id": 9398,
           "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "item_id": 7859,
+          "num": 2,
+          "chance": 0.7
         }
       ]
     }
@@ -47,25 +57,47 @@
         "id": 173,
         "group_id": 1
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015500",
-          "level": 45,
-          "exp": 13000,
-          "is_boss": true
+          "enemy_id": "0x015503",
+          "named_enemy_params_id": 54,
+          "level": 44,
+          "exp": 6364,
+          "is_boss": true,
+          "index": 8
         },
         {
-          "enemy_id": "0x015500",
-          "level": 45,
-          "exp": 13000,
-          "is_boss": true
+          "enemy_id": "0x015503",
+          "named_enemy_params_id": 54,
+          "level": 44,
+          "exp": 6364,
+          "is_boss": true,
+          "index": 0
         },
         {
-          "enemy_id": "0x010515",
-          "level": 45,
-          "exp": 1550,
-          "is_boss": false
-
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 5354,
+          "is_boss": false,
+          "index": 5
+        },
+        {
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 5354,
+          "is_boss": false,
+          "index": 6
+        },
+        {
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 5354,
+          "is_boss": false,
+          "index": 4
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
@@ -6,7 +6,25 @@
     "base_level": 57,
     "minimum_item_rank": 0,
     "discoverable": true,	
-  "area_id": "EasternZandora",	
+    "area_id": "EasternZandora",	
+    "news_image": 168,
+    "quest_layout_set_info_flags": [
+        {
+          "flag_no": 346,
+          "stage_no": 92,
+          "group_id": 1
+        },
+        {
+          "flag_no": 2213,
+          "stage_no": 92,
+          "group_id": 7
+        },
+        {
+          "flag_no": 886,
+          "stage_no": 92,
+          "group_id": 12
+        }
+      ],
     "rewards": [
         {
             "type": "exp",
@@ -44,64 +62,126 @@
         {
             "stage_id": {
                 "id": 92,
-                "group_id": 19
+                "group_id": 1
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 8
+                },
+                {
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 5
+                },
+                {
                     "enemy_id": "0x010607",
-                    "level": 57,
-                    "exp": 1200
+                    "start_think_tbl_no": 2,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 9
+                },
+                {
+                    "enemy_id": "0x010607",
+                    "start_think_tbl_no": 2,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 7
+                },
+                {
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 6
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 92,
-                "group_id": 8
+                "group_id": 7
             },
-            "starting_index": 1,
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 4
+                },
+                {
                     "enemy_id": "0x010607",
-                    "level": 57,
-                    "exp": 1200
+                    "start_think_tbl_no": 2,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 3
+                },
+                {
+                    "enemy_id": "0x010607",
+                    "start_think_tbl_no": 2,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 1
                 },
                 {
                     "enemy_id": "0x010206",
-                    "level": 57,
-                    "exp": 1200
-                },
-                {
-                    "enemy_id": "0x010206",
-                    "level": 57,
-                    "exp": 1200
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590,
+                    "index": 0
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 92,
-                "group_id": 12
+                "group_id": 9
             },
-            "starting_index": 1,
+            "starting_index": 5,
             "enemies": [
-                {
+               {
                     "enemy_id": "0x015202",
-                    "level": 58,
-                    "exp": 24000,
-                    "is_boss": true					
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 56,
+                    "level": 57,
+                    "is_boss": true,
+                    "exp": 23700                    
+                },
+                {
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+		            "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 6590                    
                 }
             ]
         }
     ],
-    "processes": [
-        {
-            "comment": "Process 0",
-            "blocks": [
+      "blocks": [
                 {
-                    "type": "NewNpcTalkAndOrder",
+                    "type": "NpcTalkAndOrder",
                     "flags": [
-                        {"type": "QstLayout", "action": "Set", "value": 1071, "comment": "Spawns NPC"}
+                        {"type": "QstLayout", 
+                        "action": "Set", 
+                        "value": 1071, 
+                        "comment": "Spawns NPC"}
                     ],
                     "stage_id": {
                         "id": 1,
@@ -109,13 +189,35 @@
                         "layer_no": 1
                     },
                     "npc_id": "Soldier0",
-                    "message_id": 11372
+                    "message_id": 13281
                 },
                 {
-                    "type": "MyQstFlags",
+                    "type": "SeekOutEnemiesAtMarkedLocation",
                     "announce_type": "Accept",
-                    "set_flags": [1],
-                    "check_flags": [2, 3, 4]
+                    "groups": [ 0 ]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "reset_group": false,
+                    "groups": [ 0 ]
+                  },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [ 0 ]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [ 1 ]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [ 2 ]
                 },
                 {
                     "type": "NewTalkToNpc",
@@ -126,78 +228,8 @@
                     },
                     "announce_type": "Update",
                     "npc_id": "Soldier0",
-                    "message_id": 11842
-                }
-            ]
-        },
-        {
-            "comment": "Process1 (Shadow Group 1)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",
-                    "groups": [0]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [0]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [2]
-                }
-            ]
-        },
-        {
-            "comment": "Process2 (Shadow Group 2)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",
-                    "groups": [1]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [1]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [3]
-                }
-            ]
-        },
-        {
-            "comment": "Process3 (Chimera Group 3)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",
-                    "groups": [2]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [2]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [4]
+                    "message_id": 13283
                 }
             ]
         }
-    ]
-}
+    

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085008.json
@@ -6,7 +6,8 @@
     "base_level": 57,
     "minimum_item_rank": 0,
     "discoverable": false,
-  "area_id": "EasternZandora",		
+    "area_id": "EasternZandora",
+    "news_image": 168,		
     "rewards": [
         {
             "type": "wallet",
@@ -49,8 +50,9 @@
             "enemies": [
                 {
                     "enemy_id": "0x015850",
+                    "named_enemy_params_id": 54,
                     "level": 58,
-                    "exp": 22000,
+                    "exp": 26700,
                     "is_boss": true				
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
@@ -6,7 +6,8 @@
     "base_level": 53,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",	
+    "news_image": 181,	
     "rewards": [
         {
             "type": "exp",
@@ -38,20 +39,34 @@
                     "num": 1					
                 }
             ]
-        }
-    ],
+          },
+                {
+                    "type": "random",
+                    "loot_pool": [
+                      {
+                        "item_id": 7554,
+                        "num": 1,
+                        "chance": 0.6
+                      }
+                    ]
+                  }
+                ],
     "enemy_groups" : [
         {
             "stage_id": {
                 "id": 157,
                 "group_id": 7
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x015500",
+                    "enemy_id": "0x015503",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 248,
                     "level": 53,
-                    "exp": 23000,
-                    "is_boss": true					
+                    "exp": 15632,
+                    "is_boss": true,
+                    "index": 2					
                 }
             ]
         }
@@ -78,6 +93,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
@@ -6,65 +6,127 @@
     "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",	
+    "news_image": 183,
     "rewards": [
         {
             "type": "exp",
-            "amount": 5590
+            "amount": 2580
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 3750
+            "amount": 1840
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 330
+            "amount": 290
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7959,
+                    "item_id": 9438,
                     "num": 1
                 },
                 {
-                    "item_id": 7745,
+                    "item_id": 7740,
                     "num": 1
                 },
                 {
-                    "item_id": 7744,
-                    "num": 1					
+                    "item_id": 7924,
+                    "num": 3					
                 }
             ]
-        }
-    ],
+          },
+                {
+                    "type": "random",
+                    "loot_pool": [
+                      {
+                        "item_id": 7554,
+                        "num": 1,
+                        "chance": 0.6
+                      },
+                      {
+                        "item_id": 41,
+                        "num": 1,
+                        "chance": 0.6
+                      }
+                    ]
+                  }
+                ],
     "enemy_groups" : [
         {
             "stage_id": {
                 "id": 1,
                 "group_id": 391
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x015040",
-                    "level": 54,
-                    "exp": 25000,
-                    "is_boss": true
+                    "enemy_id": "0x011130",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 6476,
+                    "is_boss": false,
+                    "index": 3                    
+        },
+        {
+            "enemy_id": "0x011130",
+            "start_think_tbl_no": 1,
+            "named_enemy_params_id": 53,
+            "level": 55,
+            "exp": 6476,
+            "is_boss": false,
+            "index": 6                    
+},
+{
+    "enemy_id": "0x011130",
+    "start_think_tbl_no": 1,
+    "named_enemy_params_id": 53,
+    "level": 55,
+    "exp": 6476,
+    "is_boss": false,
+    "index": 4                    
+},
+{
+    "enemy_id": "0x011130",
+    "start_think_tbl_no": 1,
+    "named_enemy_params_id": 53,
+    "level": 55,
+    "exp": 6476,
+    "is_boss": false,
+    "index": 5                    
+},
+        {
+                    "enemy_id": "0x011132",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 6476,
+                    "is_boss": false,
+                    "index": 0
         },
         {
                     "enemy_id": "0x011132",
-                    "level": 50,
-                    "exp": 1400,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x011132",
-                    "level": 50,
-                    "exp": 1400,
-                    "is_boss": false					
-                }
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 6476,
+                    "is_boss": false,
+                    "index": 1					
+                },
+                {
+                    "enemy_id": "0x015000",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 21700,
+                    "is_boss": true,
+                    "index": 2
+        }
             ]
         }
     ],	
@@ -87,6 +149,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		


### PR DESCRIPTION
Fixes for the following world quests
- The Perilous Labyrinth
- DeadLord Retainer
- Knight Devourer
- Dubious Remedy

Authored-by: Cert

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
