### PR TITLE
feat: Added support for Partner Pawns

### DIFF
--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -36,13 +36,4 @@
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Shared\Arrowgene.Ddon.Shared.csproj" />
     </ItemGroup>
-    
-    <ItemGroup>
-      <None Update="Files\Database\Script\migration_epitaph_road.sql">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Files\Database\Script\migration_scheduling.sql">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
 </Project>

--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -14,7 +14,7 @@ namespace Arrowgene.Ddon.Database
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
         private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-        public const uint Version = 29;
+        public const uint Version = 30;
 
         public static IDatabase Build(DatabaseSetting settings)
         {

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn.sql
@@ -5,7 +5,6 @@ CREATE TABLE "ddon_partner_pawn"
 (
     "character_id" INTEGER NOT NULL,
     "pawn_id" INTEGER NOT NULL,
-    "personality" INTEGER NOT NULL,
     "num_gifts" INTEGER NOT NULL,
     "num_crafts" INTEGER NOT NULL,
     "num_adventures" INTEGER NOT NULL,

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn.sql
@@ -1,0 +1,33 @@
+ALTER TABLE "ddon_character"
+    ADD COLUMN "partner_pawn_id" INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE "ddon_partner_pawn"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "personality" INTEGER NOT NULL,
+    "num_gifts" INTEGER NOT NULL,
+    "num_crafts" INTEGER NOT NULL,
+    "num_adventures" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn PRIMARY KEY ("character_id", "pawn_id"),
+    CONSTRAINT fk_ddonpartner_pawn_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+
+CREATE TABLE "ddon_partner_pawn_last_affection_increase"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "action" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn PRIMARY KEY ("character_id", "pawn_id", "action"),
+    CONSTRAINT fk_ddon_partner_pawn_affection_increase_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO ddon_schedule_next(type, timestamp) VALUES (13, 0);
+
+CREATE TABLE "ddon_partner_pawn_pending_rewards"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "reward_level" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn_pending_rewards PRIMARY KEY ("character_id", "pawn_id"),
+    CONSTRAINT fk_ddon_partner_pawn_pending_rewards_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -828,7 +828,6 @@ CREATE TABLE IF NOT EXISTS "ddon_partner_pawn"
 (
     "character_id" INTEGER NOT NULL,
     "pawn_id" INTEGER NOT NULL,
-    "personality" INTEGER NOT NULL,
     "num_gifts" INTEGER NOT NULL,
     "num_crafts" INTEGER NOT NULL,
     "num_adventures" INTEGER NOT NULL,

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS "ddon_character"
     "arisen_profile_share_range" SMALLINT                          NOT NULL,
     "fav_warp_slot_num"          INTEGER                           NOT NULL,
     "max_bazaar_exhibits"        INTEGER                           NOT NULL,
+    "partner_pawn_id"            INTEGER                           NOT NULL DEFAULT 0,
     "game_mode"                  INTEGER                           NOT NULL,
     CONSTRAINT "fk_ddon_character_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_character_account_id" FOREIGN KEY ("account_id") REFERENCES "account" ("id") ON DELETE CASCADE
@@ -822,3 +823,34 @@ CREATE TABLE IF NOT EXISTS "ddon_rank_record"
     CONSTRAINT "fk_ddon_rank_record_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character"("character_id") ON DELETE CASCADE
 );
 INSERT INTO ddon_schedule_next(type, timestamp) VALUES (23, 0);
+
+CREATE TABLE IF NOT EXISTS "ddon_partner_pawn"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "personality" INTEGER NOT NULL,
+    "num_gifts" INTEGER NOT NULL,
+    "num_crafts" INTEGER NOT NULL,
+    "num_adventures" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn PRIMARY KEY ("character_id", "pawn_id"),
+    CONSTRAINT fk_ddonpartner_pawn_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_last_affection_increase"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "action" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn PRIMARY KEY ("character_id", "pawn_id", "action"),
+    CONSTRAINT fk_ddon_partner_pawn_affection_increase_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO ddon_schedule_next(type, timestamp) VALUES (13, 0);
+
+CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id" INTEGER NOT NULL,
+    "reward_level" INTEGER NOT NULL,
+    CONSTRAINT pk_ddon_partner_pawn_pending_rewards PRIMARY KEY ("character_id", "pawn_id"),
+    CONSTRAINT fk_ddon_partner_pawn_pending_rewards_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -296,7 +296,7 @@ namespace Arrowgene.Ddon.Database
         bool ReplaceAbilityPreset(uint characterId, CDataPresetAbilityParam preset);
         bool UpdateAbilityPreset(uint characterId, CDataPresetAbilityParam preset);
 
-        bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility);
+        bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility, DbConnection? connectionIn = null);
         List<SecretAbility> SelectAllUnlockedSecretAbilities(uint commonId);
 
         // (Learned) Normal Skills / Learned Core Skills
@@ -619,5 +619,19 @@ namespace Arrowgene.Ddon.Database
         List<CDataRankingData> SelectRankingDataByCharacterId(uint characterId, uint questId, uint limit = 1000, DbConnection? connectionIn = null);
         List<CDataRankingData> SelectRankingData(uint questId, uint limit = 1000, DbConnection? connectionIn = null);
         bool DeleteAllRankRecords(DbConnection? connectionIn = null);
+
+        // Partner Pawn
+        bool InsertPartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null);
+        bool UpdatePartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null);
+        PartnerPawnData GetPartnerPawnRecord(uint characterId, uint pawnId, DbConnection? connectionIn = null);
+        bool SetPartnerPawn(uint characterId, uint pawnId, DbConnection? connectionIn = null);
+
+        bool InsertPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null);
+        bool HasPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null);
+        void DeleteAllPartnerPawnLastAffectionIncreaseRecords(DbConnection? connectionIn = null);
+
+        HashSet<uint> GetPartnerPawnPendingRewards(uint characterId, uint pawnId, DbConnection? connectionIn = null);
+        bool InsertPartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null);
+        void DeletePartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null);
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 
 namespace Arrowgene.Ddon.Database.Sql.Core
 {
@@ -16,7 +17,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
     {
         private static readonly string[] CharacterFields = new string[]
         {
-            /* character_id */ "version", "character_common_id", "account_id", "first_name", "last_name", "created", "my_pawn_slot_num", "rental_pawn_slot_num", "hide_equip_head_pawn", "hide_equip_lantern_pawn", "arisen_profile_share_range", "fav_warp_slot_num", "max_bazaar_exhibits", "game_mode"
+            /* character_id */ "version", "character_common_id", "account_id", "first_name", "last_name", "created", "my_pawn_slot_num", "rental_pawn_slot_num", "hide_equip_head_pawn", "hide_equip_lantern_pawn", "arisen_profile_share_range", "fav_warp_slot_num", "max_bazaar_exhibits", "partner_pawn_id", "game_mode"
         };
 
         private static readonly string[] CDataMatchingProfileFields = new string[]
@@ -85,6 +86,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private readonly string SqlInsertCharacterBinaryData = $"INSERT INTO \"ddon_binary_data\" ({BuildQueryField(CharacterBinaryDataFields)}) VALUES ({BuildQueryInsert(CharacterBinaryDataFields)});";
         private readonly string SqlUpdateCharacterBinaryData = $"UPDATE \"ddon_binary_data\" SET {BuildQueryUpdate(CharacterBinaryDataFields)} WHERE \"character_id\" = @character_id;";
         private static readonly string SqlSelectCharacterBinaryData = $"SELECT {BuildQueryField(CharacterBinaryDataFields)} FROM \"ddon_binary_data\" WHERE \"character_id\" = @character_id;";
+
+        private readonly string SqlUpdatePartnerPawnId = $"UPDATE \"ddon_character\" SET \"partner_pawn_id\" = @partner_pawn_id WHERE \"character_id\" = @character_id;";
 
         public bool CreateCharacter(Character character)
         {
@@ -682,6 +685,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             character.LastName = GetString(reader, "last_name");
             character.Created = GetDateTime(reader, "created");
             character.MyPawnSlotNum = GetByte(reader, "my_pawn_slot_num");
+            character.PartnerPawnId = GetUInt32(reader, "partner_pawn_id");
             character.RentalPawnSlotNum = GetByte(reader, "rental_pawn_slot_num");
             character.HideEquipHeadPawn = GetBoolean(reader, "hide_equip_head_pawn");
             character.HideEquipLanternPawn = GetBoolean(reader, "hide_equip_lantern_pawn");
@@ -724,6 +728,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             AddParameter(command, "@last_name", character.LastName);
             AddParameter(command, "@created", character.Created);
             AddParameter(command, "@my_pawn_slot_num", character.MyPawnSlotNum);
+            AddParameter(command, "@partner_pawn_id", character.PartnerPawnId);
             AddParameter(command, "@rental_pawn_slot_num", character.RentalPawnSlotNum);
             AddParameter(command, "@hide_equip_head_pawn", character.HideEquipHeadPawn);
             AddParameter(command, "@hide_equip_lantern_pawn", character.HideEquipLanternPawn);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -323,7 +323,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             common.EditInfo.Sex = GetByte(reader, "sex");
             common.EditInfo.Voice = GetByte(reader, "voice");
             common.EditInfo.VoicePitch = GetUInt16(reader, "voice_pitch");
-            common.EditInfo.Personality = GetByte(reader, "personality");
+            common.EditInfo.Personality = (PawnPersonality) GetByte(reader, "personality");
             common.EditInfo.SpeechFreq = GetByte(reader, "speech_freq");
             common.EditInfo.BodyType = GetByte(reader, "body_type");
             common.EditInfo.Hair = GetByte(reader, "hair");
@@ -417,7 +417,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             AddParameter(command, "@sex", common.EditInfo.Sex);
             AddParameter(command, "@voice", common.EditInfo.Voice);
             AddParameter(command, "@voice_pitch", common.EditInfo.VoicePitch);
-            AddParameter(command, "@personality", common.EditInfo.Personality);
+            AddParameter(command, "@personality", (byte) common.EditInfo.Personality);
             AddParameter(command, "@speech_freq", common.EditInfo.SpeechFreq);
             AddParameter(command, "@body_type", common.EditInfo.BodyType);
             AddParameter(command, "@hair", common.EditInfo.Hair);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawn.cs
@@ -1,0 +1,92 @@
+using Arrowgene.Ddon.Shared.Model;
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        /* ddon_partner_pawn */
+        protected static readonly string[] PartnerPawnFields= new string[]
+        {
+            "character_id", "pawn_id", "personality", "num_gifts", "num_crafts", "num_adventures"
+        };
+
+        private readonly string SqlSelectPartnerPawnRecord = $"SELECT {BuildQueryField(PartnerPawnFields)} FROM \"ddon_partner_pawn\" WHERE \"character_id\"=@character_id AND \"pawn_id\" = @pawn_id;";
+        private readonly string SqlInsertPartnerPawnRecord = $"INSERT INTO \"ddon_partner_pawn\" ({BuildQueryField(PartnerPawnFields)}) VALUES ({BuildQueryInsert(PartnerPawnFields)});";
+        private readonly string SqlUpdatePartnerPawnRecord = $"UPDATE \"ddon_partner_pawn\" SET {BuildQueryUpdate(PartnerPawnFields)} WHERE \"character_id\" = @character_id AND \"pawn_id\" = @pawn_id;";
+
+        public bool InsertPartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
+            {
+                return ExecuteNonQuery(connection, SqlInsertPartnerPawnRecord, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", partnerPawnData.PawnId);
+                    AddParameter(command, "personality", (byte)partnerPawnData.Personality);
+                    AddParameter(command, "num_gifts", partnerPawnData.NumGifts);
+                    AddParameter(command, "num_crafts", partnerPawnData.NumCrafts);
+                    AddParameter(command, "num_adventures", partnerPawnData.NumAdventures);
+                }) == 1;
+            });
+        }
+
+        public bool UpdatePartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
+            {
+                return ExecuteNonQuery(connection, SqlUpdatePartnerPawnRecord, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", partnerPawnData.PawnId);
+                    AddParameter(command, "personality", (byte) partnerPawnData.Personality);
+                    AddParameter(command, "num_gifts", partnerPawnData.NumGifts);
+                    AddParameter(command, "num_crafts", partnerPawnData.NumCrafts);
+                    AddParameter(command, "num_adventures", partnerPawnData.NumAdventures);
+                }) == 1;
+            });
+        }
+
+        public PartnerPawnData GetPartnerPawnRecord(uint characterId, uint pawnId, DbConnection? connectionIn = null)
+        {
+            PartnerPawnData result = null;
+            ExecuteQuerySafe(connectionIn, (connection) =>
+            {
+                ExecuteReader(connection, SqlSelectPartnerPawnRecord, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                }, reader =>
+                {
+                    if (reader.Read())
+                    {
+                        result = new PartnerPawnData()
+                        {
+                            PawnId = GetUInt32(reader, "pawn_id"),
+                            Personality = (PawnPersonality) GetByte(reader, "personality"),
+                            NumGifts = GetUInt32(reader, "num_gifts"),
+                            NumCrafts = GetUInt32(reader, "num_crafts"),
+                            NumAdventures = GetUInt32(reader, "num_adventures"),
+                        };
+                    }
+                });
+            });
+            return result;
+        }
+
+        public bool SetPartnerPawn(uint characterId, uint pawnId, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
+            {
+                return ExecuteNonQuery(connection, SqlUpdatePartnerPawnId, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "partner_pawn_id", pawnId);
+                }) == 1;
+            });
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawn.cs
@@ -11,7 +11,7 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         /* ddon_partner_pawn */
         protected static readonly string[] PartnerPawnFields= new string[]
         {
-            "character_id", "pawn_id", "personality", "num_gifts", "num_crafts", "num_adventures"
+            "character_id", "pawn_id", "num_gifts", "num_crafts", "num_adventures"
         };
 
         private readonly string SqlSelectPartnerPawnRecord = $"SELECT {BuildQueryField(PartnerPawnFields)} FROM \"ddon_partner_pawn\" WHERE \"character_id\"=@character_id AND \"pawn_id\" = @pawn_id;";
