### PR TITLE
Fix: Schedule Command / Multi-Channel Scheduled Tasks

### DIFF
--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -164,7 +164,8 @@ namespace Arrowgene.Ddon.GameServer
             GpCourseManager.EvaluateCourses();
 
             AssetRepository.AssetChanged += OnAssetChanged;
-
+            
+            ScheduleManager.PopulateTasks();
             if (ServerUtils.IsHeadServer(this))
             {
                 ScheduleManager.StartServerTasks();

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -1,6 +1,7 @@
 using Arrowgene.Ddon.GameServer.Tasks;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
@@ -49,14 +50,6 @@ namespace Arrowgene.Ddon.GameServer
 
         public void StartServerTasks()
         {
-            Tasks = Server.ScriptManager.SchedulerTaskModule.Tasks;
-
-            var settings = Server.GameSettings.GameServerSettings;
-            foreach (var task in Tasks)
-                task.GetOffset = () => settings.GetEffectiveUtcOffset();
-
-            TaskEntries = Server.Database.SelectAllTaskEntries();
-
             var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             foreach (var task in Tasks)
             {
@@ -77,6 +70,7 @@ namespace Arrowgene.Ddon.GameServer
                 {
                     task.RunTask(Server);
                     TaskEntries[task.Type].Timestamp = task.NextTimestamp();
+                    Server.RpcManager.AnnounceOthers("internal/command", RpcInternalCommand.ScheduleManagerUpdateTasks, null);
                     Server.Database.UpsertScheduleInfo(task.Type, TaskEntries[task.Type].Timestamp);
                 }
 
@@ -90,6 +84,7 @@ namespace Arrowgene.Ddon.GameServer
                         TaskEntries[task.Type].Timestamp = task.NextTimestamp();
                         if (task.Interval != ScheduleInterval.Secondly)
                         {
+                            Server.RpcManager.AnnounceOthers("internal/command", RpcInternalCommand.ScheduleManagerUpdateTasks, null);
                             Server.Database.UpsertScheduleInfo(task.Type, TaskEntries[task.Type].Timestamp);
                         }
                     }
@@ -124,6 +119,25 @@ namespace Arrowgene.Ddon.GameServer
         public List<SchedulerTask> GetTasks()
         {
             return Tasks;
+        }
+
+        public void PopulateTasks()
+        {
+            var settings = Server.GameSettings.GameServerSettings;
+            Tasks = Server.ScriptManager.SchedulerTaskModule.Tasks;
+            foreach (var task in Tasks)
+                task.GetOffset = () => settings.GetEffectiveUtcOffset();
+
+            TaskEntries = Server.Database.SelectAllTaskEntries();
+        }
+
+        public void UpdateTaskTimestamps()
+        {
+            foreach (var task in Tasks)
+            {
+                long next = task.NextTimestamp();
+                TaskEntries[task.Type].Timestamp = next;
+            }
         }
 
         public SchedulerTask GetTask(TaskType type)

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Tasks;
 using Arrowgene.Ddon.Rpc.Command;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Quest;
@@ -41,6 +42,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                     RpcInternalCommand.UpdateCrafting => HandleUpdateCrafting(gameServer),
                     RpcInternalCommand.WorldQuestReset => HandleWorldQuestReset(gameServer),
                     RpcInternalCommand.ExtremeMissionRewardReset => HandleExtremeMissionRewardReset(gameServer),
+                    RpcInternalCommand.ScheduleManagerUpdateTasks => HandleScheduleManagerUpdateTasks(gameServer),
                     _ => new RpcCommandResult(this, false),
                 };
             }
@@ -164,6 +166,14 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                 };
             }
 
+            private RpcCommandResult HandleScheduleManagerUpdateTasks(DdonGameServer gameServer)
+            {
+                gameServer.ScheduleManager.UpdateTaskTimestamps();
+                return new RpcCommandResult(this, true)
+                {
+                    Message = _entry.Command.ToString()
+                };
+            }
             private RpcCommandResult HandleStampReset(DdonGameServer gameServer)
             {
                 foreach (var character in gameServer.ClientLookup.GetAllCharacter())

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.GameServer.Characters;
-using Arrowgene.Ddon.GameServer.Tasks;
 using Arrowgene.Ddon.Rpc.Command;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Quest;

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
@@ -20,6 +20,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
         ExtremeMissionRewardReset, // null
 
         StampReset, //null
+        ScheduleManagerUpdateTasks, // null
 
         //InternalChatRoute
         SendTellMessage, // RpcChatData


### PR DESCRIPTION
This fixes scheduled tasks (and thus the `/schedule` command) to function consistently on multi-channel setups.

Currently, only the head node actually populates scheduled task information, as initialization is done inside `StartServerTasks()`. This makes `ScheduleManager` effectively empty on child nodes, which the `/schedule` command gets its data from.

### Summary of changes:

* Removed task initialization from `StartServerTasks()` and put it into a new function `ScheduleManager.PopulateTasks()`, which is called for all server nodes on startup instead of just the head.
* New RPC Internal Command `ScheduleManagerUpdateTasks` which the head node issues via `AnnounceOthers` when (non-Secondly) tasks are run to let child nodes know they need to update their task timestamps.
* New function `ScheduleManager.UpdateTaskTimestamps()` which is invoked via the above RPC command, which loops through all loaded tasks and gets their `NextTimestamp` to update the task list with.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
