### PR TITLE
fixes: Fixes for S2 Content

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300004.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300004.csx
@@ -31,7 +31,7 @@ public class ScriptedQuest : IQuest
     {
         var process0 = AddNewProcess(0);
         process0.AddNpcTalkAndOrderBlock(Stage.CraftRoom, NpcId.Craig0, 26396);
-        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.CraftRoom, false)
+        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.CraftRoom, false)
             .AddResultCmdTutorialDialog(TutorialId.UltimateSynthesisofArms)
             .AddAnnotation("TODO: Detect an ultimate synthesis has occurred");
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.CraftRoom, NpcId.Craig0, 26398);

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -1218,17 +1218,20 @@ namespace Arrowgene.Ddon.Shared.AssetReader
         {
             foreach (var jContentsReleaseId in jContentsReleaseList.EnumerateArray())
             {
-                if (!Enum.TryParse(jContentsReleaseId.GetProperty("type").GetString(), true, out ContentsRelease contentsReleaseId))
+                var unlock = new QuestUnlock();
+
+                unlock.ReleaseId = ContentsRelease.None;
+                if (jContentsReleaseId.TryGetProperty("type", out JsonElement jReleaseId))
                 {
-                    Logger.Error($"Unable to parse contents release element. Skipping.");
-                    return false;
+                    if (!Enum.TryParse(jReleaseId.GetString(), true, out ContentsRelease releaseId))
+                    {
+                        Logger.Error($"Unable to parse contents release element. Skipping.");
+                        return false;
+                    }
+                    unlock.ReleaseId = releaseId;
                 }
 
-                var unlock = new QuestUnlock()
-                {
-                    ReleaseId = contentsReleaseId
-                };
-
+                unlock.TutorialId = TutorialId.None;
                 if (jContentsReleaseId.TryGetProperty("tutorial_id", out JsonElement jTutorialId))
                 {
                     if (!Enum.TryParse(jTutorialId.GetString(), true, out TutorialId tutorialId))

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
@@ -117,7 +117,10 @@
                     "announce_type": "Update",
                     "stage_id": {
                         "id": 61
-                    }
+                    },
+                    "contents_release": [
+                        {"flag_info": "Lestania.TempleOfPurificationSouthChamber"}
+                    ]
                 },
                 {
                     "type": "TalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020050.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020050.json
@@ -249,6 +249,7 @@
                     "flags": [
                         {"type": "QstLayout", "action": "Clear", "value": 2741, "comment": "Spawns Gurdolin"}
                     ],
+                    "bgm_stop": true,
                     "npc_id": "Joseph",
                     "message_id": 15208
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020070.json
@@ -327,7 +327,8 @@
                     "stage_id": {
                         "id": 76
                     },
-                    "event_id": 25
+                    "event_id": 25,
+                    "bgm_stop": true
                 },
                 {
                     "type": "PartyGather",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020080.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020080.json
@@ -139,7 +139,8 @@
                     "stage_id": {
                         "id": 335
                     },
-                    "event_id": 25
+                    "event_id": 25,
+                    "bgm_stop": true
                 },
                 {
                     "type": "TalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020090.json
@@ -85,6 +85,9 @@
                     "message_id": 15327,
                     "flags": [
                         {"type": "QstLayout", "action": "Set", "value": 2770, "comment": "Spawns Gurdolin, Lise and Elliot"}
+                    ],
+                    "contents_release": [
+                        {"flag_info": "Lestania.KnightsDepotRuins"}
                     ]
                 },
                 {
@@ -121,11 +124,12 @@
                     "jump_stage_id": {
                         "id": 342
                     },
-                    "start_pos_no": 2
+                    "start_pos_no": 2,
+                    "bgm_stop": true
                 },
                 {
                     "type": "TalkToNpc",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 3
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020130.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020130.json
@@ -62,7 +62,7 @@
                     "exp": 197000,
                     "named_enemy_params_id": 942,
                     "is_boss": true,
-					"is_boss_bgm": true
+                    "is_boss_bgm": true
                 }
             ]
         }
@@ -164,7 +164,8 @@
                     "stage_id": {
                         "id": 361
                     },