@@ -26,7 +26,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                 {
                     AddParameter(command, "character_id", characterId);
                     AddParameter(command, "pawn_id", partnerPawnData.PawnId);
-                    AddParameter(command, "personality", (byte)partnerPawnData.Personality);
                     AddParameter(command, "num_gifts", partnerPawnData.NumGifts);
                     AddParameter(command, "num_crafts", partnerPawnData.NumCrafts);
                     AddParameter(command, "num_adventures", partnerPawnData.NumAdventures);
@@ -42,7 +41,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                 {
                     AddParameter(command, "character_id", characterId);
                     AddParameter(command, "pawn_id", partnerPawnData.PawnId);
-                    AddParameter(command, "personality", (byte) partnerPawnData.Personality);
                     AddParameter(command, "num_gifts", partnerPawnData.NumGifts);
                     AddParameter(command, "num_crafts", partnerPawnData.NumCrafts);
                     AddParameter(command, "num_adventures", partnerPawnData.NumAdventures);
@@ -66,7 +64,6 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                         result = new PartnerPawnData()
                         {
                             PawnId = GetUInt32(reader, "pawn_id"),
-                            Personality = (PawnPersonality) GetByte(reader, "personality"),
                             NumGifts = GetUInt32(reader, "num_gifts"),
                             NumCrafts = GetUInt32(reader, "num_crafts"),
                             NumAdventures = GetUInt32(reader, "num_adventures"),

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawnLastAffectionIncrease.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawnLastAffectionIncrease.cs
@@ -1,0 +1,60 @@
+using Arrowgene.Ddon.Shared.Model;
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        /* ddon_partner_pawn_last_affection_increase */
+        protected static readonly string[] PartnerPawnLastAffectionIncreaseFields = new string[]
+        {
+            "character_id", "pawn_id", "action"
+        };
+
+        private readonly string SqlSelectPartnerPawnLastAffectionIncreaseRecord = $"SELECT {BuildQueryField(PartnerPawnLastAffectionIncreaseFields)} FROM \"ddon_partner_pawn_last_affection_increase\" WHERE \"character_id\"=@character_id AND \"pawn_id\"=@pawn_id AND \"action\"=@action;";
+        private readonly string SqlInsertPartnerPawnLastAffectionIncreaseRecord = $"INSERT INTO \"ddon_partner_pawn_last_affection_increase\" ({BuildQueryField(PartnerPawnLastAffectionIncreaseFields)}) VALUES ({BuildQueryInsert(PartnerPawnLastAffectionIncreaseFields)});";
+        private readonly string SqlDeleteDailyPartnerPawnLastAffectionIncreaseRecords = $"DELETE FROM ddon_partner_pawn_last_affection_increase;";
+
+        public bool InsertPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
+            {
+                return ExecuteNonQuery(connection, SqlInsertPartnerPawnLastAffectionIncreaseRecord, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                    AddParameter(command, "action", (byte) action);
+                }) == 1;
+            });
+        }
+
+        public bool HasPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null)
+        {
+            bool foundRecord = false;
+            ExecuteQuerySafe(connectionIn, (connection) =>
+            {
+                ExecuteReader(connection, SqlSelectPartnerPawnLastAffectionIncreaseRecord, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                    AddParameter(command, "action", (byte) action);
+                }, reader =>
+                {
+                    foundRecord = reader.Read();
+                });
+            });
+            return foundRecord;
+        }
+
+        public void DeleteAllPartnerPawnLastAffectionIncreaseRecords(DbConnection? connectionIn = null)
+        {
+            ExecuteQuerySafe(connectionIn, (connection) =>
+            {
+                ExecuteNonQuery(connection, SqlDeleteDailyPartnerPawnLastAffectionIncreaseRecords, command => { });
+            });
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawnPendingRewards.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPartnerPawnPendingRewards.cs
@@ -1,0 +1,69 @@
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public abstract partial class DdonSqlDb<TCon, TCom, TReader> : SqlDb<TCon, TCom, TReader>
+        where TCon : DbConnection
+        where TCom : DbCommand
+        where TReader : DbDataReader
+    {
+        /* ddon_partner_pawn_pending_rewards */
+        protected static readonly string[] PartnerPawnPendingRewardFields = new string[]
+        {
+            "character_id", "pawn_id", "reward_level"
+        };
+
+        private readonly string SqlSelectPartnerPawnPendingRewards = $"SELECT {BuildQueryField(PartnerPawnPendingRewardFields)} FROM \"ddon_partner_pawn_pending_rewards\" WHERE \"character_id\"=@character_id AND \"pawn_id\" = @pawn_id;";
+        private readonly string SqlInsertPartnerPawnPendingReward = $"INSERT INTO \"ddon_partner_pawn_pending_rewards\" ({BuildQueryField(PartnerPawnPendingRewardFields)}) VALUES ({BuildQueryInsert(PartnerPawnPendingRewardFields)});";
+        private readonly string SqlDeletePartnerPawnPendingReward = $"DELETE FROM ddon_partner_pawn_pending_rewards WHERE \"character_id\"=@character_id AND \"pawn_id\" = @pawn_id AND \"reward_level\"=@reward_level;";
+
+        public HashSet<uint> GetPartnerPawnPendingRewards(uint characterId, uint pawnId, DbConnection? connectionIn = null)
+        {
+            var results = new HashSet<uint>();
+            ExecuteQuerySafe(connectionIn, (connection) =>
+            {
+                ExecuteReader(connection, SqlSelectPartnerPawnPendingRewards, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                }, reader =>
+                {
+                    while (reader.Read())
+                    {
+                        results.Add(GetUInt32(reader, "reward_level"));
+                    }
+                });
+            });
+            return results;
+        }
+
+        public bool InsertPartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
+            {
+                return ExecuteNonQuery(connection, SqlInsertPartnerPawnPendingReward, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                    AddParameter(command, "reward_level", rewardLevel);
+                }) == 1;
+            });
+        }
+
+        public void DeletePartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null)
+        {
+            ExecuteQuerySafe(connectionIn, (connection) =>
+            {
+                ExecuteNonQuery(connection, SqlDeletePartnerPawnPendingReward, command =>
+                {
+                    AddParameter(command, "character_id", characterId);
+                    AddParameter(command, "pawn_id", pawnId);
+                    AddParameter(command, "reward_level", rewardLevel);
+                });
+            });
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbUnlockedSecretAbility.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbUnlockedSecretAbility.cs
@@ -21,19 +21,16 @@ namespace Arrowgene.Ddon.Database.Sql.Core
         private readonly string SqlSelectAllUnlockedSecretAbility = $"SELECT {BuildQueryField(UnlockedSecretAbilityFields)} FROM \"ddon_unlocked_secret_ability\" WHERE \"character_common_id\" = @character_common_id;";
 
 
-        public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility)
+        public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility, DbConnection? connectionIn = null)
         {
-            using TCon connection = OpenNewConnection();
-            return InsertSecretAbilityUnlock(connection, commonId, secretAbility);
-        }
-
-        public bool InsertSecretAbilityUnlock(TCon conn, uint commonId, SecretAbility secretAbility)
-        {
-            return ExecuteNonQuery(conn, SqlInsertIfNotExistsUnlockedSecretAbility, command =>
+            return ExecuteQuerySafe<bool>(connectionIn, (connection) =>
             {
-                AddParameter(command, "character_common_id", commonId);
-                AddParameter(command, "ability_id", (uint) secretAbility);
-            }) == 1;
+                return ExecuteNonQuery(connection, SqlInsertIfNotExistsUnlockedSecretAbility, command =>
+                {
+                    AddParameter(command, "character_common_id", commonId);
+                    AddParameter(command, "ability_id", (uint)secretAbility);
+                }) == 1;
+            });
         }
 
         public List<SecretAbility> SelectAllUnlockedSecretAbilities(uint commonId)

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000030_PartnerPawnMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000030_PartnerPawnMigration.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class PartnerPawnMigration : IMigrationStrategy
+    {
+        public uint From => 29;
+        public uint To => 30;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public PartnerPawnMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(DatabaseSetting, "Script/migration_partner_pawn.sql");
+            db.Execute(conn, adaptedSchema);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -172,7 +172,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
             character.StatusInfo.MaxStamina = CharacterManager.BASE_STAMINA;
         }
 
