### PR TITLE
fix: Change order of packets in limit break

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/EquipEnhancedEnhanceItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EquipEnhancedEnhanceItemHandler.cs
@@ -77,6 +77,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 Server.Database.UpsertEquipmentLimitBreakRecord(client.Character.CharacterId, item.UId, newAddStatusParam, connection);
 
+                item.AddStatusParamList.Clear();
+                item.AddStatusParamList.Add(newAddStatusParam);
+                updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(client.Character, item, storageType, slotNo, 1, 1));
+                updateCharacterItemNtc.UpdateType = ItemNoticeType.GatherEquipItem;
+                packets.Enqueue(client, updateCharacterItemNtc);
+
                 packets.Enqueue(client, new S2CEquipEnhancedEnhanceItemRes()
                 {
                     Unk0 = request.UpgradeItemUID,
@@ -85,12 +91,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     Unk4 = 0,
                     Unk3 = 0,
                 });
-
-                item.AddStatusParamList.Clear();
-                item.AddStatusParamList.Add(newAddStatusParam);
-                updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(client.Character, item, storageType, slotNo, 1, 1));
-                updateCharacterItemNtc.UpdateType = ItemNoticeType.GatherEquipItem;
-                packets.Enqueue(client, updateCharacterItemNtc);
             });
 
             return packets;


### PR DESCRIPTION
Change the order of the item update packet to see if it improves UI on real servers.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
