### PR TITLE
fix: Fix a typo in area unlock

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
@@ -249,7 +249,7 @@
                     "contents_release": [
                         {"flag_info": "FaranaPlains.VegasaCorridorSouth"},
                         {"flag_info": "MorrowForest.VegasaCorridorWest"},
-                        {"flag_info": "FaranaPlains.VegasaCorridorEast"}
+                        {"flag_info": "KingalCanyon.VegasaCorridorEast"}
                     ],
                     "result_commands": [
                         {"type": "RefreshOmKeyDisp"}


### PR DESCRIPTION
Fixed an issue where the unlock flag had the wrong area.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