-        public void UpdateDatabaseOnExit(Character character)
+        public void CleanupOnExit(GameClient client)
+        {
+            // Cancel any pending timers
+            _Server.PartnerPawnManager.HandleLeaveFromParty(client);
+
+            // Update player health in the DB
+            UpdateDatabaseOnExit(client.Character);
+        }
+
+        private void UpdateDatabaseOnExit(Character character)
         {
             // When the character is first logging in, the HP
             // values are set to 0. If the player disconnects

--- a/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
@@ -221,7 +221,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
         }
 
-        public bool HandleKickFromParty(GameClient client)
+        public bool HandleLeaveFromParty(GameClient client)
         {
             lock (client.Character.PartnerTimerLockObj)
             {
@@ -229,7 +229,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     return true;
                 }
-                Logger.Info($"(PartnerPawn) PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} kicked from party, canceling timer");
+                Logger.Info($"(PartnerPawn) PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} kicked/left party, canceling timer");
                 return CancelAdventureTimer(client);
             }
         }

--- a/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
@@ -1,0 +1,282 @@
+using Arrowgene.Ddon.GameServer.Handler;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer.Characters
+{
+    public class PartnerPawnManager
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PartnerPawnManager));
+
+        public static uint MAX_PARTNER_PAWN_LIKABILITY_RATING = 25;
+
+        private DdonGameServer Server;
+
+        public PartnerPawnManager(DdonGameServer server)
+        {
+            Server = server;
+        }
+
+        public PacketQueue UpdateLikabilityIncreaseAction(GameClient client, PartnerPawnAffectionAction action, DbConnection? connectionIn = null)
+        {
+            PacketQueue packets = new();
+
+            if (client.Character.PartnerPawnId == 0)
+            {
+                return new();
+            }
+
+            if (Server.Database.HasPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, action))
+            {
+                // MAX contributed for the day, do nothing
+                return new();
+            }
+
+            var partnerPawnData = Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, client.Character.PartnerPawnId, connectionIn);
+            var previousLikability = partnerPawnData.CalculateLikability();
+            switch (action)
+            {
+                case PartnerPawnAffectionAction.Gift:
+                    partnerPawnData.NumGifts += 1;
+                    break;
+                case PartnerPawnAffectionAction.Craft:
+                    partnerPawnData.NumCrafts += 1;
+                    break;
+                case PartnerPawnAffectionAction.Adventure:
+                    partnerPawnData.NumAdventures += 1;
+                    break;
+            }
+            Server.Database.UpdatePartnerPawnRecord(client.Character.CharacterId, partnerPawnData, connectionIn);
+            Server.Database.InsertPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, action, connectionIn);
+
+            var currentLikability = partnerPawnData.CalculateLikability();
+            if (previousLikability < currentLikability)
+            {
+                packets.Enqueue(client, new S2CPartnerPawnLikabilityUpNtc()
+                {
+                    PawnId = client.Character.PartnerPawnId
+                });
+
+                if (gLikabilityRewards.ContainsKey(currentLikability))
+                {
+                    Server.Database.InsertPartnerPawnPendingReward(client.Character.CharacterId, client.Character.PartnerPawnId, currentLikability, connectionIn);
+                }
+            }
+
+            return packets;
+        }
+
+        public bool IsActionConsumedForDay(GameClient client, PartnerPawnAffectionAction action)
+        {
+            if (client.Character.PartnerPawnId == 0)
+            {
+                return true;
+            }
+            return Server.Database.HasPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, action);
+        }
+
+        public uint GetLikabilityForCurrentPartnerPawn(GameClient client, DbConnection? connectionIn = null)
+        {
+            if (client.Character.PartnerPawnId == 0)
+            {
+                return 0;
+            }
+            return Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, client.Character.PartnerPawnId, connectionIn).CalculateLikability();
+        }
+
+        public List<CDataPartnerPawnReward> GetUnclaimedRewardsForCurrentPartnerPawn(GameClient client, DbConnection? connectionIn = null)
+        {
+            if (client.Character.PartnerPawnId == 0)
+            {
+                return new();
+            }
+
+            return Server.Database.GetPartnerPawnPendingRewards(client.Character.CharacterId, client.Character.PartnerPawnId, connectionIn)
+                    .Where(x => gLikabilityRewards.ContainsKey(x))
+                    .Select(x => gLikabilityRewards[x])
+                    .ToList();
+        }
+
+        public List<CDataPartnerPawnReward> GetReleasedRewards(GameClient client, DbConnection? connectionIn = null)
+        {
+            var likeability = Server.PartnerPawnManager.GetLikabilityForCurrentPartnerPawn(client, connectionIn);
+            if (likeability == 0)
+            {
+                return new();
+            }
+
+            var fileredTypes = new List<PawnLikabilityRewardType>()
+            {
+                PawnLikabilityRewardType.Talk,
+                PawnLikabilityRewardType.Emotion,
+                PawnLikabilityRewardType.Hair,
+            };
+
+            return gLikabilityRewards
+                .Where(x => x.Key <= likeability)
+                .Where(x => fileredTypes.Contains(x.Value.Type))
+                .Select(x => x.Value)
+                .ToList();
+        }
+
+        public uint GetLevelForReward(CDataPartnerPawnReward reward)
+        {
+            return gLikabilityRewards
+                .Where(x => x.Value.Type == reward.Type)
+                .Where(x => x.Value.Value.UID == reward.Value.UID)
+                .Select(x => x.Key)
+                .FirstOrDefault();
+        }
+
+        public bool CreateAdventureTimer(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                if (client.Character.PartnerPawnId == 0 || IsActionConsumedForDay(client, PartnerPawnAffectionAction.Adventure))
+                {
+                    // No partner pawn or
+                    // can't start another adventure for credit
+                    // until the next reset
+                    return true;
+                }
+
+                if (client.Character.PartnerPawnAdventureTimerId != 0 || !StageManager.IsSafeArea(client.Character.Stage))
+                {
+                    Logger.Error("Attempted to create an adventure timer in an invalid state");
+                    return false;
+                }
+
+                client.Character.PartnerPawnAdventureTimerId = Server.TimerManager.CreateTimer(Server.GameSettings.GameServerSettings.PartnerPawnAdventureDurationInSeconds, () =>
+                {
+                    Logger.Info($"(PartnerPawn) Adventure timer for PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} met");
+                    CancelAdventureTimer(client);
+                    UpdateLikabilityIncreaseAction(client, PartnerPawnAffectionAction.Adventure);
+                });
+                Logger.Info($"(PartnerPawn) Adventure timer for PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} created");
+            }
+
+            return true;
+        }
+
+        public void HandleStageAreaChange(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                var timerId = client.Character.PartnerPawnAdventureTimerId;
+                if (timerId == 0)
+                {
+                    return;
+                }
+
+                // Handle transitioning from safe to dangerous area
+                // Handle transitioning from dangerous to safe area
+                // Dangerous to Dangerous can be considered ignored since the timer should be running still
+                if (!Server.TimerManager.IsTimerStarted(timerId) && !StageManager.IsSafeArea(client.Character.Stage) ||
+                    Server.TimerManager.IsTimerPaused(timerId) && !StageManager.IsSafeArea(client.Character.Stage))
+                {
+                    StartAdventureTimer(client);
+                }
+                else if (Server.TimerManager.IsTimerStarted(timerId) && StageManager.IsSafeArea(client.Character.Stage))
+                {
+                    PauseAdventureTimer(client);
+                }
+            }
+        }
+
+        private bool StartAdventureTimer(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                if (client.Character.PartnerPawnAdventureTimerId == 0)
+                {
+                    Logger.Error("Attempted to start/resume the adventure timer but the timer id is invalid");
+                    return false;
+                }
+                return Server.TimerManager.StartTimer(client.Character.PartnerPawnAdventureTimerId);
+            }
+        }
+
+        private bool PauseAdventureTimer(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                if (client.Character.PartnerPawnAdventureTimerId == 0)
+                {
+                    Logger.Error("Attempted to start/resume the adventure timer but the timer id is invalid");
+                    return false;
+                }
+
+                Server.TimerManager.PauseTimer(client.Character.PartnerPawnAdventureTimerId);
+                Logger.Info($"(PartnerPawn) Adventure timer for PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} paused");
+
+                return true;
+            }
+        }
+
+        public bool HandleKickFromParty(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                if (client.Character.PartnerPawnAdventureTimerId == 0)
+                {
+                    return true;
+                }
+                Logger.Info($"(PartnerPawn) PartnerPawnId={client.Character.PartnerPawnAdventureTimerId} kicked from party, canceling timer");
+                return CancelAdventureTimer(client);
+            }
+        }
+
+        private bool CancelAdventureTimer(GameClient client)
+        {
+            lock (client.Character.PartnerTimerLockObj)
+            {
+                if (client.Character.PartnerPawnAdventureTimerId == 0)
+                {
+                    Logger.Error("Attempted to cancel the adventure timer but the timer id is invalid");
+                    return false;
+                }
+
+                Server.TimerManager.CancelTimer(client.Character.PartnerPawnAdventureTimerId);
+                client.Character.PartnerPawnAdventureTimerId = 0;
+                return true;
+            }
+        }
+
+        private static readonly Dictionary<uint,CDataPartnerPawnReward> gLikabilityRewards = new Dictionary<uint, CDataPartnerPawnReward>()
+        {
+            [1] = PartnerReward.CreateEmoteReward(EmoteId.ImHerePose1),
+            // [2], TODO: Recipe: Achievement/Recipe: Dinner Set
+            [3] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionHealth),
+            [4] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionAttack),
+            [5] = PartnerReward.CreateEmoteReward(EmoteId.ImHerePose2),
+            // [6], TODO: Achievement/Recipe: Lestanian Puppet - Giant Cyclops
+            [7] = PartnerReward.CreateCommunicationReward(2),
+            [8] = PartnerReward.CreateHairstyleReward(HairStyleId.Ex1Men, 2),
+            [9] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionDefense),
+            [10] = PartnerReward.CreateEmoteReward(EmoteId.OriginalPose2),
+            [11] = PartnerReward.CreateCommunicationReward(3),
+            [12] = PartnerReward.CreateHairstyleReward(HairStyleId.Ex2Women, 2),
+            [13] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionStamina),
+            [14] = PartnerReward.CreateEmoteReward(EmoteId.ImHerePose3),
+            [15] = PartnerReward.CreateCommunicationReward(4),
+            [16] = PartnerReward.CreateHairstyleReward(HairStyleId.Ex3Women, 2),
+            [17] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionMagick),
+            [18] = PartnerReward.CreateAbilityReward(SecretAbility.CompanionMagickDefense),
+            [19] = PartnerReward.CreateEmoteReward(EmoteId.ImHerePose4),
+            // [20] = TODO: Achievement 愛を叫んだ覚者
+            [21] = PartnerReward.CreateHairstyleReward(HairStyleId.Ex4Women, 2),
+            // [22], TODO: Recipe: Achievement/Recipe: Servant's Sleepwear (Type 1)
+            [23] = PartnerReward.CreateCommunicationReward(5),
+            // [24], TODO: Recipe: Achievement/Recipe: Servant's Sleepwear (Type 2)
+            [25] = PartnerReward.CreateCommunicationReward(6),
+        };
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -1,14 +1,12 @@
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters

