### PR TITLE
fix: Fix Epitaph Road Green Light

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/EpitaphRoad.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/EpitaphRoad.json
@@ -130,7 +130,7 @@
                     "comment": "Cave: 4th Space",
                     "stage_id": {"id": 551, "group_id": 70}, "pos_id": 0,
                     "gathering_points": {
-                        "stage_id": {"id": 550, "group_id": 71},
+                        "stage_id": {"id": 551, "group_id": 71},
                         "amount": 14
                     }
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/scripts/settings/GameLogicSettings.csx
+++ b/Arrowgene.Ddon.Shared/Files/Assets/scripts/settings/GameLogicSettings.csx
@@ -95,7 +95,7 @@ ulong BazaarCooldownTimeSeconds = (ulong) TimeSpan.FromDays(1).TotalSeconds;
 uint ClanMemberMax = 100;
 
 // Epitaph Settings
-bool EnableEpitaphWeeklyRewards = false;
+bool EnableEpitaphWeeklyRewards = true;
 
 // Point Settings
 uint PlayPointMax = 2000;


### PR DESCRIPTION
Fixed an issue in Rathnite Foothills where the green lights in the 4th path of the cave did not work as expected. Enabled the weekly rewards flag so that code can start being exercised for correctness.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
