### PR TITLE
fix: Fix typo in script file

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/12_mergoda_ruins/ar04_elixir_refining_chamber.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/12_mergoda_ruins/ar04_elixir_refining_chamber.csx
@@ -22,7 +22,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         {
             // TODO: Named enemy should drop crests but no information about what crests should drop
             LibDdon.Enemy.CreateAuto(EnemyId.MerganMage, 55, 0)
-                .SetNamedEnemyParams(NamedParamId.SergiusTheApothecary)
+                .SetNamedEnemyParams(NamedParamId.SergiusTheApothecary),
             LibDdon.Enemy.CreateAuto(EnemyId.MerganWarrior, 53, 1)
                 .SetNamedEnemyParams(NamedParamId.ImmortalDrugTestSubject),
             LibDdon.Enemy.CreateAuto(EnemyId.MerganDefender, 53, 1)


### PR DESCRIPTION
Fixed an issue where a comma was missing in the previous checkin, which causes the script to fail to compile.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