--- a/Arrowgene.Ddon.GameServer/Characters/TimerManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/TimerManager.cs
@@ -29,6 +29,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             public Timer Timer { get; set; }
             public Action Action {  get; set; }
             public bool TimerStarted {  get; set; }
+            public bool TimerPaused { get; set; }
         }
 
         public uint CreateTimer(uint timeoutInSeconds, Action action)
@@ -44,7 +45,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 _Timers[timerId] = new TimerState()
                 {
                     Action = action,
-                    Duration = TimeSpan.FromSeconds(timeoutInSeconds)
+                    Duration = TimeSpan.FromSeconds(timeoutInSeconds),
+                    TimerPaused = false
                 };
             }
 
@@ -61,12 +63,21 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 }
 
                 var timerState = _Timers[timerId];
-                if (timerState.TimerStarted)
+                if (timerState.TimerStarted && !timerState.TimerPaused)
                 {
                     return false;
                 }
 
-                timerState.TimeStart = DateTime.Now;
+                if (!timerState.TimerPaused)
+                {
+                    timerState.TimeStart = DateTime.Now;
+                    Logger.Info($"Starting {timerState.Duration.TotalSeconds} second timer for TimerId={timerId}");
+                }
+                else
+                {
+                    Logger.Info($"Resuming {GetTimeLeftInSeconds(timerId)} second timer for TimerId={timerId}");
+                }
+
                 timerState.Timer = new Timer(task =>
                 {
                     TimeSpan alreadyElapsed = DateTime.Now.Subtract(timerState.TimeStart);
@@ -80,7 +91,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
                         CancelTimer(timerId);
                     }
                 }, null, 0, 1000);
-                Logger.Info($"Starting {timerState.Duration.TotalSeconds} second timer for TimerId={timerId}");
+                timerState.TimerPaused = false;
+                timerState.TimerStarted = true;
             }
 
             return true;
@@ -93,6 +105,19 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 Logger.Info($"Extending timer by {amountInSeconds} seconds for TimerId={timerId}");
                 _Timers[timerId].Duration += TimeSpan.FromSeconds(amountInSeconds);
                 return (ulong)((DateTimeOffset)(_Timers[timerId].TimeStart + _Timers[timerId].Duration)).ToUnixTimeSeconds();
+            }
+        }
+
+        public void PauseTimer(uint timerId)
+        {
+            lock (_Timers)
+            {
+                Logger.Info($"Pausing timer for TimerId={timerId}");
+                if (!_Timers[timerId].TimerPaused)
+                {
+                    _Timers[timerId].Timer.Dispose();
+                    _Timers[timerId].TimerPaused = true;
+                }
             }
         }
 
@@ -111,6 +136,30 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
         }
 
+        public bool IsTimerStarted(uint timerId)
+        {
+            lock (_Timers)
+            {
+                if (!_Timers.ContainsKey(timerId))
+                {
+                    return false;
+                }
+                return _Timers[timerId].TimerStarted;
+            }
+        }
+
+        public bool IsTimerPaused(uint timerId)
+        {
+            lock (_Timers)
+            {
+                if (!_Timers.ContainsKey(timerId))
+                {
+                    return false;
+                }
+                return _Timers[timerId].TimerPaused;
+            }
+        }
+
         public (TimeSpan Elapsed, TimeSpan MaximumDuration) CancelTimer(uint timerId)
         {
             lock (_Timers)
@@ -118,7 +167,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 if (_Timers.ContainsKey(timerId))
                 {
                     Logger.Info($"Canceling timer for TimerId={timerId}");
-                    _Timers[timerId].Timer.Dispose();
+                    if (_Timers[timerId].TimerStarted)
+                    {
+                        _Timers[timerId].Timer.Dispose();
+                    }
 
                     var timerState = _Timers[timerId];
 

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -85,6 +85,7 @@ namespace Arrowgene.Ddon.GameServer
             ScheduleManager = new ScheduleManager(this);
             AreaRankManager = new AreaRankManager(this);
             GameTimeManager = new GameTimeManager(this);
+            PartnerPawnManager = new PartnerPawnManager(this);
 
             // Orb Management is slightly complex and requires updating fields across multiple systems
             OrbUnlockManager = new OrbUnlockManager(database, WalletManager, JobManager, CharacterManager);
@@ -123,9 +124,10 @@ namespace Arrowgene.Ddon.GameServer
         public ClanManager ClanManager { get; }
         public RpcManager RpcManager { get; }
         public EpitaphRoadManager EpitaphRoadManager { get; }
-        private ScheduleManager ScheduleManager { get; }
+        public ScheduleManager ScheduleManager { get; }
         public AreaRankManager AreaRankManager { get; }
         public GameTimeManager GameTimeManager { get; }
+        public PartnerPawnManager PartnerPawnManager { get; }
 
         public ChatLogHandler ChatLogHandler { get; }
 
@@ -475,11 +477,13 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new OrbDevoteGetPawnReleaseOrbElementListHandler(this));
             AddHandler(new OrbDevoteReleasePawnOrbElementHandler(this));
 
-            AddHandler(new PartnerPawnSetHandler(this));
+            AddHandler(new PartnerPawnNextPresentTimeGetHandler(this));
             AddHandler(new PartnerPawnPawnLikabilityReleasedRewardListGetHandler(this));
-            AddHandler(new PartnerPawnPawnLikabilityRewardListGetHandler(this));
             AddHandler(new PartnerPawnPawnLikabilityRewardGetHandler(this));
-            
+            AddHandler(new PartnerPawnPawnLikabilityRewardListGetHandler(this));
+            AddHandler(new PartnerPawnPresentForPartnerPawnHandler(this));
+            AddHandler(new PartnerPawnSetHandler(this));
+
             AddHandler(new PartyMemberSetValueHandler(this));
             AddHandler(new PartyPartyBreakupHandler(this));
             AddHandler(new PartyPartyChangeLeaderHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -184,6 +184,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_GP_LACK_GP);
                     updateCharacterItemNtc.UpdateWalletList.Add(updateGP);
                 }
+
+                if (leadPawn.PawnId == client.Character.PartnerPawnId)
+                {
+                    Server.PartnerPawnManager.UpdateLikabilityIncreaseAction(client, PartnerPawnAffectionAction.Craft, connection)
+                        .Send();
+                }
             });
 
             client.Send(updateCharacterItemNtc);

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyLeaveHandler.cs
@@ -47,7 +47,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
 
                 Server.HubManager.LeaveAllHubs(client);
