### PR TITLE
S3 Result command definitions and name changes

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -3857,10 +3857,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.QstTalkChgFsm, Param01 = (int) npcId, Param02 = msgNo, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Sets invincibility on a substory enemy group. param02=1 sets invincible. */
-            public static CDataQuestCommand SetSubstoryEnemyInvincible(int enemyGroupFlag, int invincible, int param03 = 0, int param04 = 0)
+            /** @brief Sets or clears a global enemy aggression flag. Has additional functionality depending on param02. */
+            public static CDataQuestCommand SetEnemyAggroFlag(int type, int param02, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetSubstoryEnemyInvincible, Param01 = enemyGroupFlag, Param02 = invincible, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetEnemyAggroFlag, Param01 = type, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Duplicate of SetRandom. */

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -3833,22 +3833,22 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.AddSubstoryProgress, Param01 = substoryId, Param02 = progressDelta, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Triggers a substory event sequence. Checks mode; if mode==0xb fires substory FSM transition. */
-            public static CDataQuestCommand TriggerSubstoryEvent(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Triggers a substory progress update sequence. Checks mode; if mode==0xb fires substory FSM transition and sends C2S_QUEST_ADD_PACKAGE_QUEST_POINT_REQ. */
+            public static CDataQuestCommand UpdateSubstoryProgress(int progressDelta, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.TriggerSubstoryEvent, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.UpdateSubstoryProgress, Param01 = progressDelta, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Triggers display of the substory UI element. No command params used; value read from baked quest context. */
-            public static CDataQuestCommand EnableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            public static CDataQuestCommand EnableSubstoryGauge(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EnableSubstoryUIElement, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EnableSubstoryGauge, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Disables the substory UI element (+0x44 reference cleared). */
-            public static CDataQuestCommand DisableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            public static CDataQuestCommand DisableSubstoryGauge(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.DisableSubstoryUIElement, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.DisableSubstoryGauge, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Redirects NPC talk for a substory context via FUN_009ce930(param01, param02). */
@@ -3863,88 +3863,88 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetSubstoryEnemyInvincible, Param01 = enemyGroupFlag, Param02 = invincible, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Adds an NPC to the FSM talk NPC list. Validates FSM mode first. */
-            public static CDataQuestCommand AddFsmTalkNpc(int npcId, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Duplicate of SetRandom. */
+            public static CDataQuestCommand SetRandom2(int randomNo, int minValue, int maxValue, int resultValue)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.AddFsmTalkNpc, Param01 = npcId, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetRandom2, Param01 = randomNo, Param02 = minValue, Param03 = maxValue, Param04 = resultValue };
             }
 
-            /** @brief Displays an achievement banner from a given category. Only category 6 (Great Purpose) has banners to display. */
-            public static CDataQuestCommand AchievementBanner(int categoryNo, int bannerNo, int param03 = 0, int param04 = 0)
+            /** @brief Looks up a table for Great Purpose (category 6) entries (1-16) and forwards parameters to an announce display function if it finds a match. */
+            public static CDataQuestCommand CallGreatPurpose(int categoryNo, int purposeNo, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.AchievementBanner, Param01 = categoryNo, Param02 = bannerNo, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.CallGreatPurpose, Param01 = categoryNo, Param02 = purposeNo, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Enables substory element variant B. Sets +0x4c reference via FUN_00598860. */
-            public static CDataQuestCommand EnableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Enables text boxes for substory cutscenes. Sets +0x4c reference via FUN_00598860. */
+            public static CDataQuestCommand EnableSubstoryTextBox(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EnableSubstoryElementB, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EnableSubstoryTextBox, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Disables substory element variant B. Clears +0x4c reference via FUN_005986A0. */
-            public static CDataQuestCommand DisableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Disables text boxes for substory cutscenes. Clears +0x4c reference via FUN_005986A0. */
+            public static CDataQuestCommand DisableSubstoryTextBox(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.DisableSubstoryElementB, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.DisableSubstoryTextBox, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Overrides lighting and clouds on current map. Effects are purely visual and not persistent. */
-            public static CDataQuestCommand SetEnvironmentalEffect(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            public static CDataQuestCommand SetCustomWeather(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetEnvironmentalEffect, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetCustomWeather, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Resets environmental effects set by SetEnvironmentalEffect. */
-            public static CDataQuestCommand ResetEnvironmentalEffect(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Resets environmental effects set by SetCustomWeather. */
+            public static CDataQuestCommand ResetCustomWeather(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.ResetEnvironmentalEffect, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.ResetCustomWeather, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Schedules an FSM NPC behavior by calling FUN_009d1a60(scheduleId). scheduleId = param04. */
-            public static CDataQuestCommand SetFsmNpcSchedule(int param01 = 0, int param02 = 0, int param03 = 0, int scheduleId = 0)
+            /** @brief Duplicate of LayoutFlagRandomOn. */
+            public static CDataQuestCommand LayoutFlagRandomOn2(int flagNo1, int flagNo2, int flagNo3, int resultNo)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetFsmNpcSchedule, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = scheduleId };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.LayoutFlagRandomOn2, Param01 = flagNo1, Param02 = flagNo2, Param03 = flagNo3, Param04 = resultNo };
             }
 
-            /** @brief Sets the level of a quest enemy group (type 3) via FUN_00bc0670. Phase-gated. */
-            public static CDataQuestCommand SetQuestEnemyLevel(uint stageNo, int groupNo, int setNo, int level)
+            /** @brief Increases a breakable object's hit counter, lowering its current HP. Only works for OMs 503136 and 503143, does nothing otherwise. */
+            public static CDataQuestCommand SetOmHitCount(uint stageNo, int groupNo, int setNo, int count)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestEnemyLevel, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = level };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetOmHitCount, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = count };
             }
 
-            /** @brief Area-aware variant of SetQuestEnemyLevel using FUN_00a41890. */
-            public static CDataQuestCommand SetQuestEnemyLevelEx(uint stageNo, int groupNo, int setNo, int level)
+            /** @brief Quest object variant of SetOmHitCount. */
+            public static CDataQuestCommand SetQuestOmHitCount(uint stageNo, int groupNo, int setNo, int count)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestEnemyLevelEx, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = level };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestOmHitCount, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = count };
             }
 
-            /** @brief Sets the danger tier (bits 23-21) of a quest enemy group via FUN_00bc0720. Phase-gated. */
-            public static CDataQuestCommand SetQuestEnemyTierUp(uint stageNo, int groupNo, int setNo, int tier)
+            /** @brief Sets the danger tier of a breakable object and restores its health to full. Only works for OMs 503136 and 503143, does nothing otherwise. */
+            public static CDataQuestCommand SetOmTierUp(uint stageNo, int groupNo, int setNo, int tier)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestEnemyTierUp, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = tier };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetOmTierUp, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = tier };
             }
 
-            /** @brief Area-aware variant of SetQuestEnemyTierUp. */
-            public static CDataQuestCommand SetQuestEnemyTierUpEx(uint stageNo, int groupNo, int setNo, int tier)
+            /** @brief Quest object variant of SetOmTierUp. */
+            public static CDataQuestCommand SetQuestOmTierUp(uint stageNo, int groupNo, int setNo, int tier)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestEnemyTierUpEx, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = tier };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestOmTierUp, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = tier };
             }
 
-            /** @brief Sets a body/stance pose (1-6) on a quest NPC/enemy via FUN_00bbf670. */
-            public static CDataQuestCommand SetQuestOmMontageFix(uint stageNo, int groupNo, int setNo, int montagueNo)
+            /** @brief Sets a body/stance pose (1-6) on a NPC/enemy via FUN_00bbf670. */
+            public static CDataQuestCommand SetOmState(uint stageNo, int groupNo, int setNo, int state)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestOmMontageFix, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = montagueNo };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetOmState, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = state };
             }
 
-            /** @brief Area-aware variant of AddResultCmdSetQuestOmMontageFix. */
-            public static CDataQuestCommand SetQuestOmMontageFixEx(uint stageNo, int groupNo, int setNo, int montagueNo)
+            /** @brief Quest object variant of SetOmState. */
+            public static CDataQuestCommand SetQuestOmState(uint stageNo, int groupNo, int setNo, int state)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestOmMontageFixEx, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = montagueNo };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestOmState, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = state };
             }
 
-            /** @brief Sets the level of a layout enemy (type 2) by queuing it into a critical-section-guarded buffer. */
-            public static CDataQuestCommand SetQuestLayoutEnemyLevel(uint stageNo, int groupNo, int setNo, int level)
+            /** @brief Sets the named param of an enemy by queuing it into a critical-section-guarded buffer. */
+            public static CDataQuestCommand SetNamedEnemyParam(uint stageNo, int groupNo, int setNo, int param)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetQuestLayoutEnemyLevel, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = level };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetNamedEnemyParam, Param01 = (int)stageNo, Param02 = groupNo, Param03 = setNo, Param04 = param };
             }
 
             /** @brief Removes an FSM NPC entry from the process list via FUN_0063dda0(param01). */
