### PR TITLE
fix: Fix issue with spawns in q50300004

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/scripts/quests/exm/q50300004.csx
+++ b/Arrowgene.Ddon.Shared/Files/Assets/scripts/quests/exm/q50300004.csx
@@ -660,7 +660,7 @@ public class ScriptedQuest : IQuest
             13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23
         };
 
-        foreach (var groupId in requiredGroups)
+        foreach (var groupId in optionalGroups)
         {
             var process = AddNewProcess(i++);
             process.AddMyQstFlagsBlock(QuestAnnounceType.None)


### PR DESCRIPTION
Fixed an issue where the wrong set of time extension monsters was spawned after engaging the final boss.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