-                Server.CharacterManager.UpdateDatabaseOnExit(client.Character);
+                Server.CharacterManager.CleanupOnExit(client);
                 Server.PartyManager.CleanupOnExit(client);
                 Server.RpcManager.AnnouncePlayerList(client.Character);
             }

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnNextPresentTimeGetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnNextPresentTimeGetHandler.cs
@@ -27,7 +27,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 isMax = partnerPawnData.CalculateLikability() >= PartnerPawnManager.MAX_PARTNER_PAWN_LIKABILITY_RATING;
                 if (!isMax && Server.Database.HasPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, PartnerPawnAffectionAction.Gift, connection))
                 {
-                    timeToNext = Server.ScheduleManager.TimeToNextTaskUpdate(TaskType.PawnAffectionIncreaseInteraction);
+                    timeToNext = Server.ScheduleManager.TimeToNextTaskUpdate(TaskType.PawnAffectionIncreaseInteractionReset);
                 }
             });
 

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnNextPresentTimeGetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnNextPresentTimeGetHandler.cs
@@ -1,0 +1,41 @@
+using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PartnerPawnNextPresentTimeGetHandler : GameRequestPacketHandler<C2SPartnerPawnNextPresentTimeGetReq,S2CPartnerPawnNextPresentTimeGetRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PartnerPawnPawnLikabilityReleasedRewardListGetHandler));
+
+        public PartnerPawnNextPresentTimeGetHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CPartnerPawnNextPresentTimeGetRes Handle(GameClient client, C2SPartnerPawnNextPresentTimeGetReq request)
+        {
+            long timeToNext = 0;
+            bool isMax = false;
+
+            Server.Database.ExecuteInTransaction(connection =>
+            {
+                var partnerPawnData = Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, client.Character.PartnerPawnId, connection) ?? new PartnerPawnData();
+
+                isMax = partnerPawnData.CalculateLikability() >= PartnerPawnManager.MAX_PARTNER_PAWN_LIKABILITY_RATING;
+                if (!isMax && Server.Database.HasPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, PartnerPawnAffectionAction.Gift, connection))
+                {
+                    timeToNext = Server.ScheduleManager.TimeToNextTaskUpdate(TaskType.PawnAffectionIncreaseInteraction);
+                }
+            });
+
+            return new S2CPartnerPawnNextPresentTimeGetRes()
+            {
+                RemainSec = (uint) timeToNext,
+                IsMax = isMax
+            };
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPawnLikabilityReleasedRewardListGetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPawnLikabilityReleasedRewardListGetHandler.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -18,40 +16,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CPartnerPawnPawnLikabilityReleasedRewardListGetRes Handle(GameClient client, C2SPartnerPawnPawnLikabilityReleasedRewardListGetReq request)
         {
-            S2CPartnerPawnPawnLikabilityReleasedRewardListGetRes res = new S2CPartnerPawnPawnLikabilityReleasedRewardListGetRes();
-
-            res.ReleasedRewardList = new List<CDataPartnerPawnReward>
+            return new S2CPartnerPawnPawnLikabilityReleasedRewardListGetRes()
             {
-                // new CDataPartnerPawnReward
-                // {
-                //     Type = 3,
-                //     Value = new CDataPartnerPawnRewardParam
-                //     {
-                //         ParamTypeId = 0,
-                //         UID = 45
-                //     }
-                // },
-                // new CDataPartnerPawnReward
-                // {
-                //     Type = 2,
-                //     Value = new CDataPartnerPawnRewardParam
-                //     {
-                //         ParamTypeId = 0,
-                //         UID = 2
-                //     }
-                // },
-                // new CDataPartnerPawnReward
-                // {
-                //     Type = 1,
-                //     Value = new CDataPartnerPawnRewardParam
-                //     {
-                //         ParamTypeId = 2,
-                //         UID = 72
-                //     }
-                // }
+                ReleasedRewardList = Server.PartnerPawnManager.GetReleasedRewards(client)
             };
-
-            return res;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPawnLikabilityRewardListGetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPawnLikabilityRewardListGetHandler.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -17,23 +15,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CPartnerPawnPawnLikabilityRewardListGetRes Handle(GameClient client, C2SPartnerPawnPawnLikabilityRewardListGetReq request)
         {
-            S2CPartnerPawnPawnLikabilityRewardListGetRes res = new S2CPartnerPawnPawnLikabilityRewardListGetRes();
-
-            // TODO: figure out if we have dumps for this
-            res.RewardList = new List<CDataPartnerPawnReward>
+            // Returns unclaimed rewards when the player enters into the arisens room
+            return new S2CPartnerPawnPawnLikabilityRewardListGetRes()
             {
-                // new CDataPartnerPawnReward
-                // {
-                //     Type = 4,
-                //     Value = new CDataPartnerPawnRewardParam
-                //     {
-                //         ParamTypeId = 0,
-                //         UID = 441
-                //     }
-                // }
+                RewardList = Server.PartnerPawnManager.GetUnclaimedRewardsForCurrentPartnerPawn(client)
             };
-
-            return res;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
@@ -1,0 +1,57 @@
+using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Quests;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PartnerPawnPresentForPartnerPawnHandler : GameRequestPacketQueueHandler<C2SPartnerPawnPresentForPartnerPawnReq, S2CPartnerPawnPresentForPartnerPawnRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PartnerPawnPresentForPartnerPawnHandler));
+
+        public PartnerPawnPresentForPartnerPawnHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override PacketQueue Handle(GameClient client, C2SPartnerPawnPresentForPartnerPawnReq request)
+        {
+            var packets = new PacketQueue();
+
+            PartnerPawnData partnerPawnData = new PartnerPawnData();
+
+            List<CDataItemUpdateResult> itemUpdateResults = new List<CDataItemUpdateResult>();
+            Server.Database.ExecuteInTransaction(connection =>
+            {
+                foreach (var item in request.ItemUIDList)
+                {
+                    uint itemId = Server.ItemManager.LookupItemByUID(Server, item.ItemUId);
+                    var searchResult = client.Character.Storage.FindItemByUIdInStorage(ItemManager.BothStorageTypes, item.ItemUId);
+                    var itemUpdate = Server.ItemManager.ConsumeItemByUId(Server, client.Character, searchResult.Item1, item.ItemUId, item.Num, connectionIn: connection)
+                        ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_DONT_HAVE_DELIVERY_ITEM);
+
+                    itemUpdateResults.Add(itemUpdate);
+
+                    packets.AddRange(Server.PartnerPawnManager.UpdateLikabilityIncreaseAction(client, PartnerPawnAffectionAction.Gift, connection));
+                }
+            });
+
+            packets.Enqueue(client, new S2CItemUpdateCharacterItemNtc()
+            {
+                UpdateType = ItemNoticeType.QuestDelivery,
+                UpdateItemList = itemUpdateResults
+            });
+
+            packets.Enqueue(client, new S2CPartnerPawnPresentForPartnerPawnRes()
+            {
+                PartnerInfo = partnerPawnData.ToCDataPartnerPawnData()
+            });
+
+            return packets;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
@@ -20,9 +20,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override PacketQueue Handle(GameClient client, C2SPartnerPawnPresentForPartnerPawnReq request)
         {
+            CDataPartnerPawnData partnerPawnData = new CDataPartnerPawnData();
             var packets = new PacketQueue();
-
-            PartnerPawnData partnerPawnData = new PartnerPawnData();
 
             List<CDataItemUpdateResult> itemUpdateResults = new List<CDataItemUpdateResult>();
             Server.Database.ExecuteInTransaction(connection =>
@@ -38,6 +37,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                     packets.AddRange(Server.PartnerPawnManager.UpdateLikabilityIncreaseAction(client, PartnerPawnAffectionAction.Gift, connection));
                 }
+
+                partnerPawnData = Server.PartnerPawnManager.GetCDataPartnerPawnData(client, connection);
             });
 
             packets.Enqueue(client, new S2CItemUpdateCharacterItemNtc()
@@ -48,7 +49,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             packets.Enqueue(client, new S2CPartnerPawnPresentForPartnerPawnRes()
             {
-                PartnerInfo = partnerPawnData.ToCDataPartnerPawnData()
+                PartnerInfo = partnerPawnData
             });
 
             return packets;

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnSetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnSetHandler.cs
@@ -31,14 +31,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     record = new PartnerPawnData()
                     {
                         PawnId = pawn.PawnId,
-                        Personality = PawnPersonality.Normal,
                         NumGifts = 0,
                         NumCrafts = 0,
                         NumAdventures = 0,
                     };
                     Server.Database.InsertPartnerPawnRecord(client.Character.CharacterId, record, connection);
                 }
-                res.PartnerInfo = record.ToCDataPartnerPawnData();
+                res.PartnerInfo = record.ToCDataPartnerPawnData(pawn);
             });
 
             return res;

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnSetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnSetHandler.cs
@@ -19,13 +19,27 @@ namespace Arrowgene.Ddon.GameServer.Handler
             S2CPartnerPawnSetRes res = new S2CPartnerPawnSetRes();
 
             Pawn pawn = client.Character.Pawns.Find(p => p.PawnId == request.PawnId);
-            res.PartnerInfo = new CDataPartnerPawnData
+
+            client.Character.PartnerPawnId = pawn.PawnId;
+            Server.Database.ExecuteInTransaction(connection =>
             {
-                PawnId = pawn.PawnId,
-                // TODO: Likability and other attributes are not stored in the pawn memory entity yet
-                Likability = 1,
-                Personality = 1
-            };
+                Server.Database.SetPartnerPawn(client.Character.CharacterId, pawn.PawnId, connection);
+
+                var record = Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, pawn.PawnId, connection);
+                if (record == null)
+                {
+                    record = new PartnerPawnData()
+                    {
+                        PawnId = pawn.PawnId,
+                        Personality = PawnPersonality.Normal,
+                        NumGifts = 0,
+                        NumCrafts = 0,
+                        NumAdventures = 0,
+                    };
+                    Server.Database.InsertPartnerPawnRecord(client.Character.CharacterId, record, connection);
+                }
+                res.PartnerInfo = record.ToCDataPartnerPawnData();
+            });
 
             return res;
         }

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyBreakupHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyBreakupHandler.cs
@@ -30,6 +30,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 if (member is PlayerPartyMember player)
                 {
+                    Server.PartnerPawnManager.HandleLeaveFromParty(player.Client);
                     player.Client.Send(ntc);
                 }
             }

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
@@ -20,6 +20,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             PartyGroup party = client.Party
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_NOT_FOUNDED, "Could not leave party, does not exist");
 
+            if (client.Character.PartnerPawnId != 0)
+            {
+                Server.PartnerPawnManager.HandleLeaveFromParty(client);
+            }
+
             party.Leave(client);
             Logger.Info(client, $"Left PartyId:{party.Id}");
 

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyMemberKickHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyMemberKickHandler.cs
@@ -36,6 +36,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             if (member is PawnPartyMember pawnMember)
             {
                 pawnMember.Pawn.PawnState = PawnState.None;
+
+                if (pawnMember.PawnId == client.Character.PartnerPawnId)
+                {
+                    Server.PartnerPawnManager.HandleKickFromParty(client);
+                }
             }
 
             return res;

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyMemberKickHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyMemberKickHandler.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Numerics;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -29,17 +30,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 MemberIndex = (byte)member.MemberIndex
             };
             party.SendToAll(ntc);
+
             if (member is PlayerPartyMember playerMember)
             {
                 playerMember.Client.Send(ntc);
-            }           
-            if (member is PawnPartyMember pawnMember)
+            } 
+            else if (member is PawnPartyMember pawnMember)
             {
+                // todo handle other party member pawn
                 pawnMember.Pawn.PawnState = PawnState.None;
 
-                if (pawnMember.PawnId == client.Character.PartnerPawnId)
+                if (!pawnMember.Pawn.IsRented)
                 {
-                    Server.PartnerPawnManager.HandleKickFromParty(client);
+                    var memberClient = Server.ClientLookup.GetClientByCharacterId(pawnMember.Pawn.CharacterId);
+                    if (memberClient != null && (pawnMember.PawnId == memberClient.Character.PartnerPawnId))
+                    {
+                        Server.PartnerPawnManager.HandleLeaveFromParty(memberClient);
+                    }
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
@@ -3,6 +3,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -41,10 +42,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 res.PawnList.Add(pawnListData);
             }
 
-            if (client.Character.PartnerPawnId != 0)
+            var partnerPawn = client.Character.Pawns.Where(x => x.PawnId == client.Character.PartnerPawnId).FirstOrDefault();
+            if (partnerPawn != null)
             {
                 var partnerData = Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, client.Character.PartnerPawnId);
-                res.PartnerInfo =  (partnerData != null) ? partnerData.ToCDataPartnerPawnData() : new CDataPartnerPawnData();
+                res.PartnerInfo =  (partnerData != null) ? partnerData.ToCDataPartnerPawnData(partnerPawn) : new CDataPartnerPawnData();
             }
 
             return res;

