### PR TITLE
Feature: Pawn Rental Restrictions

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 67;
+    public const uint Version = 68;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/pawn_share_range_migration.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/pawn_share_range_migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ddon_pawn"
+ADD COLUMN share_range SMALLINT NOT NULL DEFAULT 1;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS "ddon_pawn"
     "consumable_quantity_level"   INTEGER                           NOT NULL,
     "cost_performance_level"      INTEGER                           NOT NULL,
     "is_official_pawn"            BOOLEAN                           NOT NULL,
+    "share_range"                 SMALLINT                          NOT NULL DEFAULT 1,
     CONSTRAINT "fk_ddon_pawn_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_pawn_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -123,6 +123,7 @@ public interface IDatabase
     bool UpdatePawnBaseInfo(Pawn pawn, DbConnection? connectionIn = null);
     uint GetPawnOwnerCharacterId(uint pawnId, DbConnection? connectionIn = null);
     bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null);
+    bool UpdatePawnShareRange(uint pawnId, byte shareRange);
 
     // Pawn Training Status
     bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -16,7 +16,7 @@ public partial class DdonSqlDb : SqlDb
         @"SELECT * FROM ddon_pawn WHERE is_official_pawn=true;";
 
     private const string SqlSelectAllPlayerPawns =
-        @"SELECT * FROM ddon_pawn WHERE is_official_pawn=false LIMIT @limit;";
+        @"SELECT * FROM ddon_pawn WHERE is_official_pawn=false AND share_range < 5 LIMIT @limit;";
 
     private const string SqlSelectPawnOwnerId =
         "SELECT * FROM ddon_pawn WHERE \"pawn_id\" = @pawn_id;";

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -58,6 +58,14 @@ public partial class DdonSqlDb : SqlDb
         	)
         WHERE
         	ddon_pawn.character_id != @character_id
+            AND ddon_pawn.share_range < 5
+            AND NOT (ddon_pawn.share_range = 2 AND (contact.status IS NULL OR contact.status != 2))
+            AND NOT (ddon_pawn.share_range = 3 AND (clan.clan_id IS NULL OR clan.clan_id != @clan_id))
+            AND NOT (
+                    ddon_pawn.share_range = 4 
+                    AND (contact.status IS NULL OR contact.status != 2)
+                    AND (clan.clan_id IS NULL OR clan.clan_id != @clan_id)
+                )
         	AND (
         		@dont_filter_by_owner_name
         		OR (
@@ -114,7 +122,8 @@ public partial class DdonSqlDb : SqlDb
         "equipment_quality_level",
         "consumable_quantity_level",
         "cost_performance_level",
-        "is_official_pawn"
+        "is_official_pawn",
+        "share_range"
     };
 
     protected static readonly string[] CDataPawnReactionFields = new[]
@@ -144,6 +153,11 @@ public partial class DdonSqlDb : SqlDb
     private static readonly string SqlUpdatePawnReaction =
         $"UPDATE \"ddon_pawn_reaction\" SET {BuildQueryUpdate(CDataPawnReactionFields)} WHERE \"pawn_id\" = @pawn_id AND \"reaction_type\"=@reaction_type;";
 
+    private static readonly string SqlUpdatePawnShareRange =
+        "UPDATE \"ddon_pawn\" SET \"share_range\"=@share_range WHERE \"pawn_id\"=@pawn_id;";
+
+    private static readonly string SqlSelectPawnShareRangeByPawnId =
+        "SELECT \"share_range\" FROM \"ddon_pawn\" WHERE \"pawn_id\" = @pawn_id;";
     private static readonly string SqlSelectPawnReactionByPawnId =
         $"SELECT {BuildQueryField(CDataPawnReactionFields)} FROM \"ddon_pawn_reaction\" WHERE \"pawn_id\" = @pawn_id;";
 
@@ -463,6 +477,16 @@ public partial class DdonSqlDb : SqlDb
 
         ExecuteReader(
             conn,
+            SqlSelectPawnShareRangeByPawnId,
+            command => { AddParameter(command, "@pawn_id", pawn.PawnId); },
+            reader =>
+            {
+                if (reader.Read()) pawn.ShareRange = GetByte(reader, "share_range");
+            }
+        );
+
+        ExecuteReader(
+            conn,
             SqlSelectPawnReactionByPawnId,
             command => { AddParameter(command, "@pawn_id", pawn.PawnId); },
             reader =>
@@ -703,6 +727,20 @@ public partial class DdonSqlDb : SqlDb
             connection,
             SqlUpdatePawnReaction,
             command => { AddParameter(command, pawnId, pawnReaction); }
+        ) == 1;
+    }
+
+    public override bool UpdatePawnShareRange(uint pawnId, byte shareRange)
+    {
+        using DbConnection connection = OpenNewConnection();
+        return ExecuteNonQuery(
+            connection,
+            SqlUpdatePawnShareRange,
+            command =>
+            {
+                AddParameter(command, "@pawn_id", pawnId);
+                AddParameter(command, "@share_range", shareRange);
+            }
         ) == 1;
     }
 

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -819,6 +819,7 @@ public partial class DdonSqlDb : SqlDb
         AddParameter(command, "@training_points", pawn.TrainingPoints);
         AddParameter(command, "@available_training", pawn.AvailableTraining);
         AddParameter(command, "@is_official_pawn", false);