@@ -3953,16 +3953,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.RemoveFsmNpcFromSchedule, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Controls enemy expedition state. mode=2: starts; mode=3: iterates party members and fires expedition signal. */
-            public static CDataQuestCommand SetEnemyExpeditionState(int mode, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Controls magma OM state. Phase 2 = resets floor magma level. Phase 3 = makes magma rise and fill the map based on state. */
+            public static CDataQuestCommand SetMagmaState (int phase, int state, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetEnemyExpeditionState, Param01 = mode, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetMagmaState, Param01 = phase, Param02 = state, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Fires a substory ending sequence: calls FUN_00be9960, FUN_00b85670, and sends messages 0x25f/0x260. */
-            public static CDataQuestCommand TriggerSubstoryEndSequence(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Fires a chain dungeon ending sequence: calls FUN_00be9960, FUN_00b85670, and sends messages 0x25f/0x260. */
+            public static CDataQuestCommand TriggerDarkDungeonEndSequence(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.TriggerSubstoryEndSequence, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.TriggerDarkDungeonEndSequence, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Sends packet 63.5.16 (C2S_CHAIN_DUNGEON_END_CHAIN_NTC) kickstarting the rewards phase of chain dungeons. */

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2839,10 +2839,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsTimerNotElapsed, Param01 = timerNo, Param02 = sec, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief S3-only: checks if the contents mode elapsed timer >= timeSec. */
-            public static CDataQuestCommand IsContentsModeTimerNotLess(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks how long magma has been rising on the current map (param01 >= timeSec). Requires cpOmRisingMagma to be present on the map. */
+            public static CDataQuestCommand RisingMagmaTime(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsContentsModeTimerNotLess, Param01 = timeSec, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.RisingMagmaTime, Param01 = timeSec, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Fire-once trigger: reads and clears a byte flag at DAT_021af4f4+0xEEA. Returns 1 if flag was set. */

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2653,10 +2653,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             // Ghidra-discovered check commands (IDs 211–256)
 
-            /** @brief Returns bit 18 of the substory state word at ctx+0x5c+0x20c. */
-            public static CDataQuestCommand IsSubstoryStateBit18(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks if the player's party has disbanded (notice bit 18). */
+            public static CDataQuestCommand IsPartyDisbanded(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsSubstoryStateBit18, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsPartyDisbanded, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Side-effect writer: reads bit 17 of ctx+0x5c+0x20c, inverts it, stores to DAT_021c06b8+0x263. No quest params. */
@@ -3971,10 +3971,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EndChain, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Controls pawn expedition. mode=1: starts; mode=2: stops. */
-            public static CDataQuestCommand SetPawnExpeditionFlag(int mode, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Activates a player's bonus dragon abilities if they meet the threshold. Gated by type. */
+            public static CDataQuestCommand GetDragonAbility(int type, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SetPawnExpeditionFlag, Param01 = mode, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.GetDragonAbility, Param01 = type, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Sets a body/pose mode on a layout enemy (type 2) via FUN_005be380(poseId). */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -938,10 +938,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsContentsModeTimerNotLess(this QuestBlock questBlock, int timeSec, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdRisingMagmaTime(this QuestBlock questBlock, int timeSec, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsContentsModeTimerNotLess(timeSec);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdRisingMagmaTime(timeSec);
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -721,10 +721,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
 
         // Ghidra-discovered check commands (IDs 211–256)
 
-        public static QuestBlock AddCheckCmdIsSubstoryStateBit18(this QuestBlock questBlock, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdIsPartyDisbanded(this QuestBlock questBlock, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsSubstoryStateBit18();
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsPartyDisbanded();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
@@ -452,9 +452,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetPawnExpeditionFlag(this QuestBlock questBlock, int mode)
+        public static QuestBlock AddResultCmdGetDragonAbility(this QuestBlock questBlock, int type)
         {
-            questBlock.ResultCommands.AddResultCmdSetPawnExpeditionFlag(mode);
+            questBlock.ResultCommands.AddResultCmdGetDragonAbility(type);
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
@@ -338,9 +338,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetSubstoryEnemyInvincible(this QuestBlock questBlock, int enemyGroupFlag, int invincible)
+        public static QuestBlock AddResultCmdSetEnemyAggroFlag(this QuestBlock questBlock, int type, int param02)
         {
-            questBlock.ResultCommands.AddResultCmdSetSubstoryEnemyInvincible(enemyGroupFlag, invincible);
+            questBlock.ResultCommands.AddResultCmdSetEnemyAggroFlag(type, param02);
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
@@ -314,21 +314,21 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdTriggerSubstoryEvent(this QuestBlock questBlock, int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+        public static QuestBlock AddResultCmdUpdateSubstoryProgress(this QuestBlock questBlock, int progressDelta, int param02 = 0, int param03 = 0, int param04 = 0)
         {
-            questBlock.ResultCommands.AddResultCmdTriggerSubstoryEvent(param01, param02, param03, param04);
+            questBlock.ResultCommands.AddResultCmdUpdateSubstoryProgress(progressDelta, param02, param03, param04);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdEnableSubstoryUIElement(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdEnableSubstoryGauge(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdEnableSubstoryUIElement();
+            questBlock.ResultCommands.AddResultCmdEnableSubstoryGauge();
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdDisableSubstoryUIElement(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdDisableSubstoryGauge(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdDisableSubstoryUIElement();
+            questBlock.ResultCommands.AddResultCmdDisableSubstoryGauge();
             return questBlock;
         }
 
@@ -344,87 +344,87 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdAddFsmTalkNpc(this QuestBlock questBlock, int npcId)
+        public static QuestBlock AddResultCmdSetRandom2(this QuestBlock questBlock, int randomNo, int minValue, int maxValue)
         {
-            questBlock.ResultCommands.AddResultCmdAddFsmTalkNpc(npcId);
+            questBlock.ResultCommands.AddResultCmdSetRandom2(randomNo, minValue, maxValue);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdAchievementBanner(this QuestBlock questBlock, int categoryNo, int bannerNo)
+        public static QuestBlock AddResultCmdCallGreatPurpose(this QuestBlock questBlock, int categoryNo, int purposeNo)
         {
-            questBlock.ResultCommands.AddResultCmdAchievementBanner(categoryNo, bannerNo);
+            questBlock.ResultCommands.AddResultCmdCallGreatPurpose(categoryNo, purposeNo);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdEnableSubstoryElementB(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdEnableSubstoryTextBox(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdEnableSubstoryElementB();
+            questBlock.ResultCommands.AddResultCmdEnableSubstoryTextBox();
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdDisableSubstoryElementB(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdDisableSubstoryTextBox(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdDisableSubstoryElementB();
+            questBlock.ResultCommands.AddResultCmdDisableSubstoryTextBox();
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetEnvironmentalEffect(this QuestBlock questBlock, int param01 = 0, int param02 = 0)
+        public static QuestBlock AddResultCmdSetCustomWeather(this QuestBlock questBlock, int param01 = 0, int param02 = 0)
         {
-            questBlock.ResultCommands.AddResultCmdSetEnvironmentalEffect(param01, param02);
+            questBlock.ResultCommands.AddResultCmdSetCustomWeather(param01, param02);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdResetEnvironmentalEffect(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdResetCustomWeather(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdResetEnvironmentalEffect();
+            questBlock.ResultCommands.AddResultCmdResetCustomWeather();
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetFsmNpcSchedule(this QuestBlock questBlock, int scheduleId)
+        public static QuestBlock AddResultCmdLayoutFlagRandomOn2(this QuestBlock questBlock, int flagNo1, int flagNo2, int flagNo3)
         {
-            questBlock.ResultCommands.AddResultCmdSetFsmNpcSchedule(scheduleId);
+            questBlock.ResultCommands.AddResultCmdLayoutFlagRandomOn2(flagNo1, flagNo2, flagNo3);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestEnemyLevel(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static QuestBlock AddResultCmdSetOmHitCount(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int count)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestEnemyLevel(stageInfo, groupNo, setNo, level);
+            questBlock.ResultCommands.AddResultCmdSetOmHitCount(stageInfo, groupNo, setNo, count);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestEnemyLevelEx(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static QuestBlock AddResultCmdSetQuestOmHitCount(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int count)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestEnemyLevelEx(stageInfo, groupNo, setNo, level);
+            questBlock.ResultCommands.AddResultCmdSetQuestOmHitCount(stageInfo, groupNo, setNo, count);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestEnemyTierUp(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int tier)
+        public static QuestBlock AddResultCmdSetOmTierUp(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int tier)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestEnemyTierUp(stageInfo, groupNo, setNo, tier);
+            questBlock.ResultCommands.AddResultCmdSetOmTierUp(stageInfo, groupNo, setNo, tier);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestEnemyTierUpEx(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int tier)
+        public static QuestBlock AddResultCmdSetQuestOmTierUp(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int tier)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestEnemyTierUpEx(stageInfo, groupNo, setNo, tier);
+            questBlock.ResultCommands.AddResultCmdSetQuestOmTierUp(stageInfo, groupNo, setNo, tier);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestOmMontageFix(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int montagueNo)
+        public static QuestBlock AddResultCmdSetOmState(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int state)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestOmMontageFix(stageInfo, groupNo, setNo, montagueNo);
+            questBlock.ResultCommands.AddResultCmdSetOmState(stageInfo, groupNo, setNo, state);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestOmMontageFixEx(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int montagueNo)
+        public static QuestBlock AddResultCmdSetQuestOmState(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int state)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestOmMontageFixEx(stageInfo, groupNo, setNo, montagueNo);
+            questBlock.ResultCommands.AddResultCmdSetQuestOmState(stageInfo, groupNo, setNo, state);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetQuestLayoutEnemyLevel(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static QuestBlock AddResultCmdSetNamedEnemyParam(this QuestBlock questBlock, StageInfo stageInfo, int groupNo, int setNo, int param)
         {
-            questBlock.ResultCommands.AddResultCmdSetQuestLayoutEnemyLevel(stageInfo, groupNo, setNo, level);
+            questBlock.ResultCommands.AddResultCmdSetNamedEnemyParam(stageInfo, groupNo, setNo, param);
             return questBlock;
         }
 
@@ -434,15 +434,15 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdSetEnemyExpeditionState(this QuestBlock questBlock, int mode)
+        public static QuestBlock AddResultCmdSetMagmaState(this QuestBlock questBlock, int phase, int state)
         {
-            questBlock.ResultCommands.AddResultCmdSetEnemyExpeditionState(mode);
+            questBlock.ResultCommands.AddResultCmdSetMagmaState(phase, state);
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdTriggerSubstoryEndSequence(this QuestBlock questBlock)
+        public static QuestBlock AddResultCmdTriggerDarkDungeonEndSequence(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdTriggerSubstoryEndSequence();
+            questBlock.ResultCommands.AddResultCmdTriggerDarkDungeonEndSequence();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -846,9 +846,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsContentsModeTimerNotLess(this List<CDataQuestCommand> checkCommands, int timeSec)
+        public static List<CDataQuestCommand> AddCheckCmdRisingMagmaTime(this List<CDataQuestCommand> checkCommands, int timeSec)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsContentsModeTimerNotLess(timeSec));
+            checkCommands.Add(QuestManager.CheckCommand.RisingMagmaTime(timeSec));
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -660,9 +660,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
 
         // Ghidra-discovered check commands (IDs 211–256)
 
-        public static List<CDataQuestCommand> AddCheckCmdIsSubstoryStateBit18(this List<CDataQuestCommand> checkCommands)
+        public static List<CDataQuestCommand> AddCheckCmdIsPartyDisbanded(this List<CDataQuestCommand> checkCommands)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsSubstoryStateBit18());
+            checkCommands.Add(QuestManager.CheckCommand.IsPartyDisbanded());
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
@@ -455,9 +455,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetPawnExpeditionFlag(this List<CDataQuestCommand> resultCommands, int mode)
+        public static List<CDataQuestCommand> AddResultCmdGetDragonAbility(this List<CDataQuestCommand> resultCommands, int type)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetPawnExpeditionFlag(mode));
+            resultCommands.Add(QuestManager.ResultCommand.GetDragonAbility(type));
             return resultCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
@@ -317,21 +317,21 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdTriggerSubstoryEvent(this List<CDataQuestCommand> resultCommands, int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+        public static List<CDataQuestCommand> AddResultCmdUpdateSubstoryProgress(this List<CDataQuestCommand> resultCommands, int progressDelta, int param02 = 0, int param03 = 0, int param04 = 0)
         {
-            resultCommands.Add(QuestManager.ResultCommand.TriggerSubstoryEvent(param01, param02, param03, param04));
+            resultCommands.Add(QuestManager.ResultCommand.UpdateSubstoryProgress(progressDelta, param02, param03, param04));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdEnableSubstoryUIElement(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdEnableSubstoryGauge(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.EnableSubstoryUIElement());
+            resultCommands.Add(QuestManager.ResultCommand.EnableSubstoryGauge());
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdDisableSubstoryUIElement(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdDisableSubstoryGauge(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.DisableSubstoryUIElement());
+            resultCommands.Add(QuestManager.ResultCommand.DisableSubstoryGauge());
             return resultCommands;
         }
 
@@ -347,87 +347,87 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdAddFsmTalkNpc(this List<CDataQuestCommand> resultCommands, int npcId)
+        public static List<CDataQuestCommand> AddResultCmdSetRandom2(this List<CDataQuestCommand> resultCommands, int randomNo, int minValue, int maxValue)
         {
-            resultCommands.Add(QuestManager.ResultCommand.AddFsmTalkNpc(npcId));
+            resultCommands.Add(QuestManager.ResultCommand.SetRandom2(randomNo, minValue, maxValue, resultValue: 0));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdAchievementBanner(this List<CDataQuestCommand> resultCommands, int categoryNo, int bannerNo)
+        public static List<CDataQuestCommand> AddResultCmdCallGreatPurpose(this List<CDataQuestCommand> resultCommands, int categoryNo, int purposeNo)
         {
-            resultCommands.Add(QuestManager.ResultCommand.AchievementBanner(categoryNo, bannerNo));
+            resultCommands.Add(QuestManager.ResultCommand.CallGreatPurpose(categoryNo, purposeNo));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdEnableSubstoryElementB(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdEnableSubstoryTextBox(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.EnableSubstoryElementB());
+            resultCommands.Add(QuestManager.ResultCommand.EnableSubstoryTextBox());
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdDisableSubstoryElementB(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdDisableSubstoryTextBox(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.DisableSubstoryElementB());
+            resultCommands.Add(QuestManager.ResultCommand.DisableSubstoryTextBox());
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetEnvironmentalEffect(this List<CDataQuestCommand> resultCommands, int param01 = 0, int param02 = 0)
+        public static List<CDataQuestCommand> AddResultCmdSetCustomWeather(this List<CDataQuestCommand> resultCommands, int param01 = 0, int param02 = 0)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetEnvironmentalEffect(param01, param02));
+            resultCommands.Add(QuestManager.ResultCommand.SetCustomWeather(param01, param02));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdResetEnvironmentalEffect(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdResetCustomWeather(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.ResetEnvironmentalEffect());
+            resultCommands.Add(QuestManager.ResultCommand.ResetCustomWeather());
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetFsmNpcSchedule(this List<CDataQuestCommand> resultCommands, int scheduleId)
+        public static List<CDataQuestCommand> AddResultCmdLayoutFlagRandomOn2(this List<CDataQuestCommand> resultCommands, int flagNo1, int flagNo2, int flagNo3)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetFsmNpcSchedule(scheduleId: scheduleId));
+            resultCommands.Add(QuestManager.ResultCommand.LayoutFlagRandomOn2(flagNo1, flagNo2, flagNo3, resultNo: 0));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestEnemyLevel(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static List<CDataQuestCommand> AddResultCmdSetOmHitCount(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int count)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestEnemyLevel(stageInfo.StageNo, groupNo, setNo, level));
+            resultCommands.Add(QuestManager.ResultCommand.SetOmHitCount(stageInfo.StageNo, groupNo, setNo, count));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestEnemyLevelEx(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static List<CDataQuestCommand> AddResultCmdSetQuestOmHitCount(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int count)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestEnemyLevelEx(stageInfo.StageNo, groupNo, setNo, level));
+            resultCommands.Add(QuestManager.ResultCommand.SetQuestOmHitCount(stageInfo.StageNo, groupNo, setNo, count));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestEnemyTierUp(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int tier)
+        public static List<CDataQuestCommand> AddResultCmdSetOmTierUp(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int tier)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestEnemyTierUp(stageInfo.StageNo, groupNo, setNo, tier));
+            resultCommands.Add(QuestManager.ResultCommand.SetOmTierUp(stageInfo.StageNo, groupNo, setNo, tier));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestEnemyTierUpEx(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int tier)
+        public static List<CDataQuestCommand> AddResultCmdSetQuestOmTierUp(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int tier)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestEnemyTierUpEx(stageInfo.StageNo, groupNo, setNo, tier));
+            resultCommands.Add(QuestManager.ResultCommand.SetQuestOmTierUp(stageInfo.StageNo, groupNo, setNo, tier));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestOmMontageFix(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int montagueNo)
+        public static List<CDataQuestCommand> AddResultCmdSetOmState(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int state)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestOmMontageFix(stageInfo.StageNo, groupNo, setNo, montagueNo));
+            resultCommands.Add(QuestManager.ResultCommand.SetOmState(stageInfo.StageNo, groupNo, setNo, state));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestOmMontageFixEx(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int montagueNo)
+        public static List<CDataQuestCommand> AddResultCmdSetQuestOmState(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int state)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestOmMontageFixEx(stageInfo.StageNo, groupNo, setNo, montagueNo));
+            resultCommands.Add(QuestManager.ResultCommand.SetQuestOmState(stageInfo.StageNo, groupNo, setNo, state));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetQuestLayoutEnemyLevel(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int level)
+        public static List<CDataQuestCommand> AddResultCmdSetNamedEnemyParam(this List<CDataQuestCommand> resultCommands, StageInfo stageInfo, int groupNo, int setNo, int param)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetQuestLayoutEnemyLevel(stageInfo.StageNo, groupNo, setNo, level));
+            resultCommands.Add(QuestManager.ResultCommand.SetNamedEnemyParam(stageInfo.StageNo, groupNo, setNo, param));
             return resultCommands;
         }
 
@@ -437,15 +437,15 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetEnemyExpeditionState(this List<CDataQuestCommand> resultCommands, int mode)
+        public static List<CDataQuestCommand> AddResultCmdSetMagmaState(this List<CDataQuestCommand> resultCommands, int phase, int state)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetEnemyExpeditionState(mode));
+            resultCommands.Add(QuestManager.ResultCommand.SetMagmaState(phase, state));
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdTriggerSubstoryEndSequence(this List<CDataQuestCommand> resultCommands)
+        public static List<CDataQuestCommand> AddResultCmdTriggerDarkDungeonEndSequence(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.TriggerSubstoryEndSequence());
+            resultCommands.Add(QuestManager.ResultCommand.TriggerDarkDungeonEndSequence());
             return resultCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
@@ -341,9 +341,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdSetSubstoryEnemyInvincible(this List<CDataQuestCommand> resultCommands, int enemyGroupFlag, int invincible)
+        public static List<CDataQuestCommand> AddResultCmdSetEnemyAggroFlag(this List<CDataQuestCommand> resultCommands, int type, int param02)
         {
-            resultCommands.Add(QuestManager.ResultCommand.SetSubstoryEnemyInvincible(enemyGroupFlag, invincible));
+            resultCommands.Add(QuestManager.ResultCommand.SetEnemyAggroFlag(type, param02));
             return resultCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -404,7 +404,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                                 x.Command != (ushort)QuestResultCommand.SetAnnounce &&
                                 x.Command != (ushort)QuestResultCommand.CallGeneralAnnounce &&
                                 x.Command != (ushort)QuestResultCommand.PlayMessage &&
-                                x.Command != (ushort)QuestResultCommand.AchievementBanner &&
+                                x.Command != (ushort)QuestResultCommand.CallGreatPurpose &&
                                 x.Command != (ushort)QuestResultCommand.HandItem &&
                                 x.Command != (ushort)QuestResultCommand.PushImteToPlBag)
                     .ToList();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300022.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300022.csx
@@ -51,7 +51,7 @@ public class ScriptedQuest : IQuest
             ]);
         process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
             .AddResultCmdQstTalkChg(NpcId.Morgan, 28291) // Don't lose context on checkpoint
-            .AddResultCmdAchievementBanner(6, 10)
+            .AddResultCmdCallGreatPurpose(6, 10)
             .AddCheckCommands([
                 QuestManager.CheckCommand.StageNo(1150)
             ])

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300032.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300032.csx
@@ -79,7 +79,7 @@ public class ScriptedQuest : IQuest
             ]);
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel2, 37);
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.FortressCityMegadoResidentialLevel2, 0, 0, NpcId.Navid, 28723)
-			.AddResultCmdSetEnvironmentalEffect(12, 1)
+			.AddResultCmdSetCustomWeather(12, 1)
 			.AddResultCmdQstTalkChg(NpcId.Ennis, 28722)
 			.AddResultCmdQstLayoutFlagOn(7612);
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.MarquiseKurtsresidence1, 0);
@@ -89,7 +89,7 @@ public class ScriptedQuest : IQuest
 			.AddResultCmdQstLayoutFlagOn(7613);
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.MarquiseKurtsresidence1, 3);
         process0.AddRawBlock(QuestAnnounceType.Update)
-			.AddResultCmdSetEnvironmentalEffect(21, 1)
+			.AddResultCmdSetCustomWeather(21, 1)
 			.AddResultCmdQstLayoutFlagOff(7613)
 			.AddResultCmdQstLayoutFlagOn(7741)
 			.AddResultCmdQstLayoutFlagOn(7742)
@@ -121,7 +121,7 @@ public class ScriptedQuest : IQuest
 			.AddResultCmdQstLayoutFlagOn(7707);
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel3, 40);
         process0.AddRawBlock(QuestAnnounceType.Update)
-			.AddResultCmdSetEnvironmentalEffect(21, 1)
+			.AddResultCmdSetCustomWeather(21, 1)
 			.AddResultCmdQstLayoutFlagOff(7707)
 			.AddResultCmdQstLayoutFlagOn(7744)
 			.AddCheckCmdSceHitIn(Stage.FortressCityMegadoResidentialLevel3, 15);
@@ -138,7 +138,7 @@ public class ScriptedQuest : IQuest
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel1, 18);
         process0.AddProcessEndBlock(true)
             .AddResultCmdReleaseAnnounce(ContentsRelease.CooperatorsoftheRoyalFamily, TutorialId.ExposetheDarkSidetotheOneOperatingbehindtheScenesMephis)
-			.AddResultCmdAchievementBanner(6, 11);
+			.AddResultCmdCallGreatPurpose(6, 11);
 
         var process1 = AddNewProcess(1);
         process1.AddRawBlock(QuestAnnounceType.None)

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60321010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60321010.csx
@@ -161,7 +161,7 @@ public class ScriptedQuest : IQuest
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FirefallMountainCampsite, NpcId.Bacias, 30163)
             .AddResultCmdQstLayoutFlagOff(8032);
         process0.AddProcessEndBlock(true)
-            .AddResultCmdAchievementBanner(6, 13);
+            .AddResultCmdCallGreatPurpose(6, 13);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60321011.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60321011.csx
@@ -59,7 +59,7 @@ public class ScriptedQuest : IQuest
         process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8295, resetGroup: false);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FirefallMountainCampsite, NpcId.Bacias, 30178);
         process0.AddProcessEndBlock(true)
-            .AddResultCmdAchievementBanner(6, 13); // Should display the achievement name this time, but how?
+            .AddResultCmdCallGreatPurpose(6, 13); // Should display the achievement name this time, but how?
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400006.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400006.csx
@@ -1,0 +1,131 @@
+/**
+ * @brief Power that Destroys Reason
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.ExtremeMission;
+    public override QuestId QuestId => (QuestId)50400006;
+    public override ushort RecommendedLevel => 100;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    protected override void InitializeState()
+    {
+        MissionParams.Group = ExtremeMissionUtils.Group.Travers;
+        MissionParams.MinimumMembers = 1;
+        MissionParams.MaximumMembers = 4;
+        MissionParams.IsSolo = false;
+        MissionParams.PlaytimeInSeconds = 900;
+        MissionParams.ArmorAllowed = true;
+        MissionParams.JewelryAllowed = true;
+        MissionParams.MaxPawns = 3;
+
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheFateOfAll));
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(100));
+    }
+
+	// TODO: Add rewards
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 0);
+        AddWalletReward(WalletType.Gold, 0);
+        AddWalletReward(WalletType.RiftPoints, 0);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.NorthLandofDarkness, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlackDragon1stForm1, 100, 0, 0)
+                .SetIsBoss(true),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.NorthLandofDarkness, 3, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlackDragon2ndForm, 100, 0, 0)
+                .SetStartThinkTblNo(6)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.DragonCrystalOfDestructionShootsLaserRocks, 100, 0, 1)
+				.SetStartThinkTblNo(1)
+                .SetIsManualSet(true)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.DragonCrystalOfDestructionSucksYouInWithMagic0, 100, 0, 2)
+				.SetStartThinkTblNo(2)
+                .SetIsManualSet(true)
+                .SetIsRequired(false),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsGatherPartyInStage(3400)
+            ]);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 0)
+            .AddResultCommands([
+                QuestManager.ResultCommand.StartMissionAnnounce(2, 0), // List sticks to memory, so clear it
+                QuestManager.ResultCommand.StartMissionAnnounce(2, 2), // (2, 1) can populate the list, but how to do it properly? Handler?
+                QuestManager.ResultCommand.AddEndContentsPurpose(0, 1),
+                QuestManager.ResultCommand.SetDiePlayerReturnPos(3400, 0, 0),
+                QuestManager.ResultCommand.StartContentsTimer(900),
+                QuestManager.ResultCommand.GetDragonAbility(1) // Dragon protection
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsLinkageEnemyFlag(3400, 1, 0, 1)
+            ]);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1)
+            .AddResultCommands([
+                QuestManager.ResultCommand.QstLayoutFlagOn(8764)
+            ]);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCommands([
+                QuestManager.ResultCommand.EventExec(3400, 20, 0, 0)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.EventEnd(3400, 20)
+            ]);
+        process0.AddRawBlock(QuestAnnounceType.None) // TODO: Timer needs to stop ticking here
+            .AddResultCommands([
+                QuestManager.ResultCommand.UpdateAnnounceDirect(1, 3),
+                QuestManager.ResultCommand.RemoveEndContentsPurpose(0),
+                QuestManager.ResultCommand.AddEndContentsPurpose(1, 1),
+                QuestManager.ResultCommand.QstLayoutFlagOn(8671),
+                QuestManager.ResultCommand.GetDragonAbility(2), // Dragon blessing
+                QuestManager.ResultCommand.Prt(3400, 760, 0, -3010)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.Prt(3400, 760, 0, -3010)
+            ]);
+        process0.AddProcessEndBlock(true);
+
+        // Phase transition
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsMyquestLayoutFlagOn(8764)
+            ]);
+        process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 0)
+            .AddResultCommands([
+                QuestManager.ResultCommand.StartTimer(1, 20)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsEndTimer(1)
+            ]);
+        process1.AddProcessEndBlock(false)
+            .AddResultCommands([
+                QuestManager.ResultCommand.QstLayoutFlagOff(8764)
+            ]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400008.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400008.csx
@@ -265,14 +265,14 @@ public class ScriptedQuest : IQuest
             ])
             .AddResultCommands([
                 QuestManager.ResultCommand.CallGeneralAnnounce (0, 100770),
-                QuestManager.ResultCommand.SetQuestOmMontageFix(3110, 160, 0, 2),
+                QuestManager.ResultCommand.SetOmState(3110, 160, 0, 2),
                 QuestManager.ResultCommand.QstLayoutFlagOff (8686),
                 QuestManager.ResultCommand.QstLayoutFlagOn (8687)
             ]);
         process3.AddRawBlock(QuestAnnounceType.None)
             .AddResultCommands([
                 QuestManager.ResultCommand.CallGeneralAnnounce (0, 100770),
-                QuestManager.ResultCommand.SetQuestOmMontageFix(3110, 161, 0, 2),
+                QuestManager.ResultCommand.SetOmState(3110, 161, 0, 2),
                 QuestManager.ResultCommand.QstLayoutFlagOff (8688),
                 QuestManager.ResultCommand.QstLayoutFlagOn (8689)
             ])

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300030.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300030.csx
@@ -34,7 +34,7 @@ public class ScriptedQuest : IQuest
         process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.FortThinesGreatDiningHall)
             .AddResultCmdQstTalkChg(NpcId.Zeki, 25938);
         process0.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.FortThinesGreatDiningHall, NpcId.Carrie2, 25939)
-            .AddResultCmdSetQuestOmMontageFix(Stage.FortThinesGreatDiningHall, 0, 0, 0)
+            .AddResultCmdSetOmState(Stage.FortThinesGreatDiningHall, 0, 0, 0)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6412);
         process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
             .AddResultCmdQstTalkChg(NpcId.Carrie2, 25940)
@@ -49,14 +49,14 @@ public class ScriptedQuest : IQuest
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortThinesGreatDiningHall, NpcId.Carrie2, 27028)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6955)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 6412)
-            .AddResultCmdSetQuestOmMontageFix(Stage.FortThinesGreatDiningHall, 1, 0, 0);
+            .AddResultCmdSetOmState(Stage.FortThinesGreatDiningHall, 1, 0, 0);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortThines1, NpcId.Zeki, 26064)
             .AddResultCmdQstTalkChg(NpcId.Carrie2, 26065);
         process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 6955)
             .AddQuestFlag(QuestFlagAction.Set, QuestFlags.FortThinesGreatDiningHall.Carrie)
             .AddResultCmdReleaseAnnounce(ContentsRelease.CooperatorsoftheRoyalFamily)
-            .AddResultCommand(QuestManager.ResultCommand.Unknown(106, 6, 3))
+			.AddResultCmdCallGreatPurpose(6, 3)
             .AddCheckCommands([
                 QuestManager.CheckCommand.TutorialTalkNpc(448, NpcId.Carrie2)
             ])
@@ -64,9 +64,8 @@ public class ScriptedQuest : IQuest
                 QuestManager.CheckCommand.TouchActToNpc(448, NpcId.Carrie2),
                 QuestManager.CheckCommand.DummyNotProgress()
             ]);
-        process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.FortThinesGreatDiningHall, false)
+        process0.AddProcessEndBlock(true)
             .AddResultCmdReleaseAnnounce(ContentsRelease.None, TutorialId.AchievementsRoyalFamilyRestoration);
-        process0.AddProcessEndBlock(true);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300102.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300102.csx
@@ -77,7 +77,7 @@ public class ScriptedQuest : IQuest
             .AddResultCmdTutorialDialog(TutorialId.NPCEscortsFoodGauge)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6746);
         process0.AddRawBlock(QuestAnnounceType.None)
-            .AddResultCmdEnableSubstoryUIElement()
+            .AddResultCmdEnableSubstoryGauge()
             .AddCheckCmdMyQstFlagOnFromFsm(3646)
             .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3645);
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RathniteFoothills, 1, 0, NpcId.Carrie2, 26282);
@@ -94,7 +94,7 @@ public class ScriptedQuest : IQuest
             .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3649);
         process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.FortThinesGreatDiningHall, 2);
         process0.AddTalkToNpcBlock(QuestAnnounceType.Update, Stage.FortThinesGreatDiningHall, NpcId.Carrie2, 26158)
-            .AddResultCmdDisableSubstoryUIElement()
+            .AddResultCmdDisableSubstoryGauge()
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 6747);
         process0.AddNoProgressBlock();
         process0.AddProcessEndBlock(true);

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/18_rathnite_foothills/q60318010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/18_rathnite_foothills/q60318010.csx
@@ -115,7 +115,7 @@ public class ScriptedQuest : IQuest
         process0.AddTalkToNpcBlock(QuestAnnounceType.Update, Stage.BerthasBanditGroupHideout, NpcId.Joaquim, 25363);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.RathniteFoothillsLakeside0, NpcId.Victor, 25365);
         process0.AddProcessEndBlock(true)
-			.AddResultCmdAchievementBanner(6, 1);
+			.AddResultCmdCallGreatPurpose(6, 1);
 
 		var process1 = AddNewProcess(1);
 		process1.AddRawBlock(QuestAnnounceType.None)

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319010.csx
@@ -64,7 +64,7 @@ public class ScriptedQuest : IQuest
         process0.AddProcessEndBlock(true)
 			.AddResultCommands([
 				QuestManager.ResultCommand.WorldManageLayoutFlagOn(1216, 70000001),
-				QuestManager.ResultCommand.AchievementBanner(6, 5)
+				QuestManager.ResultCommand.CallGreatPurpose(6, 5)
 			]);
 
 		// Branch 1 - Gerald

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320010.csx
@@ -129,7 +129,7 @@ public class ScriptedQuest : IQuest
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7484);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel1, NpcId.Doris, 28279);
         process0.AddProcessEndBlock(true)
-            .AddResultCmdAchievementBanner(6, 9)
+            .AddResultCmdCallGreatPurpose(6, 9)
             .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.FlamesOfDarkness);
     }
 }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -225,9 +225,9 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         // @note Parameter names are inferred from decompilation and may not match original source.
 
         /// <summary>
-        /// Returns bit 18 of the substory state word at this→substory+0x20c (field offset 0x5c+0x20c from cQuestProcess base).
+        /// Checks if the player's party has disbanded (notice bit 18).
         /// </summary>
-        IsSubstoryStateBit18 = 211, // 0x00635A00 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        IsPartyDisbanded = 211, // 0x00635A00 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Reads bit 17 (0x20000) of *(ctx+0x5c)+0x20c, inverts it, and stores the boolean result into the global

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -444,10 +444,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         IsTimerNotElapsed = 245, // 0x00637250 (cQuestProcess* this, s32 timerNo, s32 sec, s32 param03, s32 param04_unused)
 
         /// <summary>
-        /// S3-only: checks if the contents mode elapsed timer (FUN_00bc15d0) >= timeSec.
-        /// Guards on season-phase pointer at DAT_0220456c+0x9f4.
+        /// Checks how long magma has been rising on the current map. Requires cpOmRisingMagma to be present on the map.
+        /// Magma starts rising after result command SetMagmaState is used with phase = 3, which starts a counter.
+        /// This counter, and magma height, increases by 1/sec once started. Check passes when param01 >= counter.
+        /// Can be used as a time or height comparison depending on how you look at it.
         /// </summary>
-        IsContentsModeTimerNotLess = 246, // 0x00637320 (cQuestProcess* this, s32 timeSec, s32 param02, s32 param03, s32 param04)
+        RisingMagmaTime = 246, // 0x00637320 (cQuestProcess* this, s32 timeSec, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Fire-once trigger: reads byte at DAT_021af4f4+0xEEA. If == 1, clears it and returns 1; otherwise returns 0.

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -118,18 +118,21 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Only param01 (delta) is used: positive advances progress, negative regresses it, zero is a no-op.
         /// Sends packet 0x117 (increase) or 0x118 (decrease) to update the UI, then FUN_00bd3280 to
         /// report old and new progress ratios to the client.
+        /// Possibly made obsolete by UpdateSubstoryProgress.
         /// </summary>
         SubstoryProgress = 99, // 0x00633730 (cQuestProcess* this, s32 delta, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
         /// <summary>
         /// Finds a substory entry by substoryId and adds progressDelta to its progress value, clamped to [0,100].
+        /// Does not seem to work?
         /// </summary>
         AddSubstoryProgress = 100, // 0x006338E0 (cQuestProcess* this, s32 substoryId, s32 progressDelta, s32 param03, s32 param04)
 
         /// <summary>
-        /// Triggers a substory event sequence. Checks mode via FUN_009cffc0; if mode==0xb fires FUN_00bdee50 and FUN_00598590.
+        /// Triggers a substory progress update sequence. Checks mode via FUN_009cffc0; if mode==0xb fires FUN_00bdee50 and FUN_00598590.
+        /// Sends packet C2S_QUEST_ADD_PACKAGE_QUEST_POINT_REQ with schedule ID and progress value, then plays an UI animation updating mission progress.
         /// </summary>
-        TriggerSubstoryEvent = 101, // 0x00633920 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        UpdateSubstoryProgress = 101, // 0x00633920 (cQuestProcess* this, s32 progressDelta, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Triggers display of the substory UI element by writing a value from quest state into the substory
@@ -140,12 +143,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Chain: FUN_009cff50 (read ctx+0x228) → FUN_00bdee50(0xb) (get substory obj) →
         ///        FUN_005986d0 (write +0x44) → FUN_00a34da0 (reset state-machine dispatch ptr).
         /// </summary>
-        EnableSubstoryUIElement = 102, // 0x006339B0 (cQuestProcess* this, s32 param01_unused, s32 param02_unused, s32 param03_unused, s32 param04_unused)
+        EnableSubstoryGauge = 102, // 0x006339B0 (cQuestProcess* this, s32 param01_unused, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
         /// <summary>
         /// Disables the substory UI element. Calls FUN_00bdee50(0xb) then FUN_00598670 which clears the +0x44 reference.
         /// </summary>
-        DisableSubstoryUIElement = 103, // 0x00633A00 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        DisableSubstoryGauge = 103, // 0x00633A00 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Redirects NPC talk for a substory context. Calls FUN_009cff50 then FUN_009ce930(param01, param02).
@@ -164,78 +167,83 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Adds an NPC to the FSM talk NPC list at this+0x94/0xa0. Validates FSM mode via FUN_009d07f0 first.
         /// Uses param01 as npcId/groupId.
         /// </summary>
-        AddFsmTalkNpc = 107, // 0x00633B30 (cQuestProcess* this, s32 npcId, s32 param02, s32 param03, s32 param04)
+        SetRandom2 = 107, // 0x00633B30 (cQuestProcess* this, s32 randomNo, s32 minValue, s32 maxValue, s32 resultValue)
 
         /// <summary>
-        /// Displays an achievement banner from a given category.
-        /// Only category 6 (Great Purpose) has banners to display.
+        /// Looks up a table for Great Purpose (category 6) entries (1-16).
+        /// Forwards parameters to an announce display function if it finds a match.
         /// </summary>
-        AchievementBanner = 108, // 0x00633B80 (cQuestProcess* this, s32 categoryNo, s32 bannerNo, s32 param03, s32 param04)
+        CallGreatPurpose = 108, // 0x00633B80 (cQuestProcess* this, s32 categoryNo, s32 purposeNo, s32 param03, s32 param04)
 
         /// <summary>
-        /// Enables substory element variant B. Gets area context, calls FUN_00bdee50(0xb) then FUN_00598860 to set +0x4c.
+        /// Enables dialogue text boxes for substory cutscenes. Gets area context, calls FUN_00bdee50(0xb) then FUN_00598860 to set +0x4c.
         /// </summary>
-        EnableSubstoryElementB = 109, // 0x00633BB0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        EnableSubstoryTextBox = 109, // 0x00633BB0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Disables substory element variant B. Calls FUN_00bdee50(0xb) then FUN_005986A0 which clears +0x4c.
+        /// Disables dialogue text boxes for substory cutscenes. Calls FUN_00bdee50(0xb) then FUN_005986A0 which clears +0x4c.
         /// </summary>
-        DisableSubstoryElementB = 110, // 0x00633BF0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        DisableSubstoryTextBox = 110, // 0x00633BF0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Overrides lighting and clouds on current map. Effects are purely visual and not persistent.
         /// param01 = Time of day (0-23), param02 = clouds (0 = unchanged, 1 = fair clouds, 2 = heavy clouds, there may be more?)
         /// </summary>
-        SetEnvironmentalEffect = 111, // 0x00633CE0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        SetCustomWeather = 111, // 0x00633CE0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Resets environmental effects set by SetEnvironmentalEffect.
+        /// Resets weather effects set by SetCustomWeather.
         /// </summary>
-        ResetEnvironmentalEffect = 112, // 0x00633D20 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        ResetCustomWeather = 112, // 0x00633D20 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Schedules an FSM NPC behavior by calling FUN_009d1a60(param04). param04 is read from stack at +0x10.
         /// </summary>
-        SetFsmNpcSchedule = 113, // 0x00633D50 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 scheduleId)
+        LayoutFlagRandomOn2 = 113, // 0x00633D50 (cQuestProcess* this, s32 flagNo1, s32 flagNo2, s32 flagNo3, s32 resultNo)
 
         /// <summary>
-        /// Sets the level tier of a quest enemy group (type 3). Looks up by (stageNo, groupNo, setNo) via FUN_00a41780,
-        /// then calls FUN_00bc0670(enemy, level). Phase-gated.
+        /// Increases a breakable object's hit counter, lowering its current HP. Breaks instantly if count >= BreakHitNum (each num = 10 player hits).
+        /// Looks up by (stageNo, groupNo, setNo) via FUN_00a41780, then calls FUN_00bc0670 (layout unique ID, count).
+        /// Only works for OMs 503136 and 503143 (War Mission flag objects), does nothing otherwise.
         /// </summary>
-        SetQuestEnemyLevel = 114, // 0x00633D80 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 level)
+        SetOmHitCount = 114, // 0x00633D80 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 count)
 
         /// <summary>
-        /// Area-aware variant of SetQuestEnemyLevel. Uses FUN_00a41890 when an area instance exists.
+        /// Quest object variant of SetOmHitCount.
+        /// Only works for OMs 503136 and 503143 (War Mission flag objects), does nothing otherwise.
         /// </summary>
-        SetQuestEnemyLevelEx = 115, // 0x00633E30 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 level)
+        SetQuestOmHitCount = 115, // 0x00633E30 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 count)
 
         /// <summary>
-        /// Sets the danger tier of a quest enemy group (bits 23-21) via FUN_00bc0720. Phase-gated.
+        /// Sets the danger tier of a breakable object (bits 23-21) via FUN_00bc0720 and restores its health to full.
+        /// What "tier" does is still up in the air. May need WM quest context for full functionality.
+        /// Only works for OMs 503136 and 503143 (War Mission flag objects), does nothing otherwise.
         /// </summary>
-        SetQuestEnemyTierUp = 116, // 0x00633F30 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 tier)
+        SetOmTierUp = 116, // 0x00633F30 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 tier)
 
         /// <summary>
-        /// Area-aware variant of SetQuestEnemyTierUp.
+        /// Variant of SetOmTierUp for quest-spawned objects.
+        /// Only works for OMs 503136 and 503143 (War Mission flag objects), does nothing otherwise.
         /// </summary>
-        SetQuestEnemyTierUpEx = 117, // 0x00633FC0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 tier)
+        SetQuestOmTierUp = 117, // 0x00633FC0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 tier)
 
         /// <summary>
-        /// Sets a body/stance pose (1-6) on a quest NPC/enemy via FUN_00bbf670. Looks up by (stageNo, groupNo, setNo).
+        /// Sets a body/stance pose (1-6) on an NPC/enemy via FUN_00bbf670. Looks up by (stageNo, groupNo, setNo).
         /// </summary>
-        SetQuestOmMontageFix = 118, // 0x006341A0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 poseId)
+        SetOmState = 118, // 0x006341A0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 state)
 
         /// <summary>
-        /// Area-aware variant of SetQuestOmMontageFix.
+        /// Quest object variant of SetOmState.
         /// </summary>
-        SetQuestOmMontageFixEx = 119, // 0x006341F0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 poseId)
+        SetQuestOmState = 119, // 0x006341F0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 state)
 
         Padding120 = 120, // 0x006342D0 stub/nop - always returns 0
 
         /// <summary>
-        /// Sets the level of a layout enemy (type 2) by queuing it into a critical-section-guarded buffer via FUN_00b55e70.
-        /// GM-mode guarded. Buffer holds up to 10 entries at this+0xe48.
+        /// Sets the named param of an enemy by queuing it into a critical-section-guarded buffer via FUN_00b55e70.
+        /// GM-mode guarded. Buffer holds up to 10 entries at this+0xe48. One enemy per command (setNo > -1).
         /// </summary>
-        SetQuestLayoutEnemyLevel = 121, // 0x00634300 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 level)
+        SetNamedEnemyParam = 121, // 0x00634300 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 param)
 
         Padding122 = 122, // 0x00634390 stub/nop - always returns 0
         Padding123 = 123, // 0x006343C0 stub/nop - always returns 0
@@ -248,18 +256,21 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         Padding125 = 125, // 0x00634410 stub/nop - always returns 0
 
         /// <summary>
-        /// Controls enemy expedition state. mode=2: FUN_00bc6ff0(9) sets global to 10 and signals start.
-        /// mode=3: FUN_00bc7070(param02) iterates party members and fires expedition signal.
+        /// Changes magma OM behaviour on Evil Dragon's Roost maps to match boss phase mechanics.
+        /// Phase 2: Sets a global counter to 10, which immediately flips over to 1 (reset). Floor magma expands or contracts based on counter value.
+        /// Evil Dragon and their crystals directly increment or decrement this counter as part of their moveset.
+        /// Phase 3: Iterates a list of objects and sets state = param02 on them. Makes magma rise on the map based on state.
+        /// Requires the list (DAT) to be populated by a function beforehand (Evil Dragon populates this DAT with SetInfoOmRisingMagma).
         /// </summary>
-        SetEnemyExpeditionState = 126, // 0x00634450 (cQuestProcess* this, s32 mode, s32 param02, s32 param03, s32 param04)
+        SetMagmaState = 126, // 0x00634450 (cQuestProcess* this, s32 phase, s32 state, s32 param03, s32 param04)
 
         Padding127 = 127, // 0x006344B0 stub/nop - always returns 0
 
         /// <summary>
-        /// Fires a substory ending sequence. Calls FUN_00be9960, FUN_00b85670, then sends messages 0x25f and 0x260
-        /// to the world manager NPC via FUN_00b82b00.
+        /// Fires a chain dungeon ending sequence. Calls FUN_00be9960, FUN_00b85670, then sends messages 0x25f and 0x260
+        /// to the world manager NPC via FUN_00b82b00. Also changes objectives on the chain dungeon UI.
         /// </summary>
-        TriggerSubstoryEndSequence = 128, // 0x006345D0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        TriggerDarkDungeonEndSequence = 128, // 0x006345D0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         Padding129 = 129, // 0x00634690 stub/nop - always returns 0
 

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -156,10 +156,11 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         QstTalkChgFsm = 104, // 0x00633A30 (cQuestProcess* this, s32 npcId, s32 msgNo, s32 param03, s32 param04)
 
         /// <summary>
-        /// Sets invincibility on a substory enemy group. param01=groupFlag triggers FUN_00b5ba00(4,0x15,param01,1,0);
-        /// param02=1 sets invincible via FUN_00be9b60.
+        /// Sets (type = 1) or clears (type = 0) a global enemy aggression flag.
+        /// When set, enemies within spawn range endlessly converge on the player's position.
+        /// Also calls FUN_00be9b60 with 0 or 1 depending on param02. Unclear what this is supposed to do.
         /// </summary>
-        SetSubstoryEnemyInvincible = 105, // 0x00633A80 (cQuestProcess* this, s32 enemyGroupFlag, s32 invincible, s32 param03, s32 param04)
+        SetEnemyAggroFlag = 105, // 0x00633A80 (cQuestProcess* this, s32 type, s32 param02, s32 param03, s32 param04)
 
         Padding106 = 106, // 0x00633B00 stub/nop - always returns 0
 

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -286,10 +286,11 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         Padding132 = 132, // 0x00634750 stub/nop - always returns 0
 
         /// <summary>
-        /// Controls pawn expedition. mode=1: FUN_00b6ce30() starts expedition (writes action DAT_01d4db50).
-        /// mode=2: FUN_00b6cde0() stops expedition (writes action DAT_01d4db54).
+        /// Activates a player's bonus dragon abilities if they meet the threshold. Gated by type.
+        /// Type 1 = Dragon Protection, Type 2 = Dragon Blessing. Plays GUI message.
+        /// Dragon protection seems functional and actually raises stats.
         /// </summary>
-        SetPawnExpeditionFlag = 133, // 0x006347A0 (cQuestProcess* this, s32 mode, s32 param02, s32 param03, s32 param04)
+        GetDragonAbility = 133, // 0x006347A0 (cQuestProcess* this, s32 type, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Sets a body/pose mode on a layout enemy (type 2). Looks up entity via FUN_00a41780, checks OM alive,

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3261,7 +3261,7 @@ SubstoryProgress(int substoryId, int param02, int param03, int param04 = 0);
 AddSubstoryProgress(int substoryId, int progressDelta, int param03 = 0, int param04 = 0);
 ```
 
-### TriggerSubstoryEvent (101)
+### UpdateSubstoryProgress (101)
 
 | Field | Value |
 |-------|-------|
@@ -3271,13 +3271,13 @@ AddSubstoryProgress(int substoryId, int progressDelta, int param03 = 0, int para
 
 ```
 /**
- * @brief Triggers a substory event sequence when the quest mode is 0xb.
- * Calls FUN_00598590 to set timer data on the substory structure.
+ * @brief Triggers a substory progress update sequence when the quest mode is 0xb.
+ * Calls FUN_00598590 to set progress data on the substory structure and sends C2S_QUEST_ADD_PACKAGE_QUEST_POINT_REQ with schedule ID and progress value.
  */
-TriggerSubstoryEvent(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+TriggerSubstoryEvent(int progressDelta, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### EnableSubstoryUIElement (102)
+### EnableSubstoryGauge (102)
 
 | Field | Value |
 |-------|-------|
@@ -3294,7 +3294,7 @@ TriggerSubstoryEvent(int param01 = 0, int param02 = 0, int param03 = 0, int para
 EnableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### DisableSubstoryUIElement (103)
+### DisableSubstoryGauge (103)
 
 | Field | Value |
 |-------|-------|
@@ -3310,7 +3310,7 @@ EnableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int p
 DisableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SetSubstoryTalkTarget (104)
+### QstTalkChgFsm (104)
 
 | Field | Value |
 |-------|-------|
@@ -3324,7 +3324,7 @@ DisableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int 
  * @param param01 NPC/group identifier
  * @param param02 Talk context identifier
  */
-SetSubstoryTalkTarget(int param01, int param02, int param03 = 0, int param04 = 0);
+QstTalkChgFsm(int param01, int param02, int param03 = 0, int param04 = 0);
 ```
 
 ### SetSubstoryEnemyInvincible (105)
@@ -3345,25 +3345,26 @@ SetSubstoryTalkTarget(int param01, int param02, int param03 = 0, int param04 = 0
 SetSubstoryEnemyInvincible(int enemyGroupFlag, int invincible, int param03 = 0, int param04 = 0);
 ```
 
-### AddFsmTalkNpc (107)
+### SetRandom2 (107)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00633B30` |
 | Table index | 107 |
-| Key callees | `FUN_009d07f0` (FSM mode check), `FUN_009cfe00`, `FUN_009d2ba0(npcId, param04)` |
+| Key callees | `FUN_009d07f0`, `FUN_009cfe00`, `FUN_009d2ba0` |
 
 ```
 /**
- * @brief Adds an NPC to the FSM talk NPC list (this+0x94/0xa0).
- * Only executes when in FSM quest mode.
- * @param npcId   NPC or group identifier
- * @param param04 Secondary value passed to FUN_009d2ba0
+ * @brief Identical/duplicate function of SetRandom.
+ * @param randomNo    Index of the random slot to write (0-based).
+ * @param minValue    Inclusive lower bound of the random range (server-side only).
+ * @param maxValue    Inclusive upper bound of the random range (server-side only).
+ * @param resultValue The rolled value, computed server-side from [minValue, maxValue].
  */
-AddFsmTalkNpc(int npcId, int param02 = 0, int param03 = 0, int param04 = 0);
+SetRandom2(int randomNo, int minValue, int maxValue, int resultValue);
 ```
 
-### AchievementBanner (108)
+### CallGreatPurpose (108)
 
 | Field | Value |
 |-------|-------|
@@ -3372,15 +3373,15 @@ AddFsmTalkNpc(int npcId, int param02 = 0, int param03 = 0, int param04 = 0);
 
 ```
 /**
- * @brief Displays an achievement banner from a given category.
- * Only category 6 (Great Purpose) has banners to display.
+ * @brief Looks up a table for Great Purpose (category 6) entries (1-16).
+ * Forwards parameters to an announce display function if it finds a match.
  * @param categoryNo  Achievement category
- * @param bannerNo    Banner number (1 to 16, 15 is empty/unused)
+ * @param purposeNo   Great purpose table index (1 to 16, 15 is empty/unused)
  */
-AchievementBanner(int category, int flagValue, int param03 = 0, int param04 = 0);
+CallGreatPurpose(int categoryNo, int purposeNo, int param03 = 0, int param04 = 0);
 ```
 
-### EnableSubstoryElementB (109)
+### EnableSubstoryTextBox (109)
 
 | Field | Value |
 |-------|-------|
@@ -3390,12 +3391,12 @@ AchievementBanner(int category, int flagValue, int param03 = 0, int param04 = 0)
 
 ```
 /**
- * @brief Enables substory element variant B (field +0x4c). Paired with DisableSubstoryElementB.
+ * @brief Enables dialogue text boxes for substory cutscenes (field +0x4c). Paired with DisableSubstoryTextBox.
  */
 EnableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### DisableSubstoryElementB (110)
+### DisableSubstoryTextBox (110)
 
 | Field | Value |
 |-------|-------|
@@ -3405,12 +3406,12 @@ EnableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int pa
 
 ```
 /**
- * @brief Disables substory element variant B (field +0x4c). Paired with EnableSubstoryElementB.
+ * @brief Disables dialogue text boxes for substory cutscenes (field +0x4c). Paired with EnableSubstoryTextBox.
  */
-DisableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+DisableSubstoryTextBox(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SetEnvironmentalEffect (111)
+### SetCustomWeather (111)
 
 | Field | Value |
 |-------|-------|
@@ -3425,10 +3426,10 @@ DisableSubstoryElementB(int param01 = 0, int param02 = 0, int param03 = 0, int p
  * @param param01 Time of day
  * @param param02 Cloud type passed to FUN_00c19920
  */
-SetEnvironmentalEffect(int param01, int param02, int param03 = 0, int param04 = 0);
+SetCustomWeather(int param01, int param02, int param03 = 0, int param04 = 0);
 ```
 
-### ResetEnvironmentalEffect (112)
+### ResetCustomWeather (112)
 
 | Field | Value |
 |-------|-------|
@@ -3438,50 +3439,52 @@ SetEnvironmentalEffect(int param01, int param02, int param03 = 0, int param04 = 
 
 ```
 /**
- * @brief Resets environmental effects set by SetEnvironmentalEffect.
+ * @brief Resets environmental effects set by SetCustomWeather.
  */
-ResetEnvironmentalEffect(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+ResetCustomWeather(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SetFsmNpcSchedule (113)
+### LayoutFlagRandomOn2 (113)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00633D50` |
 | Table index | 113 |
-| Key callees | `FUN_009d1a60(scheduleId)` — param04 is read from stack at +0x10 |
+| Key callees | `FUN_009d1a60` — param04 is read from stack at +0x10 |
 
 ```
 /**
- * @brief Schedules an FSM NPC behavior by schedule ID.
- * @note  param04 / scheduleId is consumed from the stack slot at offset +0x10.
- * @param scheduleId Schedule identifier
+ * @brief Identical function to LayoutFlagRandomOn.
+ * @param flagNo1
+ * @param flagNo2
+ * @param flagNo3
+ * @param resultNo
  */
-SetFsmNpcSchedule(int param01 = 0, int param02 = 0, int param03 = 0, int scheduleId = 0);
+LayoutFlagRandomOn2(int flagNo1, int flagNo2, int flagNo3, int resultNo);
 ```
 
-### SetQuestEnemyLevel (114)
+### SetOmHitCount (114)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00633D80` |
 | Table index | 114 |
-| Key callees | `FUN_00a41780(stageNo, groupNo, setNo, 0)` (quest enemy type 3 lookup), `FUN_00bc0670(enemy, level)` |
+| Key callees | `FUN_00a41780(stageNo, groupNo, setNo, 0)`, `FUN_00bc0670(object, count)` |
 
 ```
 /**
- * @brief Sets the level tier (bits controlling level) of a quest enemy group (type 3).
- * Phase-gated: checks DAT_0220456c offsets 0x4654 vs 0x45cc.
+ * @brief Increases a breakable object's hit counter, lowering its current HP. Breaks instantly if count >= BreakHitNum (each num = 10 player hits).
+ * Phase-gated: checks DAT_0220456c offsets 0x4654 vs 0x45cc. Looks up by (stageNo, groupNo, setNo) via FUN_00a41780, then calls FUN_00bc0670 (layout unique ID, count).
  * @note FUN_00bc0670 checks for OMs 503136 and 503143 - destructible flag objects found in War Missions
  * @param stageNo  Stage number
  * @param groupNo  Enemy group number
  * @param setNo    Enemy set number
- * @param level    Level tier value passed to FUN_00bc0670
+ * @param count    Hit count passed to FUN_00bc0670
  */
-SetQuestEnemyLevel(StageNo stageNo, int groupNo, int setNo, int level);
+SetOmHitCount(StageNo stageNo, int groupNo, int setNo, int count);
 ```
 
-### SetQuestEnemyLevelEx (115)
+### SetQuestOmHitCount (115)
 
 | Field | Value |
 |-------|-------|
@@ -3491,18 +3494,18 @@ SetQuestEnemyLevel(StageNo stageNo, int groupNo, int setNo, int level);
 
 ```
 /**
- * @brief Area-aware variant of SetQuestEnemyLevel.
+ * @brief Quest object variant of SetOmHitCount.
  * Uses FUN_00a41890 when an area instance is active (FUN_009cff70 != 0).
  * @note FUN_00bc0670 checks for OMs 503136 and 503143 - destructible flag objects found in War Missions
  * @param stageNo  Stage number
  * @param groupNo  Enemy group number
  * @param setNo    Enemy set number
- * @param level    Level tier value
+ * @param level    Hit count
  */
-SetQuestEnemyLevelEx(StageNo stageNo, int groupNo, int setNo, int level);
+SetQuestOmHitCount(StageNo stageNo, int groupNo, int setNo, int count);
 ```
 
-### SetQuestEnemyTierUp (116)
+### SetOmTierUp (116)
 
 | Field | Value |
 |-------|-------|
@@ -3513,7 +3516,7 @@ SetQuestEnemyLevelEx(StageNo stageNo, int groupNo, int setNo, int level);
 ```
 /**
  * @brief Sets the danger tier (bits 23–21) of a quest enemy group.
- * Phase-gated like SetQuestEnemyLevel.
+ * Phase-gated like SetOmHitCount.
  * @note FUN_00bc0670 checks for OMs 503136 and 503143 - destructible flag objects found in War Missions
  * @param stageNo  Stage number
  * @param groupNo  Enemy group number
@@ -3523,7 +3526,7 @@ SetQuestEnemyLevelEx(StageNo stageNo, int groupNo, int setNo, int level);
 SetQuestEnemyTierUp(StageNo stageNo, int groupNo, int setNo, int tier);
 ```
 
-### SetQuestEnemyTierUpEx (117)
+### SetQuestOmTierUp (117)
 
 | Field | Value |
 |-------|-------|
@@ -3533,7 +3536,7 @@ SetQuestEnemyTierUp(StageNo stageNo, int groupNo, int setNo, int tier);
 
 ```
 /**
- * @brief Area-aware variant of SetQuestEnemyTierUp.
+ * @brief Quest object variant of SetQuestEnemyTierUp.
  * @note FUN_00bc0670 checks for OMs 503136 and 503143 - destructible flag objects found in War Missions
  * @param stageNo  Stage number
  * @param groupNo  Enemy group number
@@ -3543,66 +3546,65 @@ SetQuestEnemyTierUp(StageNo stageNo, int groupNo, int setNo, int tier);
 SetQuestEnemyTierUpEx(StageNo stageNo, int groupNo, int setNo, int tier);
 ```
 
-### SetQuestOmMontagueFix (118)
+### SetOmState (118)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006341A0` |
 | Table index | 118 |
-| Key callees | `FUN_00a41780(stageNo, groupNo, setNo, 0)`, `FUN_00bbf670(npc, poseId)` (6-bit field, values 1–6) |
+| Key callees | `FUN_00a41780(stageNo, groupNo, setNo, 0)`, `FUN_00bbf670(object, state)` (6-bit field, values 1–6) |
 
 ```
 /**
- * @brief Sets a body/stance pose on a quest NPC or look/state of an object (like a chest).
+ * @brief Sets a body/stance pose on an NPC or look/state of an object (like a chest).
  * Montague IDs 1–6 map to different stances.
  * @param stageNo    Stage number
  * @param groupNo    Group number
  * @param setNo      Set number
- * @param montagueNo Pose/stance index (1–6)
+ * @param state      Pose/stance index (1–6)
  */
-SetQuestOmMontagueFix(StageNo stageNo, int groupNo, int setNo, int montagueNo);
+SetOmState(StageNo stageNo, int groupNo, int setNo, int state);
 ```
 
-### SetQuestOmMontagueFixEx (119)
+### SetQuestOmState (119)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006341F0` |
 | Table index | 119 |
-| Key callees | Area-aware NPC lookup, `FUN_00bbf670` |
+| Key callees | Quest-aware object lookup, `FUN_00bbf670` |
 
 ```
 /**
- * @brief Area-aware variant of SetQuestOmMontague.
+ * @brief Quest object variant of SetOmState.
  * @param stageNo    Stage number
  * @param groupNo    Group number
  * @param setNo      Set number
- * @param montagueNo Pose/stance index (1–6)
+ * @param state      Pose/stance index (1–6)
  */
-SetQuestOmMontagueFixEx(StageNo stageNo, int groupNo, int setNo, int montagueNo);
+SetQuestOmState(StageNo stageNo, int groupNo, int setNo, int state);
 ```
 
-### SetQuestLayoutEnemyLevel (121)
+### SetNamedEnemyParam (121)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00634300` |
 | Table index | 121 |
-| Key callees | `FUN_00a416a0(stageNo, groupNo, setNo, 0)` (layout enemy type 2), `FUN_00b55e70(enemy, level)` |
+| Key callees | `FUN_00a416a0(stageNo, groupNo, setNo, 0)` (layout enemy type 2), `FUN_00b55e70(enemy, param)` |
 | Notes | GM-mode guarded. Queues into a CS-guarded buffer (max 10 entries) at `this+0xe48`. |
 
 ```
 /**
- * @brief Sets the level of a layout enemy (type 2) via a thread-safe queue.
- * Guarded by GM mode check (FUN_00b19cc0) and player ID comparison.
- * Buffer at this+0xe48 holds up to 10 entries.
- * @note Calls getQuestId and compares against 90040004 (Acre Selund War Chronicles), checks stage number if this fails.
+ * @brief Sets the named param of an enemy by queuing it into a critical-section-guarded buffer via FUN_00b55e70.
+ * GM-mode guarded. Buffer holds up to 10 entries at this+0xe48. One enemy per command (setNo > -1).
+ * @note Skips stage check if quest ID = 90040004 (Acre Selund War Chronicles).
  * @param stageNo  Stage number
  * @param groupNo  Layout enemy group number
  * @param setNo    Layout enemy set number
- * @param level    Level value passed to FUN_00b55e70
+ * @param param    Named param value passed to FUN_00b55e70
  */
-SetQuestLayoutEnemyLevel(StageNo stageNo, int groupNo, int setNo, int level);
+SetNamedEnemyParam(StageNo stageNo, int groupNo, int setNo, int param);
 ```
 
 ### RemoveFsmNpcFromSchedule (124)
@@ -3622,24 +3624,28 @@ SetQuestLayoutEnemyLevel(StageNo stageNo, int groupNo, int setNo, int level);
 RemoveFsmNpcFromSchedule(int param01, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SetEnemyExpeditionState (126)
+### SetMagmaState (126)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00634450` |
 | Table index | 126 |
-| Key callees | mode=2: `FUN_00bc6ff0(9)` (sets global to 10, signals start); mode=3: `FUN_00bc7070(param02)` (iterates party, fires signal via `FUN_008fdf80`/`FUN_005b8070`) |
+| Key callees | phase=2: `FUN_00bc6ff0(9)` (sets global to 10, signals start); phase=3: `FUN_00bc7070(state)` (iterates list, fires signal via `FUN_008fdf80`/`FUN_005b8070`) |
 
 ```
 /**
- * @brief Controls enemy expedition state / area boss trigger.
- * @param mode    2 = start expedition signal, 3 = fire per-party-member signal
- * @param param02 Secondary value passed to FUN_00bc7070 when mode == 3
+ * @brief Changes magma OM behaviour on Evil Dragon's Roost maps to match boss phase mechanics.
+ * @brief Phase 2: Sets a global counter to 10, which immediately flips over to 1 (reset). Floor magma expands or contracts based on counter value.
+ * @brief Evil Dragon and their crystals directly increment or decrement this counter as part of their moveset.
+ * @brief Phase 3: Iterates a list of objects and sets state = param02 on them. Makes magma rise on the map based on state.
+ * @brief Requires the list (DAT) to be populated by a function beforehand (Evil Dragon populates this DAT with SetInfoOmRisingMagma).
+ * @param phase   2 = resets floor magma expansion, 3 = iterates object list and sets every match to state = param02
+ * @param state   Secondary value passed to FUN_00bc7070 when phase == 3
  */
-SetEnemyExpeditionState(int mode, int param02 = 0, int param03 = 0, int param04 = 0);
+SetMagmaState(int phase, int state, int param03 = 0, int param04 = 0);
 ```
 
-### EndContentsPurposePhaseChange (128)
+### TriggerDarkDungeonEndSequence (128)
 
 | Field | Value |
 |-------|-------|
@@ -3655,7 +3661,7 @@ SetEnemyExpeditionState(int mode, int param02 = 0, int param03 = 0, int param04 
  * Sends world-manager NPC messages 0x25f and 0x260.
  * @param
  */
-EndContentsPurposePhaseChange(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+TriggerDarkDungeonEndSequence(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### EndChain (130)

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -4343,7 +4343,7 @@ IsSubstoryProgressInRange(int minValue, int maxValue, int param03 = 0, int param
 IsTimerNotElapsed(int timerNo, int sec, int param03 = 0, int param04 = 0);
 ```
 
-### IsContentsModeTimerNotLess (246)
+### RisingMagmaTime (246)
 
 | Field | Value |
 |-------|-------|
@@ -4353,11 +4353,13 @@ IsTimerNotElapsed(int timerNo, int sec, int param03 = 0, int param04 = 0);
 
 ```
 /**
- * @brief S3-only: checks if the contents mode elapsed timer >= timeSec.
- * Returns 0 if not in the correct season phase.
+ * @brief Checks how long magma has been rising on the current map. Requires cpOmRisingMagma to be present on the map.
+ * Magma starts rising after result command SetMagmaState is used with phase = 3, which starts a counter.
+ * This counter, and magma height, increases by 1/sec once started. Check passes when param01 >= counter.
+ * Can be used as a time or height comparison depending on how you look at it.
  * @param timeSec Minimum elapsed seconds
  */
-IsContentsModeTimerNotLess(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
+RisingMagmaTime(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsTriggerFlagSetAndClear (247)

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3327,22 +3327,23 @@ DisableSubstoryUIElement(int param01 = 0, int param02 = 0, int param03 = 0, int 
 QstTalkChgFsm(int param01, int param02, int param03 = 0, int param04 = 0);
 ```
 
-### SetSubstoryEnemyInvincible (105)
+### SetEnemyAggroFlag (105)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00633A80` |
 | Table index | 105 |
-| Key callees | `FUN_00b5ba00(4, 0x15, enemyGroupFlag, 1, 0)`, `FUN_00be9b60(invincible)` |
+| Key callees | `sFlag::setFlag(4, 0x15, flag, 1, 0)`, `FUN_00be9b60(0 or 1)` |
 
 ```
 /**
- * @brief Sets or clears invincibility on a substory enemy group.
- * Uses enemy type 4 / category 0x15. FUN_00be9b60 writes flag at +0x92 on matching NPCs.
- * @param enemyGroupFlag  Group flag / filter value passed to FUN_00b5ba00
- * @param invincible      1 = invincible, 0 = vulnerable
+ * @brief Sets (type = 1) or clears (type = 0) a global enemy aggression flag.
+ * When set, enemies within spawn range endlessly converge on the player's position.
+ * Also calls FUN_00be9b60 with 0 or 1 depending on param02. Unclear what this is supposed to do.
+ * @param type            1 = set, 0 = clear, passed to sFlag::setFlag
+ * @param param02         1 = unknown, 0 = unknown
  */
-SetSubstoryEnemyInvincible(int enemyGroupFlag, int invincible, int param03 = 0, int param04 = 0);
+SetEnemyAggroFlag(int type, int param02, int param03 = 0, int param04 = 0);
 ```
 
 ### SetRandom2 (107)

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3682,20 +3682,21 @@ TriggerDarkDungeonEndSequence(int param01 = 0, int param02 = 0, int param03 = 0,
 EndChain(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SetPawnExpeditionFlag (133)
+### GetDragonAbility (133)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006347A0` |
 | Table index | 133 |
-| Key callees | mode=1: `FUN_00b6ce30()` (writes action `DAT_01d4db50`); mode=2: `FUN_00b6cde0()` (writes action `DAT_01d4db54`) |
+| Key callees | type=1: `FUN_00b6ce30()` (writes action `DAT_01d4db50`); type=2: `FUN_00b6cde0()` (writes action `DAT_01d4db54`) |
 
 ```
 /**
- * @brief Starts or stops a pawn expedition.
- * @param mode  1 = start expedition, 2 = stop expedition
+ * @brief Activates a player's bonus dragon abilities if they meet the threshold. Gated by type.
+ * @param Type 1 = Dragon Protection, Type 2 = Dragon Blessing. Plays GUI message.
+ * @param Dragon protection seems functional and actually raises stats.
  */
-SetPawnExpeditionFlag(int mode, int param02 = 0, int param03 = 0, int param04 = 0);
+GetDragonAbility(int type, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### SetQuestLayoutOmMontageFix (134)
@@ -3727,21 +3728,21 @@ SetQuestLayoutOmMontageFix(StageNo stageNo, int groupNo, int setNo, int montague
 The following check commands were found by analysing the check function dispatch table at `.data:02126998`.
 The dispatch function is at approximately `.text:0063E04A`. It validates `commandId < 0x101` (257 entries, indices 0–256).
 
-### IsSubstoryProgressBit18 (211)
+### IsPartyDisbanded (211)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00635A00` |
 | Table index | 211 |
-| State offset | `cQuestProcess+0x5c+0x20c` (substory state word), bit 18 (0x12) |
+| State offset | `cQuestProcess+0x5c+0x20c` notice bit 18 (0x12) |
 
 ```
 /**
- * @brief Returns bit 18 of the substory progress state word.
- * All four quest params are unused — only the implicit `this` context is read.
- * State word is at *(cQuestProcess+0x5c)+0x20c.
+ * @brief Checks if the player's party has disbanded (notice bit 18). 
+ * Only triggers after disbanding a multiplayer party (exm with pawns will also work).
+ * Notice bit is at *(cQuestProcess+0x5c)+0x20c.
  */
-IsSubstoryProgressBit18(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+IsPartyDisbanded(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### SetGlobalSubstoryProgressBit17Inverse (212)


### PR DESCRIPTION
Renames the following result commands:

- 101: TriggerSubstoryEvent to UpdateSubstoryProgress
- 102: EnableSubstoryUIElement to EnableSubstoryGauge
- 103: DisableSubstoryUIElement to DisableSubstoryGauge
- 105: SetSubstoryEnemyInvincible to SetEnemyAggroFlag
- 107: AddFsmTalkNpc to SetRandom2
- 108: AchievementBanner to CallGreatPurpose
- 109: EnableSubstoryElementB to EnableSubstoryTextBox
- 110: DisableSubstoryElementB to DisableSubstoryTextBox
- 111: SetEnvironmentalEffect to SetCustomWeather
- 112: ResetEnvironmentalEffect to ResetCustomWeather
- 113: SetFsmNpcSchedule to LayoutFlagRandomOn2
- 114: SetQuestEnemyLevel to SetOmHitCount
- 115: SetQuestEnemyLevelEx to SetQuestOmHitCount
- 116: SetQuestEnemyTierUp to SetOmTierUp
- 117: SetQuestEnemyTierUpEx to SetQuestOmTierUp
- 118: SetQuestOmMontageFix to SetOmState
- 119: SetQuestOmMontageFixEx to SetQuestOmState
- 121: SetQuestLayoutEnemyLevel to SetNamedEnemyParam
- 126: SetEnemyExpeditionState to SetMagmaState
- 128: TriggerSubstoryEndSequence to TriggerDarkDungeonEndSequence
- 133: SetPawnExpeditionFlag to GetDragonAbility

Also updates parameter definitions for some of these commands. Notes below:

- UpdateSubstoryProgress sends param01 as part of a packet (C2S_QUEST_ADD_PACKAGE_QUEST_POINT_REQ)
- SetEnemyAggroFlag makes every spawned enemy around you home in on your position. Also triggers enemy found commands, likely not made for overworld use.
- SetRandom2 is identical to SetRandom and now has the same params.
- CallGreatPurpose does not play any UI animations by itself and merely does a lookup for a matching great purpose index, then forwards params to a common announce function on a match, hence the rename.
- SetCustomWeather and ResetCustomWeather were renamed based on similar cutscene functions.
- SetOmHitCount/SetQuestOmHitCount is an OM damaging command, adds hits to the object as if the player had hit them.
- SetOmTierUp/SetQuestOmTierUp does something aside from resetting object health, the NTC packets sent by damaging them actually have different base values for different tiers. May need WM quest context to figure out the full functionality. Also cannot respawn already broken objects.
- SetOmState/SetQuestOmState were renamed because they do the same thing as S2CSeasonDungeonSetOmStateNtc and share a function.
- SetNamedEnemyParam does not seem to visually change an enemy's title (aka the name) but will add one if they don't have it. Can be used to fake health loss by spawning an enemy with a lower HP cap param and swapping titles with the command (hello Ifrit). Change is not instant so you see the enemy lose HP.
- SetMagmaState is what makes Evil Dragon phase 2 (all fights) and phase 3 (WM only) work properly. param01 = 2 should not be used after phase 2 starts (for normal fight at least), can mess up boss AI if used improperly.
- TriggerDarkDungeonEndSequence is used for chain dungeons, hence the rename.
- GetDragonAbility is used to activate a player's bonus dragon abilities (Force). Type 1 =  Dragon Protection (bonus stats, use at the start). Type 2 = Dragon Blessing (bonus drops, use at the ending/rewards phase).

Also renames check command 246 from IsContentsModeTimerNotLess to RisingMagmaTime (this is the check counterpart of result SetMagmaState with phase 3, both commands see use in Evil Dragon's war missions.) and check command 211 from IsSubstoryStateBit18 to IsPartyDisbanded (checks for the moment a party is disbanded).

As part of command investigations, EXM Power that Destroys Reason (Black Dragon) has been added as well. It's a work in progress, but fully playable (dragon abilities are not detected even if you meet the threshold, also no rewards).