--- a/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
@@ -3,8 +3,6 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -18,7 +16,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CPawnGetMypawnListRes Handle(GameClient client, C2SPawnGetMyPawnListReq request)
         {
-
             S2CPawnGetMypawnListRes res = new S2CPawnGetMypawnListRes();
 
             uint index = 1;
@@ -44,13 +41,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 res.PawnList.Add(pawnListData);
             }
 
-            // TODO: PartnerInfo
-            res.PartnerInfo = new CDataPartnerPawnData()
+            if (client.Character.PartnerPawnId != 0)
             {
-                PawnId = client.Character.Pawns.FirstOrDefault()?.PawnId ?? 0,
-                Likability = 1,
-                Personality = 1
-            };
+                var partnerData = Server.Database.GetPartnerPawnRecord(client.Character.CharacterId, client.Character.PartnerPawnId);
+                res.PartnerInfo =  (partnerData != null) ? partnerData.ToCDataPartnerPawnData() : new CDataPartnerPawnData();
+            }
 
             return res;
         }

--- a/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyMypawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyMypawnHandler.cs
@@ -1,8 +1,10 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
+using System;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -22,6 +24,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             pawn.PawnState = PawnState.Party;
             client.Party.SendToAll(new S2CPawnJoinPartyPawnNtc() { PartyMember = partyMember.GetCDataPartyMember() });
             client.Party.SendToAll(partyMember.GetS2CContextGetParty_ContextNtc());
+
+            if (pawn.PawnId == client.Character.PartnerPawnId)
+            {
+                Server.PartnerPawnManager.CreateAdventureTimer(client);
+            }
 
             return new();
         }

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -91,6 +91,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
+            if (client.IsPartyLeader())
+            {
+                Server.PartnerPawnManager.HandleStageAreaChange(client);
+            }
+
             Server.EpitaphRoadManager.AreaChange(client, packet.StageId, queue);
             return queue;
         }

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -105,5 +105,10 @@ namespace Arrowgene.Ddon.GameServer
 
             return (next > now) ? (next - now) : 0;
         }
+
+        public List<SchedulerTask> GetTasks()
+        {
+            return Tasks;
+        }
     }
 }

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Ddon.GameServer.Tasks;
+using Arrowgene.Ddon.GameServer.Tasks.Implementations;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Scheduler;
 using Arrowgene.Logging;
@@ -29,7 +30,8 @@ namespace Arrowgene.Ddon.GameServer
             {
                 new EpitaphSchedulerTask(DayOfWeek.Monday, 5, 0),
                 new AreaPointResetTask(DayOfWeek.Monday, 5, 0),
-                new RankingBoardResetTask(DayOfWeek.Monday, 5, 0)
+                new RankingBoardResetTask(DayOfWeek.Monday, 5, 0),
+                new PawnLikabilityIncreaseResetTask(5, 0),
             };
         }
 
@@ -87,6 +89,21 @@ namespace Arrowgene.Ddon.GameServer
                     }
                 }, null, timerTick, timerTick);
             }