+        AddParameter(command, "@share_range", pawn.ShareRange);
 
         AddParameter(command, "@craft_exp", pawn.CraftData.CraftExp);
         AddParameter(command, "@craft_rank", pawn.CraftData.CraftRank);

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000068_PawnShareRange.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000068_PawnShareRange.cs
@@ -1,0 +1,19 @@
+using System.Data.Common;
+using System.IO;
+using System.Text;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class PawnShareRangeMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 67;
+        public uint To => 68;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/pawn_share_range_migration.sql");
+            db.Execute(conn, adaptedSchema);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -376,6 +376,7 @@ public abstract class SqlDb : IDatabase
     public abstract List<CDataRegisterdPawnList> SelectRegisteredPawns(Character searchingCharacter, CDataPawnSearchParameter searchParams, DbConnection? connectionIn = null);
     public abstract bool DeletePawn(uint pawnId, DbConnection? connectionIn = null);
     public abstract bool UpdatePawnBaseInfo(Pawn pawn, DbConnection? connectionIn = null);
+    public abstract bool UpdatePawnShareRange(uint pawnId, byte shareRange);
     public abstract uint GetPawnOwnerCharacterId(uint pawnId, DbConnection? connectionIn = null);
     public abstract bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null);
     public abstract bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -614,6 +614,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new PawnJoinPartyRentedPawnHandler(this));
             AddHandler(new PawnReturnRentedPawnHandler(this));
             AddHandler(new PawnUpdatePawnReactionListHandler(this));
+            AddHandler(new PawnUpdatePawnShareRangeHandler(this));
             AddHandler(new PawnGetFavoritePawnListHandler(this));
             AddHandler(new PawnSetFavoritePawnHandler(this));
             AddHandler(new PawnDeleteFavoritePawnHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
@@ -86,6 +86,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ExtendedParams = new CDataOrbGainExtendParam(),
                 Server = client.Character.Server,
                 PartnerPawnData = new PartnerPawnData(),
+                ShareRange = request.PawnInfo.ShareRange,
                 CraftData = new CDataPawnCraftData
                 {
                     CraftExp = 0,

--- a/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnGetMyPawnListHandler.cs
@@ -37,7 +37,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         PawnCraftSkillList = pawn.CraftData.PawnCraftSkillList,
                         // TODO: CommentSize, LatestReturnDate
                     },
-                    // TODO: ShareRange, Unk0, Unk1, Unk2
+                    ShareRange = pawn.ShareRange,
+                    // TODO: Unk0, Unk1, Unk2
                 };
                 res.PawnList.Add(pawnListData);
             }

--- a/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
@@ -1,0 +1,37 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PawnUpdatePawnShareRangeHandler : GameRequestPacketHandler<C2SPawnUpdatePawnShareRangeReq, S2CPawnUpdatePawnShareRangeRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnUpdatePawnShareRangeHandler));
+
+        public PawnUpdatePawnShareRangeHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CPawnUpdatePawnShareRangeRes Handle(GameClient client, C2SPawnUpdatePawnShareRangeReq request)
+        {
+            Pawn pawn = client.Character.Pawns.Find(x => x.PawnId == request.PawnId)
+                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_INVALID);
+
+            //TODO: Actually update the pawn's share range in the database
+            // pawn.ShareRange = request.ShareRange;
+            // Server.Database.ExecuteInTransaction(conn =>
+            // {
+            //     Server.Database.UpdatePawnShareRange(request.PawnId, request.ShareRange, conn);
+            // });
+
+            var res = new S2CPawnUpdatePawnShareRangeRes()
+            {
+                PawnId = request.PawnId,
+                ShareRange = request.ShareRange
+            };
+
+            return res;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
@@ -18,9 +18,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             Pawn pawn = client.Character.Pawns.Find(x => x.PawnId == request.PawnId)
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_INVALID);
 
-            //TODO: Actually update the pawn's share range in the database
             pawn.ShareRange = request.ShareRange;
 
+            Server.Database.UpdatePawnShareRange(pawn.PawnId, pawn.ShareRange);
             var res = new S2CPawnUpdatePawnShareRangeRes()
             {
                 PawnId = request.PawnId,

--- a/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnShareRangeHandler.cs
@@ -19,11 +19,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_INVALID);
 
             //TODO: Actually update the pawn's share range in the database
-            // pawn.ShareRange = request.ShareRange;
-            // Server.Database.ExecuteInTransaction(conn =>
-            // {
-            //     Server.Database.UpdatePawnShareRange(request.PawnId, request.ShareRange, conn);
-            // });
+            pawn.ShareRange = request.ShareRange;
 
             var res = new S2CPawnUpdatePawnShareRangeRes()
             {

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -915,6 +915,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SPawnTrainingGetTrainingStatusReq.Serializer());
             Create(new C2SPawnTrainingSetTrainingStatusReq.Serializer());
             Create(new C2SPawnUpdatePawnReactionListReq.Serializer());
