### PR TITLE
War Mission commands and Dragon Skill packets

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2671,28 +2671,28 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.NpcPreTalkAndOrderUi, Param01 = stageNo, Param02 = npcId, Param03 = noOrderGroupSerial, Param04 = storeVal };
             }
 
-            /** @brief Checks if substory enemy's HP% >= hpRatePercent. */
-            public static CDataQuestCommand SubstoryEnemyHpNotLess(int substoryId, int hpRatePercent, int param03 = 0, int param04 = 0)
+            /** @brief Checks if a war mission gauge is not under the percent threshold. */
+            public static CDataQuestCommand WarGaugeNotLess(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.SubstoryEnemyHpNotLess, Param01 = substoryId, Param02 = hpRatePercent, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.WarGaugeNotLess, Param01 = gaugeNo, Param02 = percentRate, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks if substory enemy's HP% < hpRatePercent. Inverse of SubstoryEnemyHpNotLess. */
-            public static CDataQuestCommand SubstoryEnemyHpLess(int substoryId, int hpRatePercent, int param03 = 0, int param04 = 0)
+            /** @brief Checks if a war mission gauge is under the percent threshold. Inverse of WarGaugeNotLess. */
+            public static CDataQuestCommand WarGaugeLess(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.SubstoryEnemyHpLess, Param01 = substoryId, Param02 = hpRatePercent, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.WarGaugeLess, Param01 = gaugeNo, Param02 = percentRate, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks if average HP% across all substory NPCs >= hpRatePercent. */
-            public static CDataQuestCommand SubstoryAvgEnemyHpNotLess(int param01, int hpRatePercent, int param03 = 0, int param04 = 0)
+            /** @brief Checks if the average of all war mission gauges are not under the percent threshold. */
+            public static CDataQuestCommand WarGaugeAvgNotLess(int percentRate, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.SubstoryAvgEnemyHpNotLess, Param01 = param01, Param02 = hpRatePercent, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.WarGaugeAvgNotLess, Param01 = percentRate, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks if average HP% across all substory NPCs < hpRatePercent. */
-            public static CDataQuestCommand SubstoryAvgEnemyHpLess(int param01, int hpRatePercent, int param03 = 0, int param04 = 0)
+            /** @brief Checks if the average of all war mission gauges are under the percent threshold. Inverse of WarGaugeAvgNotLess. */
+            public static CDataQuestCommand WarGaugeAvgLess(int percentRate, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.SubstoryAvgEnemyHpLess, Param01 = param01, Param02 = hpRatePercent, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.WarGaugeAvgLess, Param01 = percentRate, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Checks if an OM's behavior state enum matches behaviorState. */
@@ -2839,10 +2839,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsTimerNotElapsed, Param01 = timerNo, Param02 = sec, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks how long magma has been rising on the current map (param01 >= timeSec). Requires cpOmRisingMagma to be present on the map. */
-            public static CDataQuestCommand RisingMagmaTime(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks how much magma has risen on the current map. Requires cpOmRisingMagma to be present on the map. */
+            public static CDataQuestCommand RisingMagmaLevel(int level, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.RisingMagmaTime, Param01 = timeSec, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.RisingMagmaLevel, Param01 = level, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Fire-once trigger: reads and clears a byte flag at DAT_021af4f4+0xEEA. Returns 1 if flag was set. */
@@ -3827,10 +3827,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.SubstoryProgress, Param01 = delta, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Finds a substory entry by substoryId and adds progressDelta to its progress, clamped to [0,100]. */
-            public static CDataQuestCommand AddSubstoryProgress(int substoryId, int progressDelta, int param03 = 0, int param04 = 0)
+            /** @brief Adds progress to an active war mission gauge, clamped to [0,100]. */
+            public static CDataQuestCommand AddWarProgress(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.AddSubstoryProgress, Param01 = substoryId, Param02 = progressDelta, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.AddWarProgress, Param01 = gaugeNo, Param02 = percentRate, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Triggers a substory progress update sequence. Checks mode; if mode==0xb fires substory FSM transition and sends C2S_QUEST_ADD_PACKAGE_QUEST_POINT_REQ. */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -742,31 +742,31 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdSubstoryEnemyHpNotLess(this QuestBlock questBlock, int substoryId, int hpRatePercent, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdWarGaugeNotLess(this QuestBlock questBlock, int gaugeNo, int percentRate, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdSubstoryEnemyHpNotLess(substoryId, hpRatePercent);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdWarGaugeNotLess(gaugeNo, percentRate);
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdSubstoryEnemyHpLess(this QuestBlock questBlock, int substoryId, int hpRatePercent, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdWarGaugeLess(this QuestBlock questBlock, int gaugeNo, int percentRate, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdSubstoryEnemyHpLess(substoryId, hpRatePercent);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdWarGaugeLess(gaugeNo, percentRate);
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdSubstoryAvgEnemyHpNotLess(this QuestBlock questBlock, int param01, int hpRatePercent, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdWarGaugeAvgNotLess(this QuestBlock questBlock, int percentRate, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdSubstoryAvgEnemyHpNotLess(param01, hpRatePercent);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdWarGaugeAvgNotLess(percentRate);
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdSubstoryAvgEnemyHpLess(this QuestBlock questBlock, int param01, int hpRatePercent, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdWarGaugeAvgLess(this QuestBlock questBlock, int percentRate, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdSubstoryAvgEnemyHpLess(param01, hpRatePercent);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdWarGaugeAvgLess(percentRate);
             return questBlock;
         }
 
@@ -938,10 +938,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdRisingMagmaTime(this QuestBlock questBlock, int timeSec, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdRisingMagmaLevel(this QuestBlock questBlock, int level, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdRisingMagmaTime(timeSec);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdRisingMagmaLevel(level);
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
@@ -308,9 +308,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdAddSubstoryProgress(this QuestBlock questBlock, int substoryId, int progressDelta)
+        public static QuestBlock AddResultCmdAddWarProgress(this QuestBlock questBlock, int gaugeNo, int percentRate)
         {
-            questBlock.ResultCommands.AddResultCmdAddSubstoryProgress(substoryId, progressDelta);
+            questBlock.ResultCommands.AddResultCmdAddWarProgress(gaugeNo, percentRate);
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -678,27 +678,27 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdSubstoryEnemyHpNotLess(this List<CDataQuestCommand> checkCommands, int substoryId, int hpRatePercent)
+        public static List<CDataQuestCommand> AddCheckCmdWarGaugeNotLess(this List<CDataQuestCommand> checkCommands, int gaugeNo, int percentRate)
         {
-            checkCommands.Add(QuestManager.CheckCommand.SubstoryEnemyHpNotLess(substoryId, hpRatePercent));
+            checkCommands.Add(QuestManager.CheckCommand.WarGaugeNotLess(gaugeNo, percentRate));
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdSubstoryEnemyHpLess(this List<CDataQuestCommand> checkCommands, int substoryId, int hpRatePercent)
+        public static List<CDataQuestCommand> AddCheckCmdWarGaugeLess(this List<CDataQuestCommand> checkCommands, int gaugeNo, int percentRate)
         {
-            checkCommands.Add(QuestManager.CheckCommand.SubstoryEnemyHpLess(substoryId, hpRatePercent));
+            checkCommands.Add(QuestManager.CheckCommand.WarGaugeLess(gaugeNo, percentRate));
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdSubstoryAvgEnemyHpNotLess(this List<CDataQuestCommand> checkCommands, int param01, int hpRatePercent)
+        public static List<CDataQuestCommand> AddCheckCmdWarGaugeAvgNotLess(this List<CDataQuestCommand> checkCommands, int percentRate)
         {
-            checkCommands.Add(QuestManager.CheckCommand.SubstoryAvgEnemyHpNotLess(param01, hpRatePercent));
+            checkCommands.Add(QuestManager.CheckCommand.WarGaugeAvgNotLess(percentRate));
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdSubstoryAvgEnemyHpLess(this List<CDataQuestCommand> checkCommands, int param01, int hpRatePercent)
+        public static List<CDataQuestCommand> AddCheckCmdWarGaugeAvgLess(this List<CDataQuestCommand> checkCommands, int percentRate)
         {
-            checkCommands.Add(QuestManager.CheckCommand.SubstoryAvgEnemyHpLess(param01, hpRatePercent));
+            checkCommands.Add(QuestManager.CheckCommand.WarGaugeAvgLess(percentRate));
             return checkCommands;
         }
 
@@ -846,9 +846,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdRisingMagmaTime(this List<CDataQuestCommand> checkCommands, int timeSec)
+        public static List<CDataQuestCommand> AddCheckCmdRisingMagmaLevel(this List<CDataQuestCommand> checkCommands, int level)
         {
-            checkCommands.Add(QuestManager.CheckCommand.RisingMagmaTime(timeSec));
+            checkCommands.Add(QuestManager.CheckCommand.RisingMagmaLevel(level));
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
@@ -311,9 +311,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdAddSubstoryProgress(this List<CDataQuestCommand> resultCommands, int substoryId, int progressDelta)
+        public static List<CDataQuestCommand> AddResultCmdAddWarProgress(this List<CDataQuestCommand> resultCommands, int gaugeNo, int percentRate)
         {
-            resultCommands.Add(QuestManager.ResultCommand.AddSubstoryProgress(substoryId, progressDelta));
+            resultCommands.Add(QuestManager.ResultCommand.AddWarProgress(gaugeNo, percentRate));
             return resultCommands;
         }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400006.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/exm/q50400006.csx
@@ -73,8 +73,7 @@ public class ScriptedQuest : IQuest
             ]);
         process0.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 0)
             .AddResultCommands([
-                QuestManager.ResultCommand.StartMissionAnnounce(2, 0), // List sticks to memory, so clear it
-                QuestManager.ResultCommand.StartMissionAnnounce(2, 2), // (2, 1) can populate the list, but how to do it properly? Handler?
+                QuestManager.ResultCommand.StartMissionAnnounce(1),
                 QuestManager.ResultCommand.AddEndContentsPurpose(0, 1),
                 QuestManager.ResultCommand.SetDiePlayerReturnPos(3400, 0, 0),
                 QuestManager.ResultCommand.StartContentsTimer(900),
@@ -83,18 +82,18 @@ public class ScriptedQuest : IQuest
             .AddCheckCommands([
                 QuestManager.CheckCommand.IsLinkageEnemyFlag(3400, 1, 0, 1)
             ]);
-        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1)
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1) // BGM request fix here?
             .AddResultCommands([
                 QuestManager.ResultCommand.QstLayoutFlagOn(8764)
             ]);
-        process0.AddRawBlock(QuestAnnounceType.None)
+        process0.AddRawBlock(QuestAnnounceType.None) // Send stop timer NTC here
             .AddResultCommands([
                 QuestManager.ResultCommand.EventExec(3400, 20, 0, 0)
             ])
             .AddCheckCommands([
                 QuestManager.CheckCommand.EventEnd(3400, 20)
             ]);
-        process0.AddRawBlock(QuestAnnounceType.None) // TODO: Timer needs to stop ticking here
+        process0.AddRawBlock(QuestAnnounceType.None)
             .AddResultCommands([
                 QuestManager.ResultCommand.UpdateAnnounceDirect(1, 3),
                 QuestManager.ResultCommand.RemoveEndContentsPurpose(0),

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -151,11 +151,13 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataCraftSupportPawnID.Serializer());
             Create(new CDataCraftTimeSaveCost.Serializer());
             Create(new CDataCurrentEquipInfo.Serializer());
+            Create(new CDataCycleContentsPlayStartData.Serializer());
             Create(new CDataCycleContentsStateList.Serializer());
             Create(new CDataCycleContentsNews.Serializer());
             Create(new CDataCycleContentsNewsDetail.Serializer());
             Create(new CDataCycleContentsRank.Serializer());
             Create(new CDataCycleContentsUnk.Serializer());
+            Create(new CDataCycleContentsUnk1.Serializer());
 
             Create(new CDataDeliveredItem.Serializer());
             Create(new CDataDeliveredItemRecord.Serializer());
@@ -175,6 +177,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataDispelLockCostData.Serializer());
             Create(new CDataDispelLockSealData.Serializer());
             Create(new CDataDragonAbility.Serializer());
+            Create(new CDataDragonSkill.Serializer());
             Create(new CDataDropItemSetInfo.Serializer());
 
             Create(new CDataEditInfo.Serializer());
@@ -1311,6 +1314,9 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CDispelGetLockSettingRes.Serializer());
             Create(new S2CDispelLockSettingRes.Serializer());
 
+            Create(new S2C_73_0_16_NTC.Serializer());
+            Create(new S2C_73_1_16_NTC.Serializer());
+
             Create(new S2CEntryBoardEntryBoardItemChangeMemberNtc.Serializer());
             Create(new S2CEntryBoardEntryBoardItemCreateRes.Serializer());
             Create(new S2CEntryBoardEntryBoardItemEntryRes.Serializer());
@@ -1690,6 +1696,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CQuestPlayStartTimerNtc.Serializer());
             Create(new S2CQuestPlayStartTimerRes.Serializer());
             Create(new S2CQuestPlayTimeupNtc.Serializer());
+            Create(new S2CQuestRestartTimerNtc.Serializer());
+            Create(new S2CQuestStopTimerNtc.Serializer());
             Create(new S2CQuestQuestCancelNtc.Serializer());
             Create(new S2CQuestQuestCancelRes.Serializer());
             Create(new S2CQuestQuestCancelForceNtc.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestRestartTimerNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestRestartTimerNtc.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestRestartTimerNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_QUEST_11_104_16_NTC;
+
+        public S2CQuestRestartTimerNtc()
+        {
+        }
+
+        public ulong PlayEndDateTime { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CQuestRestartTimerNtc>
+        {
+            public override void Write(IBuffer buffer, S2CQuestRestartTimerNtc obj)
+            {
+                WriteUInt64(buffer, obj.PlayEndDateTime);
+            }
+
+            public override S2CQuestRestartTimerNtc Read(IBuffer buffer)
+            {
+                S2CQuestRestartTimerNtc obj = new S2CQuestRestartTimerNtc();
+                obj.PlayEndDateTime = ReadUInt64(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestStopTimerNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestStopTimerNtc.cs
@@ -1,0 +1,22 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestStopTimerNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_QUEST_11_103_16_NTC;
+
+        public class Serializer : PacketEntitySerializer<S2CQuestStopTimerNtc>
+        {
+            public override void Write(IBuffer buffer, S2CQuestStopTimerNtc obj)
+            {
+            }
+
+            public override S2CQuestStopTimerNtc Read(IBuffer buffer)
+            {
+                return new S2CQuestStopTimerNtc();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_73_0_16_NTC.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_73_0_16_NTC.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2C_73_0_16_NTC : IPacketStructure
+    {
+        public S2C_73_0_16_NTC()
+        {
+        }
+
+        public List<CDataDragonSkill> DragonSkillList { get; set; }
+
+        public PacketId Id => PacketId.S2C_73_0_16_NTC;
+
+        public class Serializer : PacketEntitySerializer<S2C_73_0_16_NTC>
+        {
+            public override void Write(IBuffer buffer, S2C_73_0_16_NTC obj)
+            {
+                WriteEntityList(buffer, obj.DragonSkillList);
+            }
+
+            public override S2C_73_0_16_NTC Read(IBuffer buffer)
+            {
+                var obj = new S2C_73_0_16_NTC();
+                obj.DragonSkillList = ReadEntityList<CDataDragonSkill>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_73_1_16_NTC.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_73_1_16_NTC.cs
@@ -1,0 +1,32 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2C_73_1_16_NTC : IPacketStructure
+    {
+        public S2C_73_1_16_NTC()
+        {
+        }
+
+        public uint PartyDragonPoints {  get; set; }
+
+        public PacketId Id => PacketId.S2C_73_1_16_NTC;
+
+        public class Serializer : PacketEntitySerializer<S2C_73_1_16_NTC>
+        {
+            public override void Write(IBuffer buffer, S2C_73_1_16_NTC obj)
+            {
+                WriteUInt32(buffer, obj.PartyDragonPoints);
+            }
+
+            public override S2C_73_1_16_NTC Read(IBuffer buffer)
+            {
+                var obj = new S2C_73_1_16_NTC();
+                obj.PartyDragonPoints = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataCycleContentsPlayStartData.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataCycleContentsPlayStartData.cs
@@ -1,0 +1,61 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataCycleContentsPlayStartData
+    {
+        public CDataCycleContentsPlayStartData()
+        {
+            QuestProcessStateList = new List<CDataQuestProcessState>();
+            QuestEnemyInfoList = new List<CDataQuestEnemyInfo>();
+            QuestLayoutFlagSetInfoList = new List<CDataQuestLayoutFlagSetInfo>();
+            Unk0List = new List<CDataCycleContentsUnk1>(); // Always two entries?
+        }
+
+        public uint CycleContentsScheduleId { get; set; }
+        public uint KeyId { get; set; }
+        public uint QuestScheduleId { get; set; }
+        public uint QuestId { get; set; }
+        public uint BaseLevel { get; set; }
+        public byte StartPos { get; set; }
+        public List<CDataQuestProcessState> QuestProcessStateList { get; set; }
+        public List<CDataQuestEnemyInfo> QuestEnemyInfoList { get; set; }
+        public List<CDataQuestLayoutFlagSetInfo> QuestLayoutFlagSetInfoList { get; set; }
+        public List<CDataCycleContentsUnk1> Unk0List { get; set; }
+
+        public class Serializer : EntitySerializer<CDataCycleContentsPlayStartData>
+        {
+            public override void Write(IBuffer buffer, CDataCycleContentsPlayStartData obj)
+            {
+                WriteUInt32(buffer, obj.CycleContentsScheduleId);
+                WriteUInt32(buffer, obj.KeyId);
+                WriteUInt32(buffer, obj.QuestScheduleId);
+                WriteUInt32(buffer, obj.QuestId);
+                WriteUInt32(buffer, obj.BaseLevel);
+                WriteByte(buffer, obj.StartPos);
+                WriteEntityList(buffer, obj.QuestProcessStateList);
+                WriteEntityList(buffer, obj.QuestEnemyInfoList);
+                WriteEntityList(buffer, obj.QuestLayoutFlagSetInfoList);
+                WriteEntityList(buffer, obj.Unk0List);
+            }
+
+            public override CDataCycleContentsPlayStartData Read(IBuffer buffer)
+            {
+                CDataCycleContentsPlayStartData obj = new CDataCycleContentsPlayStartData();
+                obj.CycleContentsScheduleId = ReadUInt32(buffer);
+                obj.KeyId = ReadUInt32(buffer);
+                obj.QuestScheduleId = ReadUInt32(buffer);
+                obj.QuestId = ReadUInt32(buffer);
+                obj.BaseLevel = ReadUInt32(buffer);
+                obj.StartPos = ReadByte(buffer);
+                obj.QuestProcessStateList = ReadEntityList<CDataQuestProcessState>(buffer);
+                obj.QuestEnemyInfoList = ReadEntityList<CDataQuestEnemyInfo>(buffer);
+                obj.QuestLayoutFlagSetInfoList = ReadEntityList<CDataQuestLayoutFlagSetInfo>(buffer);
+                obj.Unk0List = ReadEntityList<CDataCycleContentsUnk1>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataCycleContentsUnk1.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataCycleContentsUnk1.cs
@@ -1,0 +1,27 @@
+using Arrowgene.Buffers;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataCycleContentsUnk1
+    {
+        public uint Unk0 { get; set; } // index (for commands 215-218)
+        public uint Unk1 { get; set; } // value (for commands 217-218)
+
+        public class Serializer : EntitySerializer<CDataCycleContentsUnk1>
+        {
+            public override void Write(IBuffer buffer, CDataCycleContentsUnk1 obj)
+            {
+                WriteUInt32(buffer, obj.Unk0);
+                WriteUInt32(buffer, obj.Unk1);
+            }
+
+            public override CDataCycleContentsUnk1 Read(IBuffer buffer)
+            {
+                CDataCycleContentsUnk1 obj = new CDataCycleContentsUnk1();
+                obj.Unk0 = ReadUInt32(buffer);
+                obj.Unk1 = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataDragonSkill.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataDragonSkill.cs
@@ -1,0 +1,34 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataDragonSkill
+    {
+        public CDataDragonSkill()
+        {
+        }
+
+        public DragonSkill DragonSkill { get; set; }
+        public byte Level { get; set; }
+
+        public class Serializer : EntitySerializer<CDataDragonSkill>
+        {
+            public override void Write(IBuffer buffer, CDataDragonSkill obj)
+            {
+                WriteByte(buffer, (byte) obj.DragonSkill);
+                WriteByte(buffer, obj.Level);
+            }
+
+            public override CDataDragonSkill Read(IBuffer buffer)
+            {
+                CDataDragonSkill obj = new CDataDragonSkill();
+                obj.DragonSkill = (DragonSkill) ReadByte(buffer);
+                obj.Level = ReadByte(buffer);
+                return obj;
+            }
+        }
+    }
+}
+

--- a/Arrowgene.Ddon.Shared/Model/DragonSkill.cs
+++ b/Arrowgene.Ddon.Shared/Model/DragonSkill.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arrowgene.Ddon.Shared.Model
+{
+    public enum DragonSkill : byte
+    {
+        DragonProtection = 1,
+        BeastSlayer = 2,
+        FiendSlayer = 3,
+        SpiritSlayer = 4,
+        DragonSlayer = 5,
+        SpiritDragonEmbrace = 6,
+        SpiritDragonCounter = 7,
+        FireDragonPurification = 8,
+        FireDragonDemonBulwark = 9,
+        WhiteDragonBulwark = 10,
+        WhiteDragonEdge = 11,
+        DragonBlessing = 12,
+        GoldenDragonBlow = 13
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -252,25 +252,25 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         TalkNpcChoice = 214, // 0x00635B10 (cQuestProcess* this, s32 stageNo, s32 npcId, s32 choice, s32 param04_unused)
 
         /// <summary>
-        /// Checks if a specific substory enemy's HP% >= hpRatePercent. Calls FUN_00be10d0(substoryId) to get HP ratio,
+        /// Checks if a war mission gauge is not under the percent threshold. Calls FUN_00be10d0(gaugeNo) to get HP ratio,
         /// multiplies by 100, compares >= param02. (0x00635BF0)
         /// </summary>
-        SubstoryEnemyHpNotLess = 215, // 0x00635BF0 (cQuestProcess* this, s32 substoryId, s32 hpRatePercent, s32 param03, s32 param04)
+        WarGaugeNotLess = 215, // 0x00635BF0 (cQuestProcess* this, s32 gaugeNo, s32 percentRate, s32 param03, s32 param04)
 
         /// <summary>
-        /// Checks if a specific substory enemy's HP% &lt; hpRatePercent. Inverse of SubstoryEnemyHpNotLess.
+        /// Checks if a war mission gauge is under the percent threshold. Inverse of WarGaugeNotLess.
         /// </summary>
-        SubstoryEnemyHpLess = 216, // 0x00635C40 (cQuestProcess* this, s32 substoryId, s32 hpRatePercent, s32 param03, s32 param04)
+        WarGaugeLess = 216, // 0x00635C40 (cQuestProcess* this, s32 gaugeNo, s32 percentRate, s32 param03, s32 param04)
 
         /// <summary>
-        /// Checks if the average HP% across ALL substory NPCs >= hpRatePercent. Calls FUN_00be1130 for the average.
+        /// Checks if the average of all war mission gauges are not under the percent threshold. Calls FUN_00be1130 for the average.
         /// </summary>
-        SubstoryAvgEnemyHpNotLess = 217, // 0x00635C90 (cQuestProcess* this, s32 param01, s32 hpRatePercent, s32 param03, s32 param04)
+        WarGaugeAvgNotLess = 217, // 0x00635C90 (cQuestProcess* this, s32 percentRate, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Checks if the average HP% across ALL substory NPCs &lt; hpRatePercent. Inverse of SubstoryAvgEnemyHpNotLess.
+        /// Checks if the average of all war mission gauges are under the percent threshold. Inverse of WarGaugeAvgNotLess.
         /// </summary>
-        SubstoryAvgEnemyHpLess = 218, // 0x00635CD0 (cQuestProcess* this, s32 param01, s32 hpRatePercent, s32 param03, s32 param04)
+        WarGaugeAvgLess = 218, // 0x00635CD0 (cQuestProcess* this, s32 percentRate, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Checks if an OM's behavior state enum matches an expected value. Resolves OM via FUN_0063d480(stageNo, groupNo, setNo),
@@ -444,12 +444,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         IsTimerNotElapsed = 245, // 0x00637250 (cQuestProcess* this, s32 timerNo, s32 sec, s32 param03, s32 param04_unused)
 
         /// <summary>
-        /// Checks how long magma has been rising on the current map. Requires cpOmRisingMagma to be present on the map.
+        /// Checks how much magma has risen on the current map. Requires cpOmRisingMagma to be present on the map.
         /// Magma starts rising after result command SetMagmaState is used with phase = 3, which starts a counter.
-        /// This counter, and magma height, increases by 1/sec once started. Check passes when param01 >= counter.
-        /// Can be used as a time or height comparison depending on how you look at it.
+        /// This counter keeps increasing as magma rises up to 50. Check passes when param01 >= counter.
+        /// Not a height/time comparison, as magma level has been observed to not rise uniformly.
         /// </summary>
-        RisingMagmaTime = 246, // 0x00637320 (cQuestProcess* this, s32 timeSec, s32 param02, s32 param03, s32 param04)
+        RisingMagmaLevel = 246, // 0x00637320 (cQuestProcess* this, s32 level, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Fire-once trigger: reads byte at DAT_021af4f4+0xEEA. If == 1, clears it and returns 1; otherwise returns 0.

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -123,10 +123,9 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         SubstoryProgress = 99, // 0x00633730 (cQuestProcess* this, s32 delta, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
         /// <summary>
-        /// Finds a substory entry by substoryId and adds progressDelta to its progress value, clamped to [0,100].
-        /// Does not seem to work?
+        /// Adds progress to an active war mission gauge, clamped to [0,100].
         /// </summary>
-        AddSubstoryProgress = 100, // 0x006338E0 (cQuestProcess* this, s32 substoryId, s32 progressDelta, s32 param03, s32 param04)
+        AddWarProgress = 100, // 0x006338E0 (cQuestProcess* this, s32 gaugeNo, s32 percentRate, s32 param03, s32 param04)
 
         /// <summary>
         /// Triggers a substory progress update sequence. Checks mode via FUN_009cffc0; if mode==0xb fires FUN_00bdee50 and FUN_00598590.

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -2162,6 +2162,10 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId C2S_DAILY_MISSION_EVENT_LIST_GET_REQ = new PacketId(72, 3, 1, "C2S_DAILY_MISSION_EVENT_LIST_GET_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_DAILY_MISSION_EVENT_LIST_GET_RES = new PacketId(72, 3, 2, "S2C_DAILY_MISSION_EVENT_LIST_GET_RES", ServerType.Game, PacketSource.Server); // デイリーミッション：期間イベントのリストの取得に
 
+// Group: 73 - (DRAGON_SKILL)
+        public static readonly PacketId S2C_73_0_16_NTC = new PacketId(73, 0, 16, "S2C_73_0_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_73_1_16_NTC = new PacketId(73, 1, 16, "S2C_73_1_16_NTC", ServerType.Game, PacketSource.Server);
+
         #endregion
 
         #region GamePacketIdsInit
@@ -4093,6 +4097,10 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_DAILY_MISSION_REWARD_RECEIVE_RES);
             AddPacketIdEntry(packetIds, C2S_DAILY_MISSION_EVENT_LIST_GET_REQ);
             AddPacketIdEntry(packetIds, S2C_DAILY_MISSION_EVENT_LIST_GET_RES);
+
+// Group: 73 - (DRAGON_SKILL)
+            AddPacketIdEntry(packetIds, S2C_73_0_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_73_1_16_NTC);
 
             return packetIds;
         }

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3243,22 +3243,23 @@ The dispatch function is at `.text:0063E254`. It validates `commandId < 0x87` (1
 SubstoryProgress(int substoryId, int param02, int param03, int param04 = 0);
 ```
 
-### AddSubstoryProgress (100)
+### AddWarProgress (100)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006338E0` |
 | Table index | 100 |
-| Key callees | `FUN_00bd3730` (substory list lookup), clamps result to [0, 100] |
+| Key callees | `FUN_00bd3730` (war mission list lookup), clamps result to [0, 100] |
 
 ```
 /**
- * @brief Finds a substory entry by substoryId and adds progressDelta to its progress value.
- * Result is clamped to [0, 100].
- * @param substoryId   Substory identifier
- * @param progressDelta Amount to add (can be negative)
+ * @brief Adds progress to an active war mission gauge, clamped to [0,100].
+ * Gauges are started by S2C_FORT_DEFENSE_PLAY_START_NOTICE and S2C_QUEST_RAID_BOSS_PLAY_START_NTC.
+ * The command looks up the list for param01 = index and adds param02 to value (as a percentage).
+ * @param gaugeNo     War mission gauge identifier
+ * @param percentRate Amount to add (can be negative)
  */
-AddSubstoryProgress(int substoryId, int progressDelta, int param03 = 0, int param04 = 0);
+AddWarProgress(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0);
 ```
 
 ### UpdateSubstoryProgress (101)
@@ -3636,10 +3637,11 @@ RemoveFsmNpcFromSchedule(int param01, int param02 = 0, int param03 = 0, int para
 ```
 /**
  * @brief Changes magma OM behaviour on Evil Dragon's Roost maps to match boss phase mechanics.
- * @brief Phase 2: Sets a global counter to 10, which immediately flips over to 1 (reset). Floor magma expands or contracts based on counter value.
- * @brief Evil Dragon and their crystals directly increment or decrement this counter as part of their moveset.
- * @brief Phase 3: Iterates a list of objects and sets state = param02 on them. Makes magma rise on the map based on state.
- * @brief Requires the list (DAT) to be populated by a function beforehand (Evil Dragon populates this DAT with SetInfoOmRisingMagma).
+ * Phase 2: Sets a global counter to 10, which immediately flips over to 1 (reset). Floor magma expands or contracts based on counter value.
+ * Evil Dragon and their crystals directly increment or decrement this counter as part of their moveset.
+ * Phase 3: Iterates a list of objects and sets state = param02 on them. Makes magma rise on the map based on state.
+ * Requires the list (DAT) to be populated by a function beforehand (Evil Dragon populates this DAT with SetInfoOmRisingMagma).
+ * @note War mission phase 3: check for linkage flag 6, then use (3, 1) and play the camera event.
  * @param phase   2 = resets floor magma expansion, 3 = iterates object list and sets every match to state = param02
  * @param state   Secondary value passed to FUN_00bc7070 when phase == 3
  */
@@ -3738,7 +3740,7 @@ The dispatch function is at approximately `.text:0063E04A`. It validates `comman
 
 ```
 /**
- * @brief Checks if the player's party has disbanded (notice bit 18). 
+ * @brief Checks if the player's party has disbanded (notice bit 18).
  * Only triggers after disbanding a multiplayer party (exm with pawns will also work).
  * Notice bit is at *(cQuestProcess+0x5c)+0x20c.
  */
@@ -3820,59 +3822,64 @@ NpcPreTalkAndOrderUi(StageNo stageNo, NpcId npcId, int noOrderGroupSerial, int s
 TalkNpcChoice(StageNo stageNo, int npcId, int choice, int param04 = 0);
 ```
 
-### SubstoryEnemyHpNotLess (215)
+### WarGaugeNotLess (215)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00635BF0` |
 | Table index | 215 |
-| Key callees | `FUN_00be10d0(substoryId)` returns HP ratio as float; `ratio * 100 >= hpRatePercent` |
+| Key callees | `FUN_00be10d0(gaugeNo)` returns HP ratio as float; `ratio * 100 >= percentRate` |
 
 ```
 /**
- * @brief Checks if a specific substory enemy's current HP% >= hpRatePercent.
- * @param substoryId    Substory identifier used to look up the enemy
- * @param hpRatePercent HP percentage threshold (0–100)
+ * @brief Checks if a war mission gauge is not under the percent threshold.
+ * Gauges are started by S2C_FORT_DEFENSE_PLAY_START_NOTICE and S2C_QUEST_RAID_BOSS_PLAY_START_NTC.
+ * S3 added a fourth list for CDataCycleContentsPlayStartData with two uints (index and value).
+ * The command looks up the list for param01 = index and compares param02 against value (as a percentage).
+ * @param gaugeNo        Gauge identifier used to look up the value
+ * @param percentRate    Percentage threshold (0–100)
  */
-SubstoryEnemyHpNotLess(int substoryId, int hpRatePercent, int param03 = 0, int param04 = 0);
+WarGaugeNotLess(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0);
 ```
 
-### SubstoryEnemyHpLess (216)
+### WarGaugeLess (216)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00635C40` |
 | Table index | 216 |
-| Key callees | Same as SubstoryEnemyHpNotLess but inverted: `ratio * 100 < hpRatePercent` |
+| Key callees | Same as WarGaugeNotLess but inverted: `ratio * 100 < percentRate` |
 
 ```
 /**
- * @brief Checks if a specific substory enemy's current HP% < hpRatePercent.
- * @param substoryId    Substory identifier
- * @param hpRatePercent HP percentage threshold (0–100)
+ * @brief Checks if a war mission gauge is not under the percent threshold.
+ * See WarGaugeNotLess for a more detailed explanation.
+ * @param gaugeNo        Gauge identifier used to look up the value
+ * @param percentRate    Percentage threshold (0–100)
  */
-SubstoryEnemyHpLess(int substoryId, int hpRatePercent, int param03 = 0, int param04 = 0);
+WarGaugeLess(int gaugeNo, int percentRate, int param03 = 0, int param04 = 0);
 ```
 
-### SubstoryAvgEnemyHpNotLess (217)
+### WarGaugeAvgNotLess (217)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x00635C90` |
 | Table index | 217 |
-| Key callees | `FUN_00be1130()` computes average HP ratio across ALL substory NPCs |
+| Key callees | `FUN_00be1130()` computes average HP ratio across ALL war mission gauges |
 
 ```
 /**
- * @brief Checks if the average HP% of all substory NPCs >= hpRatePercent.
- * Uses the whole-list average, not a specific enemy.
- * @param param01       Unused / reserved
- * @param hpRatePercent HP percentage threshold (0–100)
+ * @brief Checks if the average of all war mission gauges are not under the percent threshold.
+ * Gauges are started by S2C_FORT_DEFENSE_PLAY_START_NOTICE and S2C_QUEST_RAID_BOSS_PLAY_START_NTC.
+ * S3 added a fourth list for CDataCycleContentsPlayStartData with two uints (index and value).
+ * The command looks up the entire list for values, converts them to a percentage and compares against param01.
+ * @param percentRate    Percentage threshold (0–100)
  */
-SubstoryAvgEnemyHpNotLess(int param01 = 0, int hpRatePercent = 0, int param03 = 0, int param04 = 0);
+WarGaugeAvgNotLess(int percentRate, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### SubstoryAvgEnemyHpLess (218)
+### WarGaugeAvgLess (218)
 
 | Field | Value |
 |-------|-------|
@@ -3882,11 +3889,11 @@ SubstoryAvgEnemyHpNotLess(int param01 = 0, int hpRatePercent = 0, int param03 = 
 
 ```
 /**
- * @brief Checks if the average HP% of all substory NPCs < hpRatePercent.
- * @param param01       Unused / reserved
- * @param hpRatePercent HP percentage threshold (0–100)
+ * @brief Checks if the average of all war mission gauges are under the percent threshold.
+ * See WarGaugeAvgNotLess for a more detailed explanation.
+ * @param percentRate    HP percentage threshold (0–100)
  */
-SubstoryAvgEnemyHpLess(int param01 = 0, int hpRatePercent = 0, int param03 = 0, int param04 = 0);
+WarGaugeAvgLess(int percentRate, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsOmBehaviorState (219)
@@ -4344,7 +4351,7 @@ IsSubstoryProgressInRange(int minValue, int maxValue, int param03 = 0, int param
 IsTimerNotElapsed(int timerNo, int sec, int param03 = 0, int param04 = 0);
 ```
 
-### RisingMagmaTime (246)
+### RisingMagmaLevel (246)
 
 | Field | Value |
 |-------|-------|
@@ -4354,13 +4361,13 @@ IsTimerNotElapsed(int timerNo, int sec, int param03 = 0, int param04 = 0);
 
 ```
 /**
- * @brief Checks how long magma has been rising on the current map. Requires cpOmRisingMagma to be present on the map.
+ * @brief Checks how much magma has risen on the current map. Requires cpOmRisingMagma to be present on the map.
  * Magma starts rising after result command SetMagmaState is used with phase = 3, which starts a counter.
- * This counter, and magma height, increases by 1/sec once started. Check passes when param01 >= counter.
- * Can be used as a time or height comparison depending on how you look at it.
- * @param timeSec Minimum elapsed seconds
+ * This counter keeps increasing as magma rises up to 50. Check passes when param01 >= counter.
+ * Not a height/time comparison, as magma level has been observed to not rise uniformly.
+ * @param level Magma level on current map (0-50).
  */
-RisingMagmaTime(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
+RisingMagmaLevel(int level, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsTriggerFlagSetAndClear (247)
@@ -4376,6 +4383,9 @@ RisingMagmaTime(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
  * @brief Fire-once trigger: reads byte at DAT_021af4f4+0xEEA.
  * If the byte equals 1, clears it to 0 and returns 1. Otherwise returns 0.
  * The flag is set by an external event; this command consumes it atomically.
+ * @note EEA = 1 when the player comes within 50f of a cpOmRisingMagma object.
+ * The event teleports the player to the nearest safe spot without taking damage and sets the flag on. Currently, this event is not triggering anywhere.
+ * This check is not passing even if you use an assembler to arrive at the flag-setting instruction: further investigation is needed.
  */
 IsTriggerFlagSetAndClear(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```


### PR DESCRIPTION
Disclaimer: commands need final confirmation from quest context.

**War Mission Commands:**
Identifies several check commands and one result command, previously assumed to be substory-related, as war mission related commands. All commands below read or write to fields populated by packets S2C_FORT_DEFENSE_PLAY_START_NOTICE and S2C_QUEST_RAID_BOSS_PLAY_START_NTC:

- Check command 215: WarGaugeNotLess
- Check command 216: WarGaugeLess
- Check command 217: WarGaugeAvgNotLess
- Check command 218: WarGaugeAvgLess
- Result command 100: AddWarProgress

Two CDatas were added: CDataCycleContentsPlayStartData (same structure as S2 + one extra list) and CDataCycleContentsUnk1 (the new list, checked by the commands).
Additionally, one of the check commands (246: RisingMagmaLevel) had its name and description updated to reflect how it actually works.

**Dragon Skill Packets:**
Adds two missing packets to the list: S2C_73_0_16_NTC and S2C_73_1_16_NTC, a CData (CDataDragonSkill) and a Model (DragonSkill).
S2C_73_0_16_NTC activates Dragon Skills for the instance when sent. The skills are seemingly triggered by the bosses, so they have limited use outside of the intended fights (Abaddon, Baphomet, Black Knight, Black Dragon).
S2C_73_1_16_NTC sends the party's combined dragon points for the instance. Used by StartMissionAnnounce(1) to populate the dragon skill announce list (just the display, 73_0_16 is still needed for the actual buffs). When the party doesn't qualify for any buffs, (1) displays the regular Start announce instead.

Also adds two other packets: S2CQuestStopTimerNtc (sees use inside dragon skill EXMs) and S2CQuestRestartTimerNtc (no clue, but it's there).

Dragon skill threshold list below for convenience:

            [DragonSkill.BeastSlayer]             = 10, 25, 45
            [DragonSkill.FiendSlayer]             = 10, 25, 45
            [DragonSkill.SpiritSlayer]            = 10, 25, 45
            [DragonSkill.DragonSlayer]            = 10, 25, 45, 75, 110
            [DragonSkill.SpiritDragonEmbrace]     = 15, 30, 50
            [DragonSkill.SpiritDragonCounter]     = 4, 20, 35, 60, 100
            [DragonSkill.FireDragonPurification]  = 15, 30, 50, 90, 120
            [DragonSkill.FireDragonDemonBulwark]  = 4, 20, 35
            [DragonSkill.WhiteDragonBulwark]      = 4, 20, 35, 60, 100
            [DragonSkill.WhiteDragonEdge]         = 15, 30, 50
            [DragonSkill.GoldenDragonBlow]        = 15, 30, 50, 90, 120

The game does seem to support level 5 for all skills, but only the ones in Black Dragon's Restricted Zone EXM are sent as level 5 (the announce command confirms this).