### PR TITLE
feat: Add lambda callbacl functions to QuestBlock

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -281,6 +281,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 questBlock = process.Blocks[questBlock.CheckpointDetails.BlockNo];
             }
 
+            foreach (var callback in questBlock.Callbacks)
+            {
+                callback(client);
+            }
+
             return new List<CDataQuestProcessState>()
             {
                 questBlock.QuestProcessState
@@ -289,11 +294,6 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         private static CDataQuestProcessState BlockAsCDataQuestProcessState(GenericQuest quest, QuestBlock questBlock)
         {
-            // QuestManager.CheckCommand.Craft()
-            // QuestManager.CheckCommand.MakeCraft()
-            // QuestManager.CheckCommand.OpenCraftExam()
-            // QuestManager.CheckCommand.LevelUpCraft()
-
             CDataQuestProcessState result = new CDataQuestProcessState()
             {
                 ProcessNo = questBlock.ProcessNo,

--- a/Arrowgene.Ddon.GameServer/Quests/QuestBlockUtil.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestBlockUtil.cs
@@ -1,5 +1,8 @@
+using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using System;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.Shared.Model.Quest
@@ -418,6 +421,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public static QuestBlock SetNpcMsg(this QuestBlock questBlock, NpcId npcId, int msgNo)
         {
             questBlock.ResultCommands.Add(QuestManager.ResultCommand.QstTalkChg(npcId, msgNo));
+            return questBlock;
+        }
+
+        public static QuestBlock AddCallback(this QuestBlock questBlock, Action<GameClient> callback)
+        {
+            questBlock.Callbacks.Add(new Action<Object>(o => callback((GameClient)o)));
             return questBlock;
         }
         #endregion

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
@@ -1,7 +1,5 @@
-using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Shared.Asset;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using System;

--- a/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
@@ -59,7 +59,6 @@ namespace Arrowgene.Ddon.GameServer.Scripting
                     dropTables.Add(enemyId, LibDdon.GetDropsTable((uint)enemyId, lv));
                 }
             }
-
             return new InstancedRandomEnemy(enemyIds, dropTables, lv, exp, index);
         }
 

--- a/Arrowgene.Ddon.Shared/Files/Assets/scripts/quests/exm/q50300005.csx
+++ b/Arrowgene.Ddon.Shared/Files/Assets/scripts/quests/exm/q50300005.csx
@@ -343,7 +343,7 @@ public class ScriptedQuest : IQuest
             .AddMyQstSetFlag(MyQuestFlag.SpawnStartingGroups)
             .AddMyQstCheckFlag(MyQuestFlag.DetectAnyDragonKinDeath);
         process0.AddMyQstFlagsBlock(QuestAnnounceType.ExUpdate)
-            .AddMyQstCheckFlags(new List<uint>() { MyQuestFlag.RubyEyeDead, MyQuestFlag.EmeraldEyeDead, MyQuestFlag.LapisEyeDead })
+            .AddMyQstCheckFlags(new() { MyQuestFlag.RubyEyeDead, MyQuestFlag.EmeraldEyeDead, MyQuestFlag.LapisEyeDead })
             .AddEndContentsPurpose(Purpose.FindAndDefeatEyes);
         process0.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.HermitsHollow + 3)
             .AddGeneralAnnounce(QuestGeneralAnnounceType.CommonMsg, GeneralAnnouncements.AllGemsCollected);

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestBlock.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestBlock.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using System;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.Shared.Model.Quest
@@ -39,6 +40,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public List<uint> MyQstCheckFlags { get; set; }
         public List<QuestFlag> QuestFlags { get; set; }
         public List<QuestFlag> CheckpointQuestFlags { get; set; }
+        public List<Action<Object>> Callbacks { get; set; }
 
         public bool ShouldStageJump { get; set; }
         public uint JumpPos { get; set; }
@@ -108,6 +110,8 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
             TargetEnemy = new QuestTargetEnemy();
             Announcements = new Announcements();
+
+            Callbacks = new List<Action<Object>>();
         }
 
         public QuestBlock AddAnnotation(string msg)


### PR DESCRIPTION
- Added a new member to the QuestBlock which a quest can define an arbitrary number of callbacks to be executed at the end of a quest step.
- Added a new function to QuestBlockUtility to make adding the callback easier in quest scripts.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