+            Create(new C2SPawnUpdatePawnShareRangeReq.Serializer());
             Create(new C2SPawnGetRentedPawnListReq.Serializer());
 
             Create(new C2SPhotoPhotoTakeNtc.Serializer());
@@ -1619,6 +1620,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CPawnTrainingSetTrainingStatusRes.Serializer());
             Create(new S2CPawnUpdatePawnReactionListNtc.Serializer());
             Create(new S2CPawnUpdatePawnReactionListRes.Serializer());
+            Create(new S2CPawnUpdatePawnShareRangeRes.Serializer());
             Create(new S2CPawnUpdateRentalPawnAdventureCountNtc.Serializer());
 
             Create(new S2CProfileGetAvailableBackgroundListRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnUpdatePawnShareRangeReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnUpdatePawnShareRangeReq.cs
@@ -1,0 +1,36 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPawnUpdatePawnShareRangeReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PAWN_UPDATE_PAWN_SHARE_RANGE_REQ;
+
+        public C2SPawnUpdatePawnShareRangeReq()
+        {
+        }
+
+        public uint PawnId { get; set; }
+        public byte ShareRange { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SPawnUpdatePawnShareRangeReq>
+        {
+            public override void Write(IBuffer buffer, C2SPawnUpdatePawnShareRangeReq obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteByte(buffer, obj.ShareRange);
+            }
+
+            public override C2SPawnUpdatePawnShareRangeReq Read(IBuffer buffer)
+            {
+                C2SPawnUpdatePawnShareRangeReq obj = new C2SPawnUpdatePawnShareRangeReq();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.ShareRange = ReadByte(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnShareRangeRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnShareRangeRes.cs
@@ -1,0 +1,34 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPawnUpdatePawnShareRangeRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PAWN_UPDATE_PAWN_SHARE_RANGE_RES;
+
+        public S2CPawnUpdatePawnShareRangeRes()
+        {
+        }
+
+        public uint PawnId { get; set; }
+        public byte ShareRange { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPawnUpdatePawnShareRangeRes>
+        {
+            public override void Write(IBuffer buffer, S2CPawnUpdatePawnShareRangeRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CPawnUpdatePawnShareRangeRes Read(IBuffer buffer)
+            {
+                S2CPawnUpdatePawnShareRangeRes obj = new S2CPawnUpdatePawnShareRangeRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -36,7 +36,6 @@ namespace Arrowgene.Ddon.Shared.Model
             IsRented = false;
             PawnState = PawnState.None;
             PartnerPawnData = new();
-            ShareRange = 1;
         }
         
         public Pawn(uint ownerCharacterId) : this()

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -36,6 +36,7 @@ namespace Arrowgene.Ddon.Shared.Model
             IsRented = false;
             PawnState = PawnState.None;
             PartnerPawnData = new();
+            ShareRange = 1;
         }
         
         public Pawn(uint ownerCharacterId) : this()
@@ -66,7 +67,7 @@ namespace Arrowgene.Ddon.Shared.Model
         public uint TrainingPoints { get; set; } // Training xp?
         public uint AvailableTraining { get; set; } // Training lv?
         public PartnerPawnData PartnerPawnData { get; set; }
-
+        public byte ShareRange { get; set; }
         public bool IsOfficialPawn {  get; set; }
         public bool IsRented {  get; set; }
         public PawnState PawnState { get; set; }
@@ -152,7 +153,7 @@ namespace Arrowgene.Ddon.Shared.Model
                     AbilityCostMax = BASE_ABILITY_COST_AMOUNT + extendParams.AbilityCost,
                     ExtendParam = extendParams,
                     PawnType = PawnType,
-                    ShareRange = 1,
+                    ShareRange = ShareRange,
                     Likability = PartnerPawnData.NumGifts,
                     TrainingStatus = TrainingStatus.GetValueOrDefault(Job, new byte[64]),
                     PawnTrainingProfile = new() { 

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -365,6 +365,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool UpdateNormalSkillParam(uint commonId, JobId job, uint skillNo, CDataNormalSkillParam normalSkillParam) { return true; }
         public bool UpdatePawnBaseInfo(Pawn pawn, DbConnection? connectionIn = null) { return true; }
         public bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool UpdatePawnShareRange(uint pawnId, byte shareRange) { return true; }
         public bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null) { return true; }
         public bool ReplacePawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null) { return true; }
         public bool InsertPawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null) { return true; }


### PR DESCRIPTION
This adds in functionality for pawn rental restrictions. (internally referred to as "Share Range") Players will be able to set their pawns to:

- Private (database value: 5)
- Friends/Clan (4)
- Clan (3)
- Friends (2)
- Anyone (1)

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
