### PR TITLE
Fix: Small Fixes, August 2026

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbContactList.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbContactList.cs
@@ -68,7 +68,7 @@ public partial class DdonSqlDb : SqlDb
     };
 
     private static readonly string SqlSelectBlackList = """SELECT "target_id" from "ddon_black_list" WHERE "character_id" = @character_id;""";
-    private static readonly string SqlDeleteBlackList = """DELETE FROM "ddon_black_list" "character_id" = @character_id AND "target_id" = @target_id;""";
+    private static readonly string SqlDeleteBlackList = """DELETE FROM "ddon_black_list" WHERE "character_id" = @character_id AND "target_id" = @target_id;""";
     private static readonly string SqlInsertBlackList = @"
         INSERT INTO ddon_black_list (character_id, target_id)
         SELECT

--- a/Arrowgene.Ddon.GameServer/Context/ContextManager.cs
+++ b/Arrowgene.Ddon.GameServer/Context/ContextManager.cs
@@ -69,25 +69,25 @@ namespace Arrowgene.Ddon.GameServer.Context
             Quest = 7
         }
 
-        private static readonly Bitfield Kind          = new Bitfield( 3,  0, "Kind");
-        private static readonly Bitfield StageId       = new Bitfield(15,  4, "StageId");
-        private static readonly Bitfield LayoutGroup   = new Bitfield(24, 16, "LayoutGroup");
-        private static readonly Bitfield LayoutId      = new Bitfield(29, 25, "LayoutId");
-        private static readonly Bitfield InnerId       = new Bitfield(34, 30, "InnerId");
+        private static readonly Bitfield Kind           = new( 3,  0, "Kind");
+        private static readonly Bitfield StageId        = new(15,  4, "StageId");
+        private static readonly Bitfield LayoutGroup    = new(24, 16, "LayoutGroup");
+        private static readonly Bitfield LayoutId       = new(29, 25, "LayoutId");
+        private static readonly Bitfield InnerId        = new(34, 30, "InnerId");
 
         public static bool IsOmUID(ulong value)
         {
-            return ((byte) Kind.Get(value)) == (byte) UIDKind.OM;
+            return ((byte)Kind.Get(value)) == (byte)UIDKind.OM;
         }
 
         public static uint GetStageId(ulong value)
         {
-            return (uint) StageId.Get(value);
+            return (uint)StageId.Get(value);
         }
 
         public static ulong CreateEnemyUID(ulong setId, CDataStageLayoutId stageLayoutId)
         {
-            return (Kind.Value((ulong) UIDKind.Enemy) |
+            return (Kind.Value((ulong)UIDKind.Enemy) |
                     StageId.Value(stageLayoutId.StageId) |
                     LayoutGroup.Value(stageLayoutId.GroupId) |
                     LayoutId.Value(setId) |
@@ -99,10 +99,10 @@ namespace Arrowgene.Ddon.GameServer.Context
         {
             List<InstancedEnemy> enemies = enemyManager.GetAssets(stageLayoutId);
 
-            List<ulong> results = new List<ulong>();
-            for (int i = 0; i < enemies.Count(); i++)
+            List<ulong> results = [];
+            for (int i = 0; i < enemies.Count; i++)
             {
-                results.Add(CreateEnemyUID((ulong) i, stageLayoutId));
+                results.Add(CreateEnemyUID((ulong)i, stageLayoutId));
             }
 
             return results;
@@ -209,11 +209,6 @@ namespace Arrowgene.Ddon.GameServer.Context
 
         public static void AwaitMaster(GameClient client, ulong uniqueID, int clientIndex = -1)
         {
-            if (clientIndex == -1)
-            {
-                clientIndex = client.Party.ClientIndex(client);
-            }
-
             client.Character.ContextOwnership[uniqueID] = false;
         }
 
@@ -229,15 +224,13 @@ namespace Arrowgene.Ddon.GameServer.Context
 
         public static void DelegateMaster(GameClient client, ulong uniqueID)
         {
-            bool isOwner = client.Character.ContextOwnership.ContainsKey(uniqueID)
-                && client.Character.ContextOwnership[uniqueID];
+            bool isOwner = client.Character.ContextOwnership.TryGetValue(uniqueID, out var value) && value;
 
             client.Character.ContextOwnership.Remove(uniqueID);
 
             if (isOwner)
             {
-                var otherClients = client.Party.Clients.Where(x => x != client && x.Character.ContextOwnership.ContainsKey(uniqueID));
-                GameClient newOwner = otherClients.FirstOrDefault() ?? client.Party.Clients.FirstOrDefault(x => x != client);
+                GameClient newOwner = client.Party.Clients.FirstOrDefault(x => x != client && x.Character.ContextOwnership.ContainsKey(uniqueID));
                 if (newOwner != null)
                 {
                     AssignMaster(newOwner, uniqueID);

--- a/Arrowgene.Ddon.Scripts/scripts/job_orb_tree/special_skill_augmentation/spirit_lancer.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/job_orb_tree/special_skill_augmentation/spirit_lancer.csx
@@ -151,7 +151,7 @@ skillAugmentation.AddNode(26)
     .Location(4, 10)
     .BloodOrbCost(3500)
     .HasUnlockDependencies(25)
-    .HasQuestDependency((QuestId)60300022)
+    .HasQuestDependency(QuestId.HerosRestFeryanaRegion)
     .Unlocks(OrbGainParamType.JobPhysicalAttack, 1);
 // Row 11
 skillAugmentation.AddNode(27)
@@ -292,7 +292,7 @@ skillAugmentation.AddNode(51)
     .Location(4, 19)
     .BloodOrbCost(4000)
     .HasUnlockDependencies(50)
-    .HasQuestDependency(QuestId.HerosRestFeryanaRegion)
+    .HasQuestDependency((QuestId)60300022)
     .Unlocks(OrbGainParamType.JobPhysicalAttack, 1);
 // Row 20
 skillAugmentation.AddNode(52)
@@ -444,7 +444,7 @@ skillAugmentation.AddNode(77)
     .Location(3, 32)
     .HighOrbCost(300)
     .HasUnlockDependencies(76)
-	.HasSpecialConditionDependencies(12)
+    .HasSpecialConditionDependencies(12)
     .Unlocks(OrbGainParamType.JobMagicalDefence, 1);
 skillAugmentation.AddNode(78)
     .Location(4, 32)
@@ -455,7 +455,7 @@ skillAugmentation.AddNode(79)
     .Location(5, 32)
     .HighOrbCost(300)
     .HasUnlockDependencies(76)
-	.HasSpecialConditionDependencies(13)
+    .HasSpecialConditionDependencies(13)
     .Unlocks(OrbGainParamType.JobPhysicalDefence, 1);
 // Row 33	
 skillAugmentation.AddNode(80)
@@ -525,7 +525,7 @@ skillAugmentation.AddNode(92)
     .Location(4, 36)
     .HighOrbCost(500)
     .HasUnlockDependencies(89)
-	.HasSpecialConditionDependencies(11)
+    .HasSpecialConditionDependencies(11)
     .Unlocks(CustomSkillId.CureGlastaT);
 skillAugmentation.AddNode(93)
     .Location(5, 36)
@@ -537,7 +537,7 @@ skillAugmentation.AddNode(94)
     .Location(4, 37)
     .HighOrbCost(500)
     .HasUnlockDependencies(92)
-	.HasSpecialConditionDependencies(14)
+    .HasSpecialConditionDependencies(14)
     .Unlocks(OrbGainParamType.JobPhysicalAttack, 1);
 // Row 38
 skillAugmentation.AddNode(95)

--- a/Arrowgene.Ddon.Scripts/scripts/scheduled_tasks/stamp_reset.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/scheduled_tasks/stamp_reset.csx
@@ -10,7 +10,7 @@ public class StampResetTask : DailyTask
             server.StampManager.RefreshStamp(character);
         }
 
-        server.RpcManager.AnnounceAll("internal/command", RpcInternalCommand.StampReset, null);
+        server.RpcManager.AnnounceOthers("internal/command", RpcInternalCommand.StampReset, null);
 
         server.Database.ResetCharacterStamps();
     }


### PR DESCRIPTION
- Fix an improperly assigned unlock condition in Spirit Lancer's S3 BO tree. Credit to Wren.
- Fix stamp reset firing twice for players who happened to be connected to the server executing tasks when it fired. Credit to Nirrudn.
- Fix continued context issues that could cause enemies to stand paralyzed in multiplayer. Credit to the Rising team.
- Fix SQL error when removing people from blacklists. Credit to Kythe.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