-                    "event_id": 5
+                    "event_id": 5,
+                    "bgm_stop": true
                 },
                 {
                     "type": "PartyGather",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020150.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020150.json
@@ -199,7 +199,8 @@
                     "stage_id": {
                         "id": 372
                     },
-                    "event_id": 5
+                    "event_id": 5,
+                    "bgm_stop": true
                 },
                 {
                     "type": "PartyGather",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
@@ -91,7 +91,9 @@
                     ],
                     "contents_release": [
                         {
-                            "type": "None",
+                            "flag_info": "FaranaPlains.KingalCanyonBorderCheckpoint"
+                        },
+                        {
                             "flag_info": "KingalCanyon.GlyndwrGates"
                         }
                     ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
@@ -11,6 +11,9 @@
         {"type": "MinimumLevel", "Param1": 75},
         {"type": "MainQuestCompleted", "Param1": 20200}
     ],
+    "contents_release": [
+        {"flag_info": "TowerOfIvanos.QuestBoard"}
+    ],
     "rewards": [
         {
             "type": "exp",
@@ -242,7 +245,15 @@
                     "stage_id": {
                         "id": 371
                     },
-                    "event_id": 35
+                    "event_id": 35,
+                    "contents_release": [
+                        {"flag_info": "FaranaPlains.VegasaCorridorSouth"},
+                        {"flag_info": "MorrowForest.VegasaCorridorWest"},
+                        {"flag_info": "FaranaPlains.VegasaCorridorEast"}
+                    ],
+                    "result_commands": [
+                        {"type": "RefreshOmKeyDisp"}
+                    ]
                 },
                 {
                     "type": "DiscoverEnemy",
@@ -343,8 +354,14 @@
                     "type": "Raw",
                     "announce_type": "Update",
                     "checkpoint": true,
+                    "contents_release": [
+                        {"flag_info": "HollowOfBeginnings.HollowOfBeginningsGatheringArea"}
+                    ],
                     "check_commands": [
                         {"type": "IsReleaseWarpPointAnyone", "Param1": 21}
+                    ],
+                    "result_commands": [
+                        {"type": "RefreshOmKeyDisp"}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020220.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020220.json
@@ -261,6 +261,12 @@
                     "groups": [ 0 ],
                     "flags": [
                         {"type": "QstLayout", "action": "Set", "value": 4967, "comment": "Spawns plants and poison mist"}
+                    ],
+                    "contents_release": [
+                        {"flag_info": "HollowOfBeginnings.ValtableHall"}
+                    ],
+                    "result_commands": [
+                        {"type": "RefreshOmKeyDisp"}
                     ]
                 },
                 {
@@ -345,7 +351,8 @@
                     "event_id": 5,
                     "flags": [
                         {"type": "QstLayout", "action": "Clear", "value": 4509, "comment": "Blockade, poison"}
-                    ]
+                    ],
+                    "bgm_stop": true
                 },
                 {
                     "type": "NewTalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020230.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020230.json
@@ -162,7 +162,8 @@
                     "stage_id": {
                         "id": 373
                     },
-                    "event_id": 5
+                    "event_id": 5,
+                    "bgm_stop": true
                 },
                 {
                     "type": "PartyGather",
@@ -236,6 +237,7 @@
                         "id": 382
                     },
                     "event_id": 20,
+                    "bgm_stop": true,
                     "flags": [
                         {"type": "QstLayout", "action": "Clear", "value": 4212, "comment": "Walls"},
                         {"type": "QstLayout", "action": "Clear", "value": 4059, "comment": "Battle NPCs"},

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020240.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020240.json
@@ -233,7 +233,10 @@
                     "checkpoint": true,
                     "stage_id": {
                         "id": 386
-                    }
+                    },
+                    "contents_release": [
+                        {"flag_info": "ValtableHall.ValtableHallUpperArea"}
+                    ]
                 },
                 {
                     "type": "PartyGather",

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
@@ -249,6 +249,16 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Allows the player to enter Mergoda Security District when set
             /// </summary>
             public static QuestFlagInfo MergodaSecurityDistrict { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(5187, QuestId.Q70034001);
+
+            /// <summary>
+            /// Allows the player to enter the Knights' Depot Ruins when set
+            /// </summary>
+            public static QuestFlagInfo KnightsDepotRuins { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(1545, QuestId.Q70021001);
+
+            /// <summary>
+            /// Allows the player to enter "Temple of Purification: South Chamber" when set
+            /// </summary>
+            public static QuestFlagInfo TempleOfPurificationSouthChamber { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(926, QuestId.Q70000001);
         }
 
         public static class GardnoxFortress0
@@ -354,6 +364,16 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Opens the gates around Dana when set.
             /// </summary>
             public static QuestFlagInfo DanaGate { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(1698, QuestId.Q70022001);
+
+            /// <summary>
+            /// Unlocks the "Kingal Canyon Border Checkpoint" when set (from Dana to Glyndwr)
+            /// </summary>
+            public static QuestFlagInfo KingalCanyonBorderCheckpoint { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(1703, QuestId.Q70023001);
+
+            /// <summary>
+            /// Unlocks the southern "Vegasa Corridor" entrance when set
+            /// </summary>
+            public static QuestFlagInfo VegasaCorridorSouth { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(1997, QuestId.Q70022001);
         }
 
         public static class MorrowForest
@@ -364,6 +384,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Opens the Western Gate in Morfaul when set
             /// </summary>
             public static QuestFlagInfo MorfaulWestGate { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(1999, QuestId.Q70022001);
+
+            /// <summary>
+            /// Unlocks the western "Vegasa Corridor" entrance when set
+            /// Morrow Forest
+            /// </summary>
+            public static QuestFlagInfo VegasaCorridorWest { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2402, QuestId.Q70022001);
         }
 
         public static class MorfaulChiefsHome
@@ -394,6 +420,43 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Unlocks "Shadolean Great Temple" when set (st0439).
             /// </summary>
             public static QuestFlagInfo ShadoleanGreatTemple { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(5184, QuestId.Q70034001);
+
+            /// <summary>
+            /// Unlocks the eastern "Vegasa Corridor" entrance when set
+            /// Kingal Canyon
+            /// </summary>
+            public static QuestFlagInfo VegasaCorridorEast { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2400, QuestId.Q70022001);
+        }
+
+        public static class TowerOfIvanos
+        {
+            private static StageInfo StageInfo = Stage.TowerofIvanos;
+
+            /// <summary>
+            /// Unlocks the quest board in the Tower of Ivanos when set.
+            /// </summary>
+            public static QuestFlagInfo QuestBoard { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2246, QuestId.Q70023001);
+        }
+
+        public static class HollowOfBeginnings
+        {
+            /// <summary>
+            /// Unlocks "Hollow Of Beginnings GatheringArea" in Stage.HollowofBeginnings0 when set.
+            /// </summary>
+            public static QuestFlagInfo HollowOfBeginningsGatheringArea { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2182, QuestId.Q70023001);
+
+            /// <summary>
+            /// Unlocks "Valtable Hall" in Stage.HollowofBeginnings0 when set
+            /// </summary>
+            public static QuestFlagInfo ValtableHall { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2183, QuestId.Q70023001);
+        }
+
+        public static class ValtableHall
+        {
+            /// <summary>
+            /// Unlocks "Valtable Hall Upper Area" when set.
+            /// </summary>
+            public static QuestFlagInfo ValtableHallUpperArea { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2184, QuestId.Q70023001);
         }
 
         public static class RathniteFoothills


### PR DESCRIPTION
- q60300004.csx: Fixed infinite repeat
- Fixed an issue where the BGM plays after the fight ends until you logged out
- Unlocked the TowerOfIvanos.QuestBoard at the correct time
- Unlocked the following areas 
  - Lestania.TempleOfPurificationSouthChamber
  - Lestania.KnightsDepotRuins
  - FaranaPlains.KingalCanyonBorderCheckpoint
  - FaranaPlains.VegasaCorridorSouth
  - MorrowForest.VegasaCorridorWest
  - FaranaPlains.VegasaCorridorEast
  - HollowOfBeginnings.HollowOfBeginningsGatheringArea
  - HollowOfBeginnings.ValtableHall
  - ValtableHall.ValtableHallUpperArea

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
