### PR TITLE
feat: Add support for debugging csx scripts

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -42,6 +42,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             quest.LightQuestDetail = questAsset.LightQuestDetail;
             quest.Enabled = questAsset.Enabled;
             quest.OverrideEnemySpawn = questAsset.OverrideEnemySpawn;
+            quest.EnableCancel = questAsset.EnableCancel;
 
             foreach (var pointReward in questAsset.PointRewards)
             {

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -92,6 +92,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public List<QuestServerAction> ServerActions { get; protected set; }
         public bool Enabled { get; protected set; }
         public bool OverrideEnemySpawn { get; protected set; }
+        public bool EnableCancel { get; protected set; }
+        public ulong DistributionStart { get; protected set; }
+        public ulong DistributionEnd { get; protected set; }
 
         public bool IsPersonal { get
             {
@@ -327,7 +330,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     Lv = enemy.Lv,
                     IsPartyRecommend = enemy.IsBossGauge
                 }))
-                .ToList()
+                .ToList(),
+                DistributionStartDate = DistributionStart,
+                DistributionEndDate = DistributionEnd,
             };
 
             quest.QuestProcessStateList = GetProcessState(step, out uint announceNoCount);
@@ -374,7 +379,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     Lv = enemy.Lv,
                     IsPartyRecommend = enemy.IsBossGauge
                 }))
-                .ToList()
+                .ToList(),
+                // Unsure if these next set of fields are correct
+                Unk5 = DistributionStart,
+                Unk6 = DistributionEnd,
+                Unk6A = 0, // Order Date?
             };
 
             quest.QuestProcessStateList = GetProcessState(step, out uint announceNoCount);
@@ -397,12 +406,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
             return quest;
         }
 
-        public virtual CDataTutorialQuestOrderList ToCDataTutorialQuestOrderList(uint step, bool enableCancel = false)
+        public virtual CDataTutorialQuestOrderList ToCDataTutorialQuestOrderList(uint step)
         {
             return new CDataTutorialQuestOrderList()
             {
                 Param = ToCDataQuestOrderList(step),
-                EnableCancel = enableCancel
+                EnableCancel = EnableCancel
             };
         }
 
@@ -425,12 +434,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
             };
         }
 
-        public virtual CDataTutorialQuestList ToCDataTutorialQuestList(uint step, bool enableCancel = false)
+        public virtual CDataTutorialQuestList ToCDataTutorialQuestList(uint step)
         {
             return new CDataTutorialQuestList()
             {
                 Param = ToCDataQuestList(step),
-                EnableCancel = enableCancel
+                EnableCancel = EnableCancel,
             };
         }
 

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
@@ -27,6 +27,11 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
             {
                 OverrideEnemySpawn = (QuestType == QuestType.Main);
             }
+
+            if (EnableCancel == null)
+            {
+                EnableCancel = (QuestType != QuestType.Tutorial && QuestType != QuestType.Main);
+            }
         }
 
         public string Path { get; set; }
@@ -45,6 +50,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
         public abstract byte MinimumItemRank { get; }
         public abstract bool IsDiscoverable { get; }
         public virtual bool? OverrideEnemySpawn { get; } = null;
+        public virtual bool? EnableCancel { get; } = null;
         public virtual bool ResetPlayerAfterQuest { get; } = false;
 
         private Dictionary<ushort, QuestProcess> Processes { get; set; }
@@ -287,6 +293,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
                 MinimumItemRank = MinimumItemRank,
                 NextQuestId = NextQuestId,
                 OverrideEnemySpawn = OverrideEnemySpawn.Value,
+                EnableCancel = EnableCancel.Value,
                 QuestAreaId = QuestAreaId,
                 QuestId = QuestId,
                 QuestOrderBackgroundImage = QuestOrderBackgroundImage,

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/GameServerScriptModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/GameServerScriptModule.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
 {

--- a/Arrowgene.Ddon.Server/Scripting/LibUtils.cs
+++ b/Arrowgene.Ddon.Server/Scripting/LibUtils.cs
@@ -32,8 +32,7 @@ namespace Arrowgene.Ddon.Server.Scripting
         public static bool WithinTimespan(DateTime startDate, DateTime endDate)
         {
             var now = DateTime.Now;
-            return (now.Month >= startDate.Month && now.Month <= endDate.Month) &&
-                   (now.Day >= startDate.Day && now.Day <= endDate.Day);
+            return (now >= startDate && now <= endDate);
         }
 
         public static bool WithinTimespan((DateTime StartDate, DateTime EndDate) timespan)

--- a/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
@@ -5,6 +5,7 @@ using Arrowgene.Ddon.Shared.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using System.IO;
+using System.Text;
 
 namespace Arrowgene.Ddon.Server.Scripting.modules
 {

--- a/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
@@ -36,6 +36,7 @@ namespace Arrowgene.Ddon.Shared.Asset
         public byte MinimumItemRank { get; set; }
         public bool Enabled { get; set; }
         public bool OverrideEnemySpawn { get; set; }
+        public bool EnableCancel { get; set; }
         public QuestSource QuestSource { get; set; }
 
         public List<QuestPointReward> PointRewards { get; set; }


### PR DESCRIPTION
If the build is a debug build, it is possible to debug csx scripts loaded by the server. Fixed an issue where the datetime range compare was incorrect with a period that crosses from one month to the next. Added a new field EnableCancel which can be used by tutorial quests.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