+        }
+
+        public long TimeToNextTaskUpdate(TaskType taskType)
+        {
+            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            var task = Tasks.Where(x => x.Type == taskType).FirstOrDefault();
+            if (task == null)
+            {
+                return 0;
+            }
+
+            long next = task.NextTimestamp();
+
+            return (next > now) ? (next - now) : 0;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
@@ -3,7 +3,6 @@ using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
-using Arrowgene.Ddon.Shared.Model.Quest;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/AreaPointResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/AreaPointResetTask.cs
@@ -7,7 +7,7 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 
-namespace Arrowgene.Ddon.GameServer.Tasks
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
 {
     public class AreaPointResetTask : WeeklyTask
     {

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/EpitaphSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/EpitaphSchedulerTask.cs
@@ -4,7 +4,7 @@ using Arrowgene.Ddon.Shared.Model.Scheduler;
 using Arrowgene.Logging;
 using System;
 
-namespace Arrowgene.Ddon.GameServer.Tasks
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
 {
     public class EpitaphSchedulerTask : WeeklyTask
     {

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/PawnLikabilityIncreaseResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/PawnLikabilityIncreaseResetTask.cs
@@ -8,7 +8,7 @@ namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnLikabilityIncreaseResetTask));
 
-        public PawnLikabilityIncreaseResetTask(uint hour, uint minute) : base(TaskType.PawnAffectionIncreaseInteraction, hour, minute)
+        public PawnLikabilityIncreaseResetTask(uint hour, uint minute) : base(TaskType.PawnAffectionIncreaseInteractionReset, hour, minute)
         {
         }
 

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/PawnLikabilityIncreaseResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/PawnLikabilityIncreaseResetTask.cs
@@ -1,0 +1,26 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
+{
+    public class PawnLikabilityIncreaseResetTask : DailyTask
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnLikabilityIncreaseResetTask));
+
+        public PawnLikabilityIncreaseResetTask(uint hour, uint minute) : base(TaskType.PawnAffectionIncreaseInteraction, hour, minute)
+        {
+        }
+
+        public override bool IsEnabled(DdonGameServer server)
+        {
+            return true;
+        }
+
+        public override void RunTask(DdonGameServer server)
+        {
+            Logger.Info("Pawn affection increase limit daily reset");
+            server.Database.DeleteAllPartnerPawnLastAffectionIncreaseRecords();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/RankingBoardResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/RankingBoardResetTask.cs
@@ -3,7 +3,7 @@ using Arrowgene.Ddon.Shared.Model.Scheduler;
 using Arrowgene.Logging;
 using System;
 
-namespace Arrowgene.Ddon.GameServer.Tasks
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
 {
     public class RankingBoardResetTask : WeeklyTask
     {

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/schedule.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/schedule.csx
@@ -1,0 +1,28 @@
+#load "libs.csx"
+
+public class ChatCommand : IChatCommand
+{
+    public override AccountStateType AccountState => AccountStateType.Admin;
+    public override string CommandName            => "schedule";
+    public override string HelpText               => "usage: `/schedule` - Print details about the current scheduled tasks";
+
+    public override void Execute(DdonGameServer server, string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
+    {
+        var lines = new List<string>();
+        lines.Add("# TaskType, Next Update");
+        foreach (var task in server.ScheduleManager.GetTasks())
+        {
+            TimeSpan ts = TimeSpan.FromSeconds(server.ScheduleManager.TimeToNextTaskUpdate(task.Type));
+            var formattedTime = string.Format("{0:D1}d:{1:D2}h:{2:D2}m:{3:D2}s", ts.Days, ts.Hours, ts.Minutes, ts.Seconds);
+            var line = $"{task.Type} ({(uint)task.Type}), {formattedTime}";
+            lines.Add(line);
+        }
+
+        ChatResponse response = new ChatResponse();
+        response.Message = String.Join("\n", lines);
+        responses.Add(response);
+        Console.WriteLine(response.Message);
+    }
+}
+
+return new ChatCommand();

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -47,9 +47,9 @@ namespace Arrowgene.Ddon.Server.Settings
         private const double _AdditionalCostPerformanceFactor = 1.0;
 
         /// <summary>
-        /// The amount of seconds that the party leaders partner pawn must be
-        /// out in a non-safe area to receive credit for adventuering with the
-        /// player for the day.
+        /// The amount of seconds that the partner pawn must be a member of the
+        /// party, adventuring in a non-safe area to receive adventure credit
+        /// for the day.
         /// </summary>
         [DefaultValue(_PartnerPawnAdventureDurationInSeconds)]
         public uint PartnerPawnAdventureDurationInSeconds

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -47,6 +47,25 @@ namespace Arrowgene.Ddon.Server.Settings
         private const double _AdditionalCostPerformanceFactor = 1.0;
 
         /// <summary>
+        /// The amount of seconds that the party leaders partner pawn must be
+        /// out in a non-safe area to receive credit for adventuering with the
+        /// player for the day.
+        /// </summary>
+        [DefaultValue(_PartnerPawnAdventureDurationInSeconds)]
+        public uint PartnerPawnAdventureDurationInSeconds
+        {
+            set
+            {
+                SetSetting("PartnerPawnAdventureDurationInSeconds", value);
+            }
+            get
+            {
+                return TryGetSetting("PartnerPawnAdventureDurationInSeconds", _PartnerPawnAdventureDurationInSeconds);
+            }
+        }
+        private const uint _PartnerPawnAdventureDurationInSeconds = 1800;
+
+        /// <summary>
         /// Controls whether to pass lobby context packets on demand or only on entry to the server.
         /// True = Server entry only. Lower packet load, but also causes invisible people in lobbies.
         /// False = On-demand. May cause performance issues due to packet load.

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -761,10 +761,14 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SOrbDevoteGetPawnReleaseOrbElementListReq.Serializer());
             Create(new C2SOrbDevoteReleaseOrbElementReq.Serializer());
             Create(new C2SOrbDevoteReleasePawnOrbElementReq.Serializer());
+
+            Create(new C2SPartnerPawnNextPresentTimeGetReq.Serializer());
             Create(new C2SPartnerPawnPawnLikabilityReleasedRewardListGetReq.Serializer());
             Create(new C2SPartnerPawnPawnLikabilityRewardGetReq.Serializer());
             Create(new C2SPartnerPawnPawnLikabilityRewardListGetReq.Serializer());
+            Create(new C2SPartnerPawnPresentForPartnerPawnReq.Serializer());
             Create(new C2SPartnerPawnSetReq.Serializer());
+
             Create(new C2SPartyPartyBreakupReq.Serializer());
             Create(new C2SPartyPartyChangeLeaderReq.Serializer());
             Create(new C2SPartyPartyCreateReq.Serializer());
@@ -1339,10 +1343,13 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2COrbDevoteReleaseOrbElementRes.Serializer());
             Create(new S2COrbDevoteReleasePawnOrbElementRes.Serializer());
 
+            Create(new S2CPartnerPawnNextPresentTimeGetRes.Serializer());
+            Create(new S2CPartnerPawnPresentForPartnerPawnRes.Serializer());
             Create(new S2CPartnerPawnPawnLikabilityReleasedRewardListGetRes.Serializer());
-            Create(new S2CPartnerPawnPawnLikabilityRewardListGetRes.Serializer());
             Create(new S2CPartnerPawnPawnLikabilityRewardGetRes.Serializer());
+            Create(new S2CPartnerPawnPawnLikabilityRewardListGetRes.Serializer());
             Create(new S2CPartnerPawnSetRes.Serializer());
+            Create(new S2CPartnerPawnLikabilityUpNtc.Serializer());
 
             Create(new S2CPartyPartyBreakupNtc.Serializer());
             Create(new S2CPartyPartyBreakupRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPartnerPawnNextPresentTimeGetReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPartnerPawnNextPresentTimeGetReq.cs
@@ -1,0 +1,28 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPartnerPawnNextPresentTimeGetReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PARTNER_PAWN_PARTNER_PAWN_NEXT_PRESENT_TIME_GET_REQ;
+
+        public C2SPartnerPawnNextPresentTimeGetReq()
+        {
+        }
+
+        public class Serializer : PacketEntitySerializer<C2SPartnerPawnNextPresentTimeGetReq>
+        {
+            public override void Write(IBuffer buffer, C2SPartnerPawnNextPresentTimeGetReq obj)
+            {
+            }
+
+            public override C2SPartnerPawnNextPresentTimeGetReq Read(IBuffer buffer)
+            {
+                C2SPartnerPawnNextPresentTimeGetReq obj = new C2SPartnerPawnNextPresentTimeGetReq();
+
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPartnerPawnPresentForPartnerPawnReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPartnerPawnPresentForPartnerPawnReq.cs
@@ -1,0 +1,35 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPartnerPawnPresentForPartnerPawnReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_REQ;
+
+
+        public C2SPartnerPawnPresentForPartnerPawnReq()
+        {
+            ItemUIDList = new List<CDataStorageItemUIDList>();
+        }
+
+        public List<CDataStorageItemUIDList> ItemUIDList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SPartnerPawnPresentForPartnerPawnReq>
+        {
+            public override void Write(IBuffer buffer, C2SPartnerPawnPresentForPartnerPawnReq obj)
+            {
+                WriteEntityList(buffer, obj.ItemUIDList);
+            }
+
+            public override C2SPartnerPawnPresentForPartnerPawnReq Read(IBuffer buffer)
+            {
+                C2SPartnerPawnPresentForPartnerPawnReq obj = new C2SPartnerPawnPresentForPartnerPawnReq();
+                obj.ItemUIDList = ReadEntityList<CDataStorageItemUIDList>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnLikabilityUpNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnLikabilityUpNtc.cs
@@ -1,0 +1,32 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPartnerPawnLikabilityUpNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_PARTNER_PAWN_LIKABILITY_UP_NTC;
+
+        public S2CPartnerPawnLikabilityUpNtc()
+        {
+            PawnId = 0;
+        }
+
+        public uint PawnId { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPartnerPawnLikabilityUpNtc>
+        {
+            public override void Write(IBuffer buffer, S2CPartnerPawnLikabilityUpNtc obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+            }
+
+            public override S2CPartnerPawnLikabilityUpNtc Read(IBuffer buffer)
+            {
+                S2CPartnerPawnLikabilityUpNtc obj = new S2CPartnerPawnLikabilityUpNtc();
+                obj.PawnId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnNextPresentTimeGetRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnNextPresentTimeGetRes.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPartnerPawnNextPresentTimeGetRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PARTNER_PAWN_PARTNER_PAWN_NEXT_PRESENT_TIME_GET_RES;
+
+        public S2CPartnerPawnNextPresentTimeGetRes()
+        {
+        }
+
+        public uint RemainSec { get; set; }
+        public bool IsMax { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPartnerPawnNextPresentTimeGetRes>
+        {
+            public override void Write(IBuffer buffer, S2CPartnerPawnNextPresentTimeGetRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteUInt32(buffer, obj.RemainSec);
+                WriteBool(buffer, obj.IsMax);
+            }
+
+            public override S2CPartnerPawnNextPresentTimeGetRes Read(IBuffer buffer)
+            {
+                S2CPartnerPawnNextPresentTimeGetRes obj = new S2CPartnerPawnNextPresentTimeGetRes();
+                ReadServerResponse(buffer, obj);
+                obj.RemainSec = ReadUInt32(buffer);
+                obj.IsMax = ReadBool(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnPresentForPartnerPawnRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPartnerPawnPresentForPartnerPawnRes.cs
@@ -1,0 +1,35 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPartnerPawnPresentForPartnerPawnRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_RES;
+
+        public S2CPartnerPawnPresentForPartnerPawnRes()
+        {
+            PartnerInfo = new CDataPartnerPawnData();
+        }
+
+        public CDataPartnerPawnData PartnerInfo { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPartnerPawnPresentForPartnerPawnRes>
+        {
+            public override void Write(IBuffer buffer, S2CPartnerPawnPresentForPartnerPawnRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteEntity(buffer, obj.PartnerInfo);
+            }
+
+            public override S2CPartnerPawnPresentForPartnerPawnRes Read(IBuffer buffer)
+            {
+                S2CPartnerPawnPresentForPartnerPawnRes obj = new S2CPartnerPawnPresentForPartnerPawnRes();
+                ReadServerResponse(buffer, obj);
+                obj.PartnerInfo = ReadEntity<CDataPartnerPawnData>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataEditInfo.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataEditInfo.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
@@ -9,7 +10,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             Sex = 1;
             Voice = 1;
             VoicePitch = 30000;
-            Personality = 1;
+            Personality = PawnPersonality.Normal;
             SpeechFreq = 1;
             BodyType = 0;
             Hair = 25;
@@ -82,7 +83,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public byte Sex;
         public byte Voice;
         public ushort VoicePitch;
-        public byte Personality;
+        public PawnPersonality Personality;
         public byte SpeechFreq;
         public byte BodyType;
         public byte Hair;
@@ -158,7 +159,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 WriteByte(buffer, obj.Sex);
                 WriteByte(buffer, obj.Voice);
                 WriteUInt16(buffer, obj.VoicePitch);
-                WriteByte(buffer, obj.Personality);
+                WriteByte(buffer, (byte) obj.Personality);
                 WriteByte(buffer, obj.SpeechFreq);
                 WriteByte(buffer, obj.BodyType);
                 WriteByte(buffer, obj.Hair);
@@ -234,7 +235,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 obj.Sex = ReadByte(buffer);
                 obj.Voice = ReadByte(buffer);
                 obj.VoicePitch = ReadUInt16(buffer);
-                obj.Personality = ReadByte(buffer);
+                obj.Personality = (PawnPersonality) ReadByte(buffer);
                 obj.SpeechFreq = ReadByte(buffer);
                 obj.BodyType = ReadByte(buffer);
                 obj.Hair = ReadByte(buffer);

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartnerPawnData.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartnerPawnData.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
@@ -6,7 +7,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
     {
         public uint PawnId { get; set; }
         public uint Likability { get; set; }
-        public byte Personality { get; set; }
+        public PawnPersonality Personality { get; set; }
 
         public class Serializer : EntitySerializer<CDataPartnerPawnData>
         {
@@ -14,7 +15,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             {
                 WriteUInt32(buffer, obj.PawnId);
                 WriteUInt32(buffer, obj.Likability);
-                WriteByte(buffer, obj.Personality);
+                WriteByte(buffer, (byte) obj.Personality);
             }
 
             public override CDataPartnerPawnData Read(IBuffer buffer)
@@ -22,7 +23,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 CDataPartnerPawnData obj = new CDataPartnerPawnData();
                 obj.PawnId = ReadUInt32(buffer);
                 obj.Likability = ReadUInt32(buffer);
-                obj.Personality = ReadByte(buffer);
+                obj.Personality = (PawnPersonality) ReadByte(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartnerPawnReward.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataPartnerPawnReward.cs
@@ -1,25 +1,26 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
     public class CDataPartnerPawnReward
     {
 
-        public byte Type { get; set; }
+        public PawnLikabilityRewardType Type { get; set; }
         public CDataPartnerPawnRewardParam Value { get; set; } = new();
 
         public class Serializer : EntitySerializer<CDataPartnerPawnReward>
         {
             public override void Write(IBuffer buffer, CDataPartnerPawnReward obj)
             {
-                WriteByte(buffer, obj.Type);
+                WriteByte(buffer, (byte) obj.Type);
                 WriteEntity<CDataPartnerPawnRewardParam>(buffer, obj.Value);
             }
 
             public override CDataPartnerPawnReward Read(IBuffer buffer)
             {
                 CDataPartnerPawnReward obj = new CDataPartnerPawnReward();
-                obj.Type = ReadByte(buffer);
+                obj.Type = (PawnLikabilityRewardType) ReadByte(buffer);
                 obj.Value = ReadEntity<CDataPartnerPawnRewardParam>(buffer);
                 return obj;
             }

--- a/Arrowgene.Ddon.Shared/Model/Character.cs
+++ b/Arrowgene.Ddon.Shared/Model/Character.cs
@@ -42,6 +42,8 @@ namespace Arrowgene.Ddon.Shared.Model
             EpitaphRoadState = new EpitaphRoadState();
             AreaRanks = new();
             AreaSupply = new();
+
+            PartnerTimerLockObj = new();
         }
 
         public int AccountId { get; set; }
@@ -109,6 +111,9 @@ namespace Arrowgene.Ddon.Shared.Model
         public byte[] BinaryData;
         public GameMode GameMode {  get; set; }
         public Dictionary<uint, uint> LastSeenLobby { get; set; }
+        public uint PartnerPawnId { get; set; }
+        public uint PartnerPawnAdventureTimerId { get; set; }
+        public object PartnerTimerLockObj { get; set; }
         public List<Pawn> Pawns { get; set; }
         public List<Pawn> RentedPawns {  get; set; }
         public uint FavWarpSlotNum { get; set; }

--- a/Arrowgene.Ddon.Shared/Model/EmoteId.cs
+++ b/Arrowgene.Ddon.Shared/Model/EmoteId.cs
@@ -1,0 +1,11 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum EmoteId : uint
+    {
+        ImHerePose1 = 45,
+        ImHerePose2 = 46,
+        ImHerePose3 = 47,
+        ImHerePose4 = 48,
+        OriginalPose2 = 69,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/HairStyleId.cs
+++ b/Arrowgene.Ddon.Shared/Model/HairStyleId.cs
@@ -1,0 +1,11 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum HairStyleId : uint
+    {
+        None = 0,
+        Ex1Men = 72,
+        Ex2Women = 73,
+        Ex3Women = 73,
+        Ex4Women = 73,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/PartnerPawnAffectionAction.cs
+++ b/Arrowgene.Ddon.Shared/Model/PartnerPawnAffectionAction.cs
@@ -1,0 +1,10 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum PartnerPawnAffectionAction : byte
+    {
+        None = 0,
+        Gift = 1,
+        Craft = 2,
+        Adventure = 3,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/PartnerPawnData.cs
+++ b/Arrowgene.Ddon.Shared/Model/PartnerPawnData.cs
@@ -1,0 +1,31 @@
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public class PartnerPawnData
+    {
+        public uint PawnId { get; set; }
+        public PawnPersonality Personality { get; set; }
+        public uint NumGifts { get; set; }
+        public uint NumCrafts { get; set; }
+        public uint NumAdventures { get; set; }
+
+        public uint CalculateLikability()
+        {
+            uint totalXP = (NumGifts * 20) + (NumCrafts * 20) + (NumAdventures * 10);
+            uint level = (totalXP < 65) ? 0 : (uint)Math.Sqrt((totalXP - 65) / 14.4);
+            return Math.Min(level, 25);  // Clamp 0 to 25
+        }
+
+        public CDataPartnerPawnData ToCDataPartnerPawnData()
+        {
+            return new CDataPartnerPawnData()
+            {
+                PawnId = PawnId,
+                Personality = Personality,
+                Likability = CalculateLikability()
+            };
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/PartnerPawnData.cs
+++ b/Arrowgene.Ddon.Shared/Model/PartnerPawnData.cs
@@ -6,7 +6,6 @@ namespace Arrowgene.Ddon.Shared.Model
     public class PartnerPawnData
     {
         public uint PawnId { get; set; }
-        public PawnPersonality Personality { get; set; }
         public uint NumGifts { get; set; }
         public uint NumCrafts { get; set; }
         public uint NumAdventures { get; set; }
@@ -18,12 +17,12 @@ namespace Arrowgene.Ddon.Shared.Model
             return Math.Min(level, 25);  // Clamp 0 to 25
         }
 
-        public CDataPartnerPawnData ToCDataPartnerPawnData()
+        public CDataPartnerPawnData ToCDataPartnerPawnData(Pawn pawn)
         {
             return new CDataPartnerPawnData()
             {
                 PawnId = PawnId,
-                Personality = Personality,
+                Personality = pawn.EditInfo.Personality,
                 Likability = CalculateLikability()
             };
         }

--- a/Arrowgene.Ddon.Shared/Model/PartnerReward.cs
+++ b/Arrowgene.Ddon.Shared/Model/PartnerReward.cs
@@ -1,0 +1,59 @@
+using Arrowgene.Ddon.Shared.Entity.Structure;
+
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public class PartnerReward
+    {
+        public static CDataPartnerPawnReward CreateEmoteReward(EmoteId emoteId)
+        {
+            return new CDataPartnerPawnReward()
+            {
+                Type = PawnLikabilityRewardType.Emotion,
+                Value = new CDataPartnerPawnRewardParam()
+                {
+                    ParamTypeId = 0,
+                    UID = (uint)emoteId
+                }
+            };
+        }
+
+        public static CDataPartnerPawnReward CreateAbilityReward(SecretAbility abilityId)
+        {
+            return new CDataPartnerPawnReward()
+            {
+                Type = PawnLikabilityRewardType.Ability,
+                Value = new CDataPartnerPawnRewardParam()
+                {
+                    ParamTypeId = 0,
+                    UID = (uint)abilityId
+                }
+            };
+        }
+
+        public static CDataPartnerPawnReward CreateCommunicationReward(uint communicationId)
+        {
+            return new CDataPartnerPawnReward()
+            {
+                Type = PawnLikabilityRewardType.Talk,
+                Value = new CDataPartnerPawnRewardParam()
+                {
+                    ParamTypeId = 0,
+                    UID = communicationId
+                }
+            };
+        }
+
+        public static CDataPartnerPawnReward CreateHairstyleReward(HairStyleId hairstyleId, uint unk0)
+        {
+            return new CDataPartnerPawnReward()
+            {
+                Type = PawnLikabilityRewardType.Hair,
+                Value = new CDataPartnerPawnRewardParam()
+                {
+                    ParamTypeId = unk0,
+                    UID = (uint) hairstyleId
+                }
+            };
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/PawnLikabilityRewardType.cs
+++ b/Arrowgene.Ddon.Shared/Model/PawnLikabilityRewardType.cs
@@ -1,0 +1,11 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum PawnLikabilityRewardType : uint
+    {
+        None = 0,
+        Hair = 1,
+        Talk = 2,
+        Emotion = 3,
+        Ability = 4,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/PawnPersonality.cs
+++ b/Arrowgene.Ddon.Shared/Model/PawnPersonality.cs
@@ -1,0 +1,15 @@
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum PawnPersonality : byte
+    {
+        None = 0,
+        Normal = 1,
+        Shy = 2,
+        Active = 3,
+        Smart = 4,
+        Cool = 5,
+        Pure = 6,
+        Wild = 7,
+        Sexy = 8,
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.Shared.Model.Scheduler
         SubstoryQuestRotation = 10,
         ExtremeMissionRewardUpdate = 11,
         PawnExpedition = 12,
-        PawnAffectionIncreaseInteraction = 13,
+        PawnAffectionIncreaseInteractionReset = 13,
         PawnTrainingExperiencePoints = 14,
         ClanDungeonReset = 15,
         MandragoraGrowth = 16,

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -1830,9 +1830,9 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_PARTNER_PAWN_PARTNER_PAWN_NEXT_PRESENT_TIME_GET_RES = new PacketId(53, 7, 2, "S2C_PARTNER_PAWN_PARTNER_PAWN_NEXT_PRESENT_TIME_GET_RES", ServerType.Game, PacketSource.Server); // 次に欠片を渡せるまでの時間(sec)を取得に
         public static readonly PacketId C2S_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_REQ = new PacketId(53, 8, 1, "C2S_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_RES = new PacketId(53, 8, 2, "S2C_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_RES", ServerType.Game, PacketSource.Server); // パートナーポーンにプレゼントに
-        public static readonly PacketId S2C_PARTNER_53_9_16_NTC = new PacketId(53, 9, 16, "S2C_PARTNER_53_9_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_PARTNER_PAWN_LIKABILITY_UP_NTC = new PacketId(53, 9, 16, "S2C_PARTNER_PAWN_LIKABILITY_UP_NTC", ServerType.Game, PacketSource.Server, "S2C_PARTNER_53_9_16_NTC");
 
-// Group: 54 - (CRAFT)
+        // Group: 54 - (CRAFT)
         public static readonly PacketId C2S_CRAFT_RECIPE_GET_CRAFT_RECIPE_REQ = new PacketId(54, 0, 1, "C2S_CRAFT_RECIPE_GET_CRAFT_RECIPE_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_CRAFT_RECIPE_GET_CRAFT_RECIPE_RES = new PacketId(54, 0, 2, "S2C_CRAFT_RECIPE_GET_CRAFT_RECIPE_RES", ServerType.Game, PacketSource.Server); // クラフト生産レシピ取得に
         public static readonly PacketId C2S_CRAFT_RECIPE_GET_CRAFT_RECIPE_DESIGNATE_REQ = new PacketId(54, 1, 1, "C2S_CRAFT_RECIPE_GET_CRAFT_RECIPE_DESIGNATE_REQ", ServerType.Game, PacketSource.Client);
@@ -3761,7 +3761,7 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_PARTNER_PAWN_PARTNER_PAWN_NEXT_PRESENT_TIME_GET_RES);
             AddPacketIdEntry(packetIds, C2S_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_REQ);
             AddPacketIdEntry(packetIds, S2C_PARTNER_PAWN_PRESENT_FOR_PARTNER_PAWN_RES);
-            AddPacketIdEntry(packetIds, S2C_PARTNER_53_9_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_PARTNER_PAWN_LIKABILITY_UP_NTC);
 
 // Group: 54 - (CRAFT)
             AddPacketIdEntry(packetIds, C2S_CRAFT_RECIPE_GET_CRAFT_RECIPE_REQ);

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -254,7 +254,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return true; }
         public bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null) { return true; }
         public bool InsertReleasedWarpPoint(uint characterId, ReleasedWarpPoint ReleasedWarpPoint) { return true; }
-        public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility) { return true; }
+        public bool InsertSecretAbilityUnlock(uint commonId, SecretAbility secretAbility, DbConnection? connectionIn = null) { return true; }
         public bool InsertShortcut(uint characterId, CDataShortCut shortcut) { return true; }
         public CraftProgress SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId) { return new CraftProgress(); }
         public bool InsertSpSkill(uint pawnId, JobId job, CDataSpSkill spSkill) { return true; }
@@ -445,6 +445,19 @@ namespace Arrowgene.Ddon.Test.Database
         public List<CDataRankingData> SelectRankingDataByCharacterId(uint characterId, uint questId, uint limit = 1000, DbConnection? connectionIn = null) { return new(); }
         public List<CDataRankingData> SelectRankingData(uint questId, uint limit = 1000, DbConnection? connectionIn = null) { return new(); }
         public bool DeleteAllRankRecords(DbConnection? connectionIn = null) { return true; }
+
+        public bool InsertPartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null) { return true; }
+        public bool UpdatePartnerPawnRecord(uint characterId, PartnerPawnData partnerPawnData, DbConnection? connectionIn = null) { return true; }
+        public PartnerPawnData GetPartnerPawnRecord(uint characterId, uint pawnId, DbConnection? connectionIn = null) { return new(); }
+        public bool SetPartnerPawn(uint characterId, uint pawnId, DbConnection? connectionIn = null) { return true; }
+
+        public bool InsertPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null) { return true; }
+        public bool HasPartnerPawnLastAffectionIncreaseRecord(uint characterId, uint pawnId, PartnerPawnAffectionAction action, DbConnection? connectionIn = null) { return true; }
+        public void DeleteAllPartnerPawnLastAffectionIncreaseRecords(DbConnection? connectionIn = null) { }
+
+        public HashSet<uint> GetPartnerPawnPendingRewards(uint characterId, uint pawnId, DbConnection? connectionIn = null) { return new(); }
+        public bool InsertPartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null) { return true; }
+        public void DeletePartnerPawnPendingReward(uint characterId, uint pawnId, uint rewardLevel, DbConnection? connectionIn = null) { }
 
         public void AddParameter(DbCommand command, string name, object? value, DbType type) { }
         public void AddParameter(DbCommand command, string name, string value) { }


### PR DESCRIPTION
- Player can now assign a partner pawn at the riftstone and the server will remember which pawn it is.
- All rewards besides achievements and recipes are obtainable.
- Player gets credit once per day for:
    - Delivering 2 Riftstone Shards to the pawn
    - Performing 1 craft with the pawn as the craft master
    - Adventuring with the pawn for 30 minutes.
- Reset occurs every day at 5:00am local server time.
- A new setting "PartnerPawnAdventureDurationInSeconds" has been added to configure the time in seconds it takes before the server considers enough time has passed to give the player credit.
- Added a new function PauseTimer to the timer manager.
- Added a new PartnerPawnManager class.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